### PR TITLE
feat: 현재 로그인한 멤버 조회하는 유틸리티 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
     // Auth
     INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다."),
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
-    AUTH_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "시큐리티 인증 정보를 찾을 수 없습니다."),
+    AUTH_NOT_EXIST(HttpStatus.INTERNAL_SERVER_ERROR, "시큐리티 인증 정보가 존재하지 않습니다."),
+    AUTH_NOT_PARSABLE(HttpStatus.INTERNAL_SERVER_ERROR, "시큐리티 인증 정보 파싱에 실패했습니다."),
 
     // Parameter
     INVALID_QUERY_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 쿼리 파라미터입니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -9,16 +9,18 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다."),
 
-    // Jwt
+    // Auth
     INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다."),
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
+    AUTH_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "시큐리티 인증 정보를 찾을 수 없습니다."),
 
     // Parameter
     INVALID_QUERY_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 쿼리 파라미터입니다."),
 
     // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
-    MEMBER_DELETED(HttpStatus.CONFLICT, "탈퇴한 회원입니다.");
+    MEMBER_DELETED(HttpStatus.CONFLICT, "탈퇴한 회원입니다."),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/gdschongik/gdsc/global/util/MemberUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/MemberUtil.java
@@ -1,0 +1,36 @@
+package com.gdschongik.gdsc.global.util;
+
+import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberUtil {
+
+    private final MemberRepository memberRepository;
+
+    private Long getCurrentMemberIdFromSecurityContext() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        try {
+            return Long.parseLong(authentication.getName());
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.AUTH_NOT_FOUND);
+        }
+    }
+
+    public Long getCurrentMemberId() {
+        return getCurrentMemberIdFromSecurityContext();
+    }
+
+    public Member getCurrentMember() {
+        return memberRepository
+                .findById(getCurrentMemberIdFromSecurityContext())
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/util/MemberUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/MemberUtil.java
@@ -15,22 +15,27 @@ public class MemberUtil {
 
     private final MemberRepository memberRepository;
 
-    private Long getCurrentMemberIdFromSecurityContext() {
+    public Long getCurrentMemberId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        validateAuthenticationNotNull(authentication);
+
         try {
             return Long.parseLong(authentication.getName());
-        } catch (Exception e) {
-            throw new CustomException(ErrorCode.AUTH_NOT_FOUND);
+        } catch (NumberFormatException e) {
+            throw new CustomException(ErrorCode.AUTH_NOT_PARSABLE);
         }
     }
 
-    public Long getCurrentMemberId() {
-        return getCurrentMemberIdFromSecurityContext();
+    private void validateAuthenticationNotNull(Authentication authentication) {
+        if (authentication == null) {
+            throw new CustomException(ErrorCode.AUTH_NOT_EXIST);
+        }
     }
 
     public Member getCurrentMember() {
         return memberRepository
-                .findById(getCurrentMemberIdFromSecurityContext())
+                .findById(getCurrentMemberId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #19

## 📌 작업 내용 및 특이사항
- 현재 로그인한 멤버를 `SecurityContext` 로부터 읽어오는 유틸리티를 구현했습니다.
- 서비스 레이어에서 주입받아서 사용하면 됩니다.
- 멤버의 모든 필드가 필요하면 `getCurrentMember` 를 통해 엔티티로 조회해와서 사용하고, id 값만 필요한 경우 `getCurrentMemberId` 로 사용하면 됩니다.

## 📝 참고사항
-

## 📚 기타
-
