### PR TITLE
fix: 스웨거 Basic Auth가 작동하지 않는 문제 해결

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
@@ -60,7 +60,7 @@ public class WebSecurityConfig {
     @Bean
     @Order(1)
     @ConditionalOnProperty(name = "spring.profiles.active", havingValue = "dev")
-    public SecurityFilterChain swaggerSecurityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain swaggerFilterChain(HttpSecurity http) throws Exception {
         defaultFilterChain(http);
 
         http.securityMatcher(getSwaggerUrls())

--- a/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
@@ -80,6 +80,9 @@ public class WebSecurityConfig {
                         .successHandler(customSuccessHandler(jwtService, cookieUtil))
                         .failureHandler((request, response, exception) -> response.setStatus(401)));
 
+        http.exceptionHandling(exception ->
+                exception.authenticationEntryPoint((request, response, authException) -> response.setStatus(401)));
+
         http.addFilterAfter(jwtExceptionFilter(objectMapper), LogoutFilter.class);
         http.addFilterAfter(jwtFilter(jwtService, cookieUtil), LogoutFilter.class);
 

--- a/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
@@ -64,6 +64,7 @@ public class WebSecurityConfig {
         defaultFilterChain(http);
 
         http.securityMatcher(getSwaggerUrls())
+                .oauth2Login(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
                 .httpBasic(withDefaults());
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #58

## 📌 작업 내용 및 특이사항
- 현재 dev 서버 스웨거 접속 시 github oauth2 로그인 창으로 리다이렉트되는 문제가 있습니다.
- 이는 권한없는 요청인 경우 스프링 시큐리티의 oauth2 설정이 `OAuth2AuthorizationRequestRedirectFilter` 에 의해 강제로 `oauth2/authorization/github` 로 리다이렉트 되도록 설정되어 있기 때문입니다. 
- 스웨거의 경우 basic auth를 사용하고 있기 때문에 `BasicAuthenticationEntryPoint` 가 작동해야 하지만, 이는 `ExceptionTranslationFilter` 에서 수행됩니다. 해당 필터는 OAuth 필터보다 뒤에 존재하기 때문에 oauth의 리다이렉트 요청이 먼저 처리되는 것입니다.
- 이러한 문제 때문에 #40 에서 별도의 `swaggerFilterChain` 을 타도록 해주었지만 이때 oauthLogin 옵션을 disable 처리해주지 않아 해당 문제가 발생했습니다.
- 아울러, 디폴트 요청이 타게 되는 `filterChain` 에서도 리다이렉트 문제가 발생하기 때문에 이를 해결해주어야 합니다. 인증 예외가 발생했을 때 대부분의 예외는 디폴트로 `LoginUrlAuthenticationEntryPoint` 에 의해서 처리됩니다. 실제로 해당 클래스의 `commence()` 에서 리다이렉트 로직을 확인할 수 있습니다.
- `HttpSecurity` 의 `exceptionHandling` 에서 `authenticationEntryPoint` 를 커스텀해주면 스프링 시큐리티는 이렇게 커스텀된 설정을 우선합니다. 간단하게 인라인으로 `(request, response, authException) -> response.setStatus(401)` 와 같이 설정하여 401을 내려주도록 해두었습니다.

## 📝 참고사항
-

## 📚 기타
-
