### PR TITLE
fix: JWT 필터 로직 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/SecurityConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/SecurityConstant.java
@@ -4,6 +4,7 @@ public class SecurityConstant {
 
     public static final String REGISTRATION_REQUIRED_HEADER = "Registration-Required";
     public static final String TOKEN_ROLE_NAME = "role";
+    public static final String GITHUB_NAME_ATTR_KEY = "id";
 
     private SecurityConstant() {}
 }

--- a/src/main/java/com/gdschongik/gdsc/global/security/CustomOAuth2User.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/CustomOAuth2User.java
@@ -1,5 +1,7 @@
 package com.gdschongik.gdsc.global.security;
 
+import static com.gdschongik.gdsc.global.common.constant.SecurityConstant.GITHUB_NAME_ATTR_KEY;
+
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import lombok.Getter;
@@ -13,7 +15,7 @@ public class CustomOAuth2User extends DefaultOAuth2User {
     private final MemberRole memberRole;
 
     public CustomOAuth2User(OAuth2User oAuth2User, Member member) {
-        super(oAuth2User.getAuthorities(), oAuth2User.getAttributes(), oAuth2User.getName());
+        super(oAuth2User.getAuthorities(), oAuth2User.getAttributes(), GITHUB_NAME_ATTR_KEY);
         this.memberId = member.getId();
         this.memberRole = member.getRole();
     }

--- a/src/main/java/com/gdschongik/gdsc/global/util/CookieUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/CookieUtil.java
@@ -1,25 +1,15 @@
 package com.gdschongik.gdsc.global.util;
 
 import com.gdschongik.gdsc.global.common.constant.JwtConstant;
-import com.gdschongik.gdsc.global.property.JwtProperty;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class CookieUtil {
 
-    private final JwtProperty jwtProperty;
-
-    public void addTokenCookies(HttpServletResponse response, String accessToken, String refreshToken) {
-        HttpHeaders headers = generateTokenCookies(accessToken, refreshToken);
-        headers.forEach((key, value) -> response.addHeader(key, value.get(0)));
-    }
-
-    private HttpHeaders generateTokenCookies(String accessToken, String refreshToken) {
+    public HttpServletResponse addTokenCookies(HttpServletResponse response, String accessToken, String refreshToken) {
         // TODO: Prod profile일 때는 Strict, 아니면 None으로 설정
         String sameSite = "None";
 
@@ -29,11 +19,10 @@ public class CookieUtil {
         ResponseCookie refreshTokenCookie =
                 generateCookie(JwtConstant.REFRESH_TOKEN.getCookieName(), refreshToken, sameSite);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
-        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
-        return headers;
+        return response;
     }
 
     private ResponseCookie generateCookie(String cookieName, String tokenValue, String sameSite) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #29 

## 📌 작업 내용 및 특이사항
- `CustomOAuth2User` 의 부모 생성자를 호출할 때 잘못된 인자를 전달하는 오류를 수정했습니다 (이름 -> 이름 속성의 키)
- 쿠키가 올바르게 설정되지 않는 문제를 해결했습니다.

## 📝 참고사항
-

## 📚 기타
-
