### PR TITLE
feat: 어드민 멤버 가입신청 승인하기 api 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
@@ -1,9 +1,11 @@
 package com.gdschongik.gdsc.domain.member.api;
 
 import com.gdschongik.gdsc.domain.member.application.MemberService;
+import com.gdschongik.gdsc.domain.member.dto.request.MemberGrantRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberUpdateRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberFindAllResponse;
+import com.gdschongik.gdsc.domain.member.dto.response.MemberGrantResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberPendingFindAllResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -55,5 +57,12 @@ public class AdminMemberController {
             @PathVariable Long memberId, @Valid @RequestBody MemberUpdateRequest request) {
         memberService.updateMember(memberId, request);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "회원 승인", description = "회원의 가입을 승인합니다.")
+    @PutMapping("/grant")
+    public ResponseEntity<MemberGrantResponse> grantMember(@Valid @RequestBody MemberGrantRequest request) {
+        MemberGrantResponse response = memberService.grantMember(request);
+        return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/MemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/MemberService.java
@@ -5,12 +5,16 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.domain.member.dto.request.MemberGrantRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberUpdateRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberFindAllResponse;
+import com.gdschongik.gdsc.domain.member.dto.response.MemberGrantResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberPendingFindAllResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -45,5 +49,21 @@ public class MemberService {
     public Page<MemberPendingFindAllResponse> findAllPendingMembers(Pageable pageable) {
         Page<Member> members = memberRepository.findAllByRole(MemberRole.GUEST, pageable);
         return members.map(MemberPendingFindAllResponse::of);
+    }
+
+    @Transactional
+    public MemberGrantResponse grantMember(MemberGrantRequest request) {
+        List<Member> verifiedMembers = getVerifiedMembers(request);
+        verifiedMembers.forEach(Member::grant);
+        return MemberGrantResponse.of(verifiedMembers);
+    }
+
+    private List<Member> getVerifiedMembers(MemberGrantRequest request) {
+        List<Long> memberIdList = request.memberIdList();
+        return memberIdList.stream()
+                .map(memberRepository::findVerifiedById)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .toList();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
@@ -10,4 +10,6 @@ public interface MemberCustomRepository {
     Page<Member> findAll(MemberQueryRequest queryRequest, Pageable pageable);
 
     Optional<Member> findNormalByOauthId(String oauthId);
+
+    Optional<Member> findVerifiedById(Long id);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -4,6 +4,7 @@ import static com.gdschongik.gdsc.domain.member.domain.QMember.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberStatus;
+import com.gdschongik.gdsc.domain.member.domain.RequirementStatus;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -42,6 +43,36 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
                 .selectFrom(member)
                 .where(eqOauthId(oauthId), eqStatus(MemberStatus.NORMAL))
                 .fetchOne());
+    }
+
+    @Override
+    public Optional<Member> findVerifiedById(Long id) {
+        return Optional.ofNullable(
+                queryFactory.selectFrom(member).where(requirementVerified(id)).fetchOne());
+    }
+
+    private BooleanBuilder requirementVerified(Long id) {
+        return new BooleanBuilder()
+                .and(eqId(id))
+                .and(discordVerified())
+                .and(univVerified())
+                .and(paymentVerified());
+    }
+
+    private BooleanExpression discordVerified() {
+        return member.requirement.discordStatus.eq(RequirementStatus.VERIFIED);
+    }
+
+    private BooleanExpression univVerified() {
+        return member.requirement.univStatus.eq(RequirementStatus.VERIFIED);
+    }
+
+    private BooleanExpression paymentVerified() {
+        return member.requirement.paymentStatus.eq(RequirementStatus.VERIFIED);
+    }
+
+    private BooleanExpression eqId(Long id) {
+        return member.id.eq(id);
     }
 
     private BooleanExpression eqOauthId(String oauthId) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -47,16 +47,14 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
 
     @Override
     public Optional<Member> findVerifiedById(Long id) {
-        return Optional.ofNullable(
-                queryFactory.selectFrom(member).where(requirementVerified(id)).fetchOne());
+        return Optional.ofNullable(queryFactory
+                .selectFrom(member)
+                .where(eqId(id), requirementVerified())
+                .fetchOne());
     }
 
-    private BooleanBuilder requirementVerified(Long id) {
-        return new BooleanBuilder()
-                .and(eqId(id))
-                .and(discordVerified())
-                .and(univVerified())
-                .and(paymentVerified());
+    private BooleanBuilder requirementVerified() {
+        return new BooleanBuilder().and(discordVerified()).and(univVerified()).and(paymentVerified());
     }
 
     private BooleanExpression discordVerified() {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -134,4 +134,8 @@ public class Member extends BaseTimeEntity {
             throw new CustomException(MEMBER_FORBIDDEN);
         }
     }
+
+    public void grant() {
+        this.role = MemberRole.USER;
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberGrantRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberGrantRequest.java
@@ -1,0 +1,6 @@
+package com.gdschongik.gdsc.domain.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record MemberGrantRequest(@Schema(description = "승인할 멤버 ID 리스트") List<Long> memberIdList) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberGrantResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberGrantResponse.java
@@ -1,0 +1,13 @@
+package com.gdschongik.gdsc.domain.member.dto.response;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record MemberGrantResponse(@Schema(description = "승인에 성공한 멤버 ID 리스트") List<Long> grantedMembers) {
+    public static MemberGrantResponse of(List<Member> grantedMembers) {
+        List<Long> grantedMemberIdList =
+                grantedMembers.stream().map(Member::getId).toList();
+        return new MemberGrantResponse(grantedMemberIdList);
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/MemberServiceTest.java
@@ -4,11 +4,9 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.member.dto.request.MemberGrantRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberUpdateRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -34,18 +32,5 @@ class MemberServiceTest {
         assertThatThrownBy(() -> memberService.updateMember(member.getId(), requestBody))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.MEMBER_DELETED.getMessage());
-    }
-
-    @Test
-    void requirement가_충족되지_않으면_승인_실패() {
-        // given
-        Member unverifiedMember = Member.createGuestMember("oAuthId");
-        memberRepository.save(unverifiedMember);
-        MemberGrantRequest request = new MemberGrantRequest(List.of(unverifiedMember.getId()));
-
-        // when & then
-        assertThatThrownBy(() -> memberService.grantMember(request))
-                .isInstanceOf(CustomException.class)
-                .hasMessage(ErrorCode.MEMBER_NOT_VERIFIED.getMessage());
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/MemberServiceTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.dto.request.MemberGrantRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberUpdateRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -32,5 +34,18 @@ class MemberServiceTest {
         assertThatThrownBy(() -> memberService.updateMember(member.getId(), requestBody))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.MEMBER_DELETED.getMessage());
+    }
+
+    @Test
+    void requirement가_충족되지_않으면_승인_실패() {
+        // given
+        Member unverifiedMember = Member.createGuestMember("oAuthId");
+        memberRepository.save(unverifiedMember);
+        MemberGrantRequest request = new MemberGrantRequest(List.of(unverifiedMember.getId()));
+
+        // when & then
+        assertThatThrownBy(() -> memberService.grantMember(request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.MEMBER_NOT_VERIFIED.getMessage());
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #23

## 📌 작업 내용 및 특이사항
- 승인할 멤버들의 id(pk)를 리스트로 받아서 승인된 멤버들의 id만 모아서 리스트로 반환합니다.
- **_3가지 requirement_**(재학생, 회비, 디스코드)의 승인 여부는 쿼리에서 확인하도록 구현했습니다.

## 📝 참고사항
-

## 📚 기타
-
