### PR TITLE
chore: 도커허브에 올라간 이미지를 재배포하는 워크플로우 추가

### DIFF
--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -8,7 +8,7 @@ on:
         required: true
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     environment: develop
     steps:

--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy to Develop
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_hash:
+        description: 'commit_hash'
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: develop
+    steps:
+      - name: Deploy to EC2 Server
+        uses: appleboy/ssh-action@master
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_IMAGE_TAG: ${{ github.event.inputs.commit_hash }}
+        with:
+            host: ${{ secrets.EC2_HOST }}
+            username: ${{ secrets.EC2_USERNAME }}
+            key: ${{ secrets.EC2_PRIVATE_KEY }}
+            envs: DOCKERHUB_USERNAME,DOCKERHUB_IMAGE_TAG  # docker-compose.yml 에서 사용할 환경 변수
+            script: |
+              echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+              docker pull ${{ env.DOCKERHUB_USERNAME }}/gdsc-server:${{ env.DOCKERHUB_IMAGE_TAG }}
+              docker compose -f /home/ubuntu/docker-compose.yml up -d
+              docker image prune -a -f


### PR DESCRIPTION
## 🌱 관련 이슈
- close #55 

## 📌 작업 내용 및 특이사항
- Actions 페이지의 `Deploy to develop` 탭에서 `commit_hash` 를 입력하여 수동으로 워크플로우를 실행합니다.
<img width="989" alt="image" src="https://github.com/GDSC-Hongik/gdsc-server/assets/91878695/1a7f3d71-56c3-483f-bb23-e609e9fe1beb">

- `commit_hash` 의 경우 도커허브의 이미지 태그로 들어갑니다. 
<img width="703" alt="image" src="https://github.com/GDSC-Hongik/gdsc-server/assets/91878695/6c70eb68-57e0-4795-b2e5-4ea08a328c07">

## 📝 참고사항
-

## 📚 기타
-
