### PR TITLE
chore: 프로파일 분리 및 운영환경 유틸리티 관련 기능 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/EnvironmentConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/EnvironmentConstant.java
@@ -3,6 +3,9 @@ package com.gdschongik.gdsc.global.common.constant;
 import java.util.List;
 
 public class EnvironmentConstant {
+
+    private EnvironmentConstant() {}
+
     public static final String PROD = "prod";
     public static final String DEV = "dev";
     public static final String LOCAL = "local";

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/EnvironmentConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/EnvironmentConstant.java
@@ -1,0 +1,10 @@
+package com.gdschongik.gdsc.global.common.constant;
+
+import java.util.List;
+
+public class EnvironmentConstant {
+    public static final String PROD = "prod";
+    public static final String DEV = "dev";
+    public static final String LOCAL = "local";
+    public static final List<String> PROD_AND_DEV = List.of(PROD, DEV);
+}

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/UrlConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/UrlConstant.java
@@ -1,0 +1,11 @@
+package com.gdschongik.gdsc.global.common.constant;
+
+public class UrlConstant {
+
+    private UrlConstant() {}
+
+    public static final String PROD_CLIENT_URL = "https://onboarding.gdschongik.com";
+    public static final String DEV_CLIENT_URL = "https://dev-onboarding.gdschongik.com";
+    public static final String LOCAL_REACT_CLIENT_URL = "http://localhost:3000";
+    public static final String LOCAL_VITE_CLIENT_URL = "http://localhost:5173";
+}

--- a/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
@@ -1,5 +1,8 @@
 package com.gdschongik.gdsc.global.config;
 
+import static com.gdschongik.gdsc.global.common.constant.EnvironmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.UrlConstant.*;
+import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.security.config.Customizer.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -10,6 +13,7 @@ import com.gdschongik.gdsc.global.security.CustomUserService;
 import com.gdschongik.gdsc.global.security.JwtExceptionFilter;
 import com.gdschongik.gdsc.global.security.JwtFilter;
 import com.gdschongik.gdsc.global.util.CookieUtil;
+import com.gdschongik.gdsc.global.util.EnviromentUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,6 +23,9 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
@@ -29,6 +36,7 @@ public class WebSecurityConfig {
     private final JwtService jwtService;
     private final CookieUtil cookieUtil;
     private final ObjectMapper objectMapper;
+    private final EnviromentUtil enviromentUtil;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
@@ -67,5 +75,29 @@ public class WebSecurityConfig {
     @Bean
     public JwtExceptionFilter jwtExceptionFilter(ObjectMapper objectMapper) {
         return new JwtExceptionFilter(objectMapper);
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        if (enviromentUtil.isProdProfile()) {
+            configuration.addAllowedOriginPattern(PROD_CLIENT_URL);
+        }
+
+        if (enviromentUtil.isDevProfile()) {
+            configuration.addAllowedOriginPattern(DEV_CLIENT_URL);
+            configuration.addAllowedOriginPattern(LOCAL_REACT_CLIENT_URL);
+            configuration.addAllowedOriginPattern(LOCAL_VITE_CLIENT_URL);
+        }
+
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+        configuration.setAllowCredentials(true);
+        configuration.addExposedHeader(SET_COOKIE);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
@@ -1,6 +1,5 @@
 package com.gdschongik.gdsc.global.config;
 
-import static com.gdschongik.gdsc.global.common.constant.EnvironmentConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.UrlConstant.*;
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.security.config.Customizer.*;
@@ -13,7 +12,7 @@ import com.gdschongik.gdsc.global.security.CustomUserService;
 import com.gdschongik.gdsc.global.security.JwtExceptionFilter;
 import com.gdschongik.gdsc.global.security.JwtFilter;
 import com.gdschongik.gdsc.global.util.CookieUtil;
-import com.gdschongik.gdsc.global.util.EnviromentUtil;
+import com.gdschongik.gdsc.global.util.EnvironmentUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -36,12 +35,11 @@ public class WebSecurityConfig {
     private final JwtService jwtService;
     private final CookieUtil cookieUtil;
     private final ObjectMapper objectMapper;
-    private final EnviromentUtil enviromentUtil;
+    private final EnvironmentUtil environmentUtil;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .httpBasic(AbstractHttpConfigurer::disable)
+        http.httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(withDefaults())
@@ -81,11 +79,11 @@ public class WebSecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        if (enviromentUtil.isProdProfile()) {
+        if (environmentUtil.isProdProfile()) {
             configuration.addAllowedOriginPattern(PROD_CLIENT_URL);
         }
 
-        if (enviromentUtil.isDevProfile()) {
+        if (environmentUtil.isDevProfile()) {
             configuration.addAllowedOriginPattern(DEV_CLIENT_URL);
             configuration.addAllowedOriginPattern(LOCAL_REACT_CLIENT_URL);
             configuration.addAllowedOriginPattern(LOCAL_VITE_CLIENT_URL);

--- a/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
@@ -39,22 +39,22 @@ public class WebSecurityConfig {
     private final EnviromentUtil enviromentUtil;
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
-        httpSecurity
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(withDefaults())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
-        httpSecurity.oauth2Login(
+        http.oauth2Login(
                 oauth2 -> oauth2.userInfoEndpoint(userInfo -> userInfo.userService(customUserService(memberRepository)))
                         .successHandler(customSuccessHandler(jwtService, cookieUtil)));
 
-        httpSecurity.addFilterBefore(jwtFilter(jwtService, cookieUtil), UsernamePasswordAuthenticationFilter.class);
-        httpSecurity.addFilterBefore(jwtExceptionFilter(objectMapper), JwtFilter.class);
+        http.addFilterBefore(jwtFilter(jwtService, cookieUtil), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(jwtExceptionFilter(objectMapper), JwtFilter.class);
 
-        return httpSecurity.build();
+        return http.build();
     }
 
     @Bean

--- a/src/main/java/com/gdschongik/gdsc/global/util/CookieUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/CookieUtil.java
@@ -13,7 +13,7 @@ public class CookieUtil {
 
     private final EnvironmentUtil environmentUtil;
 
-    public HttpServletResponse addTokenCookies(HttpServletResponse response, String accessToken, String refreshToken) {
+    public void addTokenCookies(HttpServletResponse response, String accessToken, String refreshToken) {
 
         String sameSite = determineSameSitePolicy();
 
@@ -25,8 +25,6 @@ public class CookieUtil {
 
         response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
-
-        return response;
     }
 
     private ResponseCookie generateCookie(String cookieName, String tokenValue, String sameSite) {

--- a/src/main/java/com/gdschongik/gdsc/global/util/CookieUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/CookieUtil.java
@@ -3,6 +3,7 @@ package com.gdschongik.gdsc.global.util;
 import com.gdschongik.gdsc.global.common.constant.JwtConstant;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.server.Cookie;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
@@ -38,8 +39,8 @@ public class CookieUtil {
 
     private String determineSameSitePolicy() {
         if (environmentUtil.isProdProfile()) {
-            return "Strict";
+            return Cookie.SameSite.STRICT.attributeValue();
         }
-        return "None";
+        return Cookie.SameSite.NONE.attributeValue();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/util/CookieUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/CookieUtil.java
@@ -2,16 +2,20 @@ package com.gdschongik.gdsc.global.util;
 
 import com.gdschongik.gdsc.global.common.constant.JwtConstant;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class CookieUtil {
 
+    private final EnvironmentUtil environmentUtil;
+
     public HttpServletResponse addTokenCookies(HttpServletResponse response, String accessToken, String refreshToken) {
-        // TODO: Prod profile일 때는 Strict, 아니면 None으로 설정
-        String sameSite = "None";
+
+        String sameSite = determineSameSitePolicy();
 
         ResponseCookie accessTokenCookie =
                 generateCookie(JwtConstant.ACCESS_TOKEN.getCookieName(), accessToken, sameSite);
@@ -32,5 +36,12 @@ public class CookieUtil {
                 .sameSite(sameSite)
                 .httpOnly(false)
                 .build();
+    }
+
+    private String determineSameSitePolicy() {
+        if (environmentUtil.isProdProfile()) {
+            return "Strict";
+        }
+        return "None";
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/util/EnviromentUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/EnviromentUtil.java
@@ -1,0 +1,38 @@
+package com.gdschongik.gdsc.global.util;
+
+import static com.gdschongik.gdsc.global.common.constant.EnvironmentConstant.*;
+
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EnviromentUtil {
+
+    private final Environment environment;
+
+    public String getCurrentProfile() {
+        return getActiveProfiles()
+                .filter(profile -> profile.equals(PROD) || profile.equals(DEV))
+                .findFirst()
+                .orElse(LOCAL);
+    }
+
+    public Boolean isProdProfile() {
+        return getActiveProfiles().anyMatch(PROD::equals);
+    }
+
+    public Boolean isDevProfile() {
+        return getActiveProfiles().anyMatch(DEV::equals);
+    }
+
+    public Boolean isProdAndDevProfile() {
+        return getActiveProfiles().anyMatch(PROD_AND_DEV::contains);
+    }
+
+    private Stream<String> getActiveProfiles() {
+        return Stream.of(environment.getActiveProfiles());
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/util/EnvironmentUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/EnvironmentUtil.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class EnviromentUtil {
+public class EnvironmentUtil {
 
     private final Environment environment;
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,12 @@
+spring:
+  config:
+    activate:
+      on-profile: "dev"
+  jpa:
+    hibernate:
+      ddl-auto: update
+
+logging:
+  level:
+    org.springframework.orm.jpa: DEBUG
+    org.springframework.transaction: DEBUG

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,19 @@
+spring:
+  config:
+    activate:
+      on-profile: "local"
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: ${SHOW_SQL:true}
+    properties:
+      hibernate:
+        format_sql: ${FORMAT_SQL:true}
+    defer-datasource-initialization: true
+    open-in-view: false
+
+logging:
+  level:
+    org.springframework.orm.jpa: DEBUG
+    org.springframework.transaction: DEBUG

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -1,0 +1,10 @@
+spring:
+  config:
+    activate:
+      on-profile: "redis"
+
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -1,0 +1,22 @@
+spring:
+  config:
+    activate:
+      on-profile: "security"
+
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            client-id: ${GITHUB_CLIENT_ID:default}
+            client-secret: ${GITHUB_CLIENT_SECRET:default}
+
+jwt:
+  token:
+    ACCESS_TOKEN:
+      secret: ${JWT_ACCESS_TOKEN_SECRET:}
+      expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME:7200}
+    REFRESH_TOKEN:
+      secret: ${JWT_REFRESH_TOKEN_SECRET:}
+      expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME:604800}
+  issuer: ${JWT_ISSUER:}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,28 +1,14 @@
 spring:
   profiles:
     group:
-        local: "datasource"
-        dev: "datasource"
-        test: "test"
-  security:
-    oauth2:
-      client:
-        registration:
-          github:
-            client-id: ${GITHUB_CLIENT_ID:default}
-            client-secret: ${GITHUB_CLIENT_SECRET:default}
-  data:
-    redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
-      password: ${REDIS_PASSWORD:}
+      test: "test"
+      local: "local, datasource"
+      dev: "dev, datasource"
+    include:
+      - redis
+      - storage
+      - security
 
-jwt:
-  token:
-    ACCESS_TOKEN:
-      secret: ${JWT_ACCESS_TOKEN_SECRET:}
-      expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME:7200}
-    REFRESH_TOKEN:
-      secret: ${JWT_REFRESH_TOKEN_SECRET:}
-      expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME:604800}
-  issuer: ${JWT_ISSUER:}
+logging:
+  level:
+    com.gdschongik.gdsc.domain.*.api.*: debug


### PR DESCRIPTION
## 🌱 관련 이슈
- close #18 

## 📌 작업 내용 및 특이사항
- `application.yml` 을 운영환경에 맞게 분리했습니다. (local, dev, ...)
- security, redis 설정을 분리했습니다.
- 현재 서비스의 운영환경을 확인할 수 있는 유틸리티를 구현했습니다.
- CORS 설정을 추가했습니다.
    - 운영환경에 따라 허용 origin을 다르게 설정하도록 구현했습니다.
- 운영환경에 따라 쿠키의 SameSite 정책을 다르게 설정하도록 구현했습니다.
- 그 외 자잘하게 리팩토링 필요한 부분들을 개선했습니다.

## 📝 참고사항
-

## 📚 기타
-
