### PR TITLE
feat: 어드민 대기중인 멤버 조회 api 구현 

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
@@ -5,6 +5,8 @@ import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberUpdateRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberFindAllResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberPendingFindAllResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -37,6 +39,7 @@ public class AdminMemberController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "대기중인 회원 목록 조회", description = "대기중인 회원 목록을 조회합니다.")
     @GetMapping("/pending")
     public ResponseEntity<Page<MemberPendingFindAllResponse>> getPendingMembers(Pageable pageable) {
         Page<MemberPendingFindAllResponse> response = memberService.findAllPendingMembers(pageable);

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
@@ -5,7 +5,6 @@ import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberUpdateRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberFindAllResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberPendingFindAllResponse;
-
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
@@ -42,7 +42,6 @@ public class AdminMemberController {
         return ResponseEntity.ok().build();
     }
 
-
     @Operation(summary = "대기중인 회원 목록 조회", description = "대기중인 회원 목록을 조회합니다.")
     @GetMapping("/pending")
     public ResponseEntity<Page<MemberPendingFindAllResponse>> getPendingMembers(Pageable pageable) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
@@ -3,6 +3,7 @@ package com.gdschongik.gdsc.domain.member.api;
 import com.gdschongik.gdsc.domain.member.application.MemberService;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberFindAllResponse;
+import com.gdschongik.gdsc.domain.member.dto.response.MemberPendingFindAllResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -30,5 +31,11 @@ public class AdminMemberController {
     public ResponseEntity<Void> withdrawMember(@PathVariable Long memberId) {
         memberService.withdrawMember(memberId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/pending")
+    public ResponseEntity<Page<MemberPendingFindAllResponse>> getPendingMembers(Pageable pageable) {
+        Page<MemberPendingFindAllResponse> response = memberService.findAllPendingMembers(pageable);
+        return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/MemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/MemberService.java
@@ -4,8 +4,10 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberFindAllResponse;
+import com.gdschongik.gdsc.domain.member.dto.response.MemberPendingFindAllResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -29,5 +31,10 @@ public class MemberService {
     public void withdrawMember(Long memberId) {
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
         member.withdraw();
+    }
+
+    public Page<MemberPendingFindAllResponse> findAllPendingMembers(Pageable pageable) {
+        Page<Member> members = memberRepository.findAllByRole(MemberRole.GUEST, pageable);
+        return members.map(MemberPendingFindAllResponse::of);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
@@ -1,6 +1,12 @@
 package com.gdschongik.gdsc.domain.member.dao;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {}
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
+
+    Page<Member> findAllByRole(MemberRole role, Pageable pageable);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -3,7 +3,6 @@ package com.gdschongik.gdsc.domain.member.domain;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.model.BaseTimeEntity;
-import com.gdschongik.gdsc.domain.requirement.domain.Requirement;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Requirement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Requirement.java
@@ -1,6 +1,6 @@
-package com.gdschongik.gdsc.domain.requirement.domain;
+package com.gdschongik.gdsc.domain.member.domain;
 
-import static com.gdschongik.gdsc.domain.requirement.domain.RequirementStatus.*;
+import static com.gdschongik.gdsc.domain.member.domain.RequirementStatus.*;
 
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/RequirementStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/RequirementStatus.java
@@ -1,4 +1,4 @@
-package com.gdschongik.gdsc.domain.requirement.domain;
+package com.gdschongik.gdsc.domain.member.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberPendingFindAllResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberPendingFindAllResponse.java
@@ -1,0 +1,29 @@
+package com.gdschongik.gdsc.domain.member.dto.response;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.Requirement;
+
+public record MemberPendingFindAllResponse(
+        Long memberId,
+        String studentId,
+        String name,
+        String phone,
+        String department,
+        String email,
+        String discordUsername,
+        String nickname,
+        Requirement requirement) {
+
+    public static MemberPendingFindAllResponse of(Member member) {
+        return new MemberPendingFindAllResponse(
+                member.getId(),
+                member.getStudentId(),
+                member.getName(),
+                member.getPhone(),
+                member.getDepartment(),
+                member.getEmail(),
+                member.getDiscordUsername(),
+                member.getNickname(),
+                member.getRequirement());
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #22

## 📌 작업 내용 및 특이사항
- 대기중인 멤버 조회를 위한 dto, service, repository 구현

## 📝 참고사항
- requirement 파일들의 위치를 member 디렉토리 내부로 옮겼습니다

## 📚 기타
-
