### PR TITLE
feat:  헬스체크 API를 위한 actuator 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
+    // Actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
@@ -82,6 +82,18 @@ public class WebSecurityConfig {
         http.addFilterAfter(jwtExceptionFilter(objectMapper), LogoutFilter.class);
         http.addFilterAfter(jwtFilter(jwtService, cookieUtil), LogoutFilter.class);
 
+        http.authorizeHttpRequests(authorize -> authorize
+                .requestMatchers("/oauth2/**")
+                .permitAll()
+                .requestMatchers("/gdsc-actuator/**")
+                .permitAll()
+                .requestMatchers("/onboarding/**")
+                .authenticated()
+                .requestMatchers("/admin/**")
+                .hasRole("ADMIN")
+                .anyRequest()
+                .authenticated());
+
         return http.build();
     }
 

--- a/src/main/resources/application-actuator.yml
+++ b/src/main/resources/application-actuator.yml
@@ -1,0 +1,13 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+      base-path: /gdsc-actuator
+    jmx:
+      exposure:
+        exclude: "*"
+    enabled-by-default: false
+  endpoint:
+    health:
+      enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,6 @@ spring:
       dev: "dev, datasource"
     include:
       - redis
-      - storage
       - security
       - swagger
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,7 @@ spring:
       - redis
       - security
       - swagger
+      - actuator
 
 logging:
   level:


### PR DESCRIPTION
## 🌱 관련 이슈
- close #53

## 📌 작업 내용 및 특이사항
- 스프링부트 액추에이터를 추가했습니다.
- ELB에서 헬스체크 시 `/gdsc-actuactor/health` 로 요청을 보내도록 합니다.
- 액추에이터 관련 보안설정을 적용했습니다.
    - 모든 엔드포인트를 기본적으로 비활성화 처리했습니다 (enabled-by-default)
    - jmx 방식은 모든 endpoint를 사용하므로 비활성화 처리했습니다.
    - health 관련 엔드포인트만 활성화하도록 추가했습니다.
    - 액추에이터 디폴트 경로를 `/gdsc-actuator` 로 설정하여 uri 스캔 공격을 회피할 수 있도록 했습니다.

## 📝 참고사항
-

## 📚 기타
-
