### PR TITLE
chore : Gradle Check 수행하는 CI Workflows 작성

### DIFF
--- a/.github/workflows/pull_request_gradle_build.yml
+++ b/.github/workflows/pull_request_gradle_build.yml
@@ -2,7 +2,7 @@ name : Pull Request Gradle Build 테스트
 
 on:
   pull_request:
-    types: [opened, synchronize, closed]
+    branches: [ "develop" ]
 
 permissions: read-all
 

--- a/.github/workflows/pull_request_gradle_build.yml
+++ b/.github/workflows/pull_request_gradle_build.yml
@@ -1,0 +1,41 @@
+name : Pull Request Gradle Build 테스트
+
+on:
+  pull_request:
+    types: [opened, synchronize, closed]
+
+permissions: read-all
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v3.0.2
+
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            application:
+            - 'build.gradle'
+            - '**/src/**'
+
+      - name: JDK 설치
+        if: steps.changes.outputs.application == 'true'
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: 'gradle'
+
+      - name: gradlew 권한 부여
+        run: chmod +x ./gradlew
+        
+      - name: Gradle Build
+        if: steps.changes.outputs.application == 'true'
+        run: |
+          ./gradlew build --no-build-cache

--- a/.github/workflows/pull_request_gradle_build.yml
+++ b/.github/workflows/pull_request_gradle_build.yml
@@ -27,5 +27,7 @@ jobs:
         run: chmod +x ./gradlew
         
       - name: Gradle Build
-        run: |
-          ./gradlew build --no-build-cache
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: check
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}

--- a/.github/workflows/pull_request_gradle_build.yml
+++ b/.github/workflows/pull_request_gradle_build.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches: [ "develop" ]
 
-permissions: read-all
-
 jobs:
   build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request_gradle_build.yml
+++ b/.github/workflows/pull_request_gradle_build.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-          cache: 'gradle'
 
       - name: gradlew 권한 부여
         run: chmod +x ./gradlew

--- a/.github/workflows/pull_request_gradle_build.yml
+++ b/.github/workflows/pull_request_gradle_build.yml
@@ -16,16 +16,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v3.0.2
 
-      - uses: dorny/paths-filter@v2
-        id: changes
-        with:
-          filters: |
-            application:
-            - 'build.gradle'
-            - '**/src/**'
-
       - name: JDK 설치
-        if: steps.changes.outputs.application == 'true'
         uses: actions/setup-java@v3
         with:
           distribution: temurin
@@ -36,6 +27,5 @@ jobs:
         run: chmod +x ./gradlew
         
       - name: Gradle Build
-        if: steps.changes.outputs.application == 'true'
         run: |
           ./gradlew build --no-build-cache

--- a/.github/workflows/pull_request_gradle_build.yml
+++ b/.github/workflows/pull_request_gradle_build.yml
@@ -1,4 +1,4 @@
-name : Pull Request Gradle Build 테스트
+name : Check Style and Test to Develop
 
 on:
   pull_request:

--- a/.github/workflows/pull_request_gradle_build.yml
+++ b/.github/workflows/pull_request_gradle_build.yml
@@ -7,9 +7,7 @@ on:
 jobs:
   build-test:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
+
     steps:
       - name: Git Checkout
         uses: actions/checkout@v3.0.2


### PR DESCRIPTION
## 🌱 관련 이슈
- #8 
- 테스트를 강제하기 위한 PR Code Build

## 📌 작업 내용 및 특이사항
-  Pull Request Open, Synchronize, Closed시 Gradle Build 하는 workflows 작성
- JDK는 CI/CD와 같이 17 버전 temurin 사용 예정 -> [참고글](https://whichjdk.com/ko/)
- Closed시엔 필요 없을 수도 있는데, 혹시 몰라서 넣었음.