### PR TITLE
chore: Gradle build scan 레포트 발행 활성화

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,13 @@
+plugins {
+    id "com.gradle.enterprise" version "3.15.1"
+}
+
+gradleEnterprise {
+    buildScan {
+        publishAlwaysIf(System.getenv("CI") != null)
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        termsOfServiceAgree = "yes"
+    }
+}
+
 rootProject.name = 'gdsc'


### PR DESCRIPTION
## 🌱 관련 이슈
- close #6

## 📌 작업 내용 및 특이사항
- Gradle Build Scan 레포트를 발행하려면 약관 동의가 필요함
- `setting.gradle` 에 약관 동의하는 코드 추가
- CI 환경에서만 publish 되도록 설정

## 📝 참고사항
- 

## 📚 기타
- 
