### PR TITLE
feat: 소셜 로그인 시 랜딩할 페이지 결정에 사용할 헤더 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/SecurityConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/SecurityConstant.java
@@ -2,7 +2,7 @@ package com.gdschongik.gdsc.global.common.constant;
 
 public class SecurityConstant {
 
-    public static final String REGISTRATION_REQUIRED_HEADER = "Registration-Required";
+    public static final String LANDING_STATUS_HEADER = "Landing-Status";
     public static final String TOKEN_ROLE_NAME = "role";
     public static final String GITHUB_NAME_ATTR_KEY = "id";
     public static final String ACCESS_TOKEN_HEADER_PREFIX = "Bearer ";

--- a/src/main/java/com/gdschongik/gdsc/global/security/CustomOAuth2User.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/CustomOAuth2User.java
@@ -21,8 +21,4 @@ public class CustomOAuth2User extends DefaultOAuth2User {
         this.memberRole = member.getRole();
         this.landingStatus = LandingStatus.of(member);
     }
-
-    public boolean isGuest() {
-        return memberRole == MemberRole.GUEST;
-    }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/security/CustomOAuth2User.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/CustomOAuth2User.java
@@ -13,11 +13,13 @@ public class CustomOAuth2User extends DefaultOAuth2User {
 
     private final Long memberId;
     private final MemberRole memberRole;
+    private final LandingStatus landingStatus;
 
     public CustomOAuth2User(OAuth2User oAuth2User, Member member) {
         super(oAuth2User.getAuthorities(), oAuth2User.getAttributes(), GITHUB_NAME_ATTR_KEY);
         this.memberId = member.getId();
         this.memberRole = member.getRole();
+        this.landingStatus = LandingStatus.of(member);
     }
 
     public boolean isGuest() {

--- a/src/main/java/com/gdschongik/gdsc/global/security/CustomSuccessHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/CustomSuccessHandler.java
@@ -28,8 +28,8 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
 
-        // 게스트 유저이면 회원가입 필요하므로 헤더 설정
-        response.setHeader(REGISTRATION_REQUIRED_HEADER, oAuth2User.isGuest() ? "true" : "false");
+        // 랜딩 페이지 결정에 필요한 정보를 헤더에 추가
+        response.setHeader(LANDING_STATUS_HEADER, oAuth2User.getLandingStatus().name());
 
         // 토큰 생성 후 쿠키에 저장
         AccessTokenDto accessTokenDto =

--- a/src/main/java/com/gdschongik/gdsc/global/security/LandingStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/LandingStatus.java
@@ -1,0 +1,27 @@
+package com.gdschongik.gdsc.global.security;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.RequirementStatus;
+
+public enum LandingStatus {
+    TO_STUDENT_AUTHENTICATION, // 재학생 인증 페이지로 랜딩
+    TO_REGISTRATION, // 가입신청 페이지로 랜딩
+    TO_DASHBOARD, // 대시보드로 랜딩
+    ;
+
+    public static LandingStatus of(Member member) {
+        // 아직 재학생 인증을 하지 않았다면 재학생 인증 페이지로 랜딩
+        if (member.getRequirement().getUnivStatus() == RequirementStatus.PENDING) {
+            return TO_STUDENT_AUTHENTICATION;
+        }
+
+        // 재학생 인증은 했지만 가입신청을 하지 않았다면 가입신청 페이지로 랜딩
+        // 가입신청 여부는 학번 존재여부로 판단
+        if (member.getStudentId() == null) {
+            return TO_REGISTRATION;
+        }
+
+        // 재학생 인증과 가입신청을 모두 완료했다면 대시보드로 랜딩
+        return TO_DASHBOARD;
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #61

## 📌 작업 내용 및 특이사항
- 소셜 로그인 후 유저가 어디로 랜딩할지를 결정하는 헤더를 추가했습니다.
- 헤더 이름은 `Landing-Status` 입니다.
- 헤더는 `TO_STUDENT_AUTHENTICATION` / `TO_REGISTRATION` / `TO_DASHBOARD` 세 가지 상태를 가집니다.
    - 각각 재학생 인증 페이지 / 가입신청 페이지 / 대시보드 페이지를 의미합니다.
- 결정 로직은 다음과 같습니다.
    - `univStatus` 가 `PENDING` 이면 재학생 인증 페이지로 랜딩합니다.
    - 가입신청을 하지 않았다면 학번이 null입니다. 따라서 학번이 null이면 가입신청 페이지로 랜딩합니다.   
    - 그 외의 경우에는 대시보드 페이지로 랜딩합니다.

## 📝 참고사항
-

## 📚 기타
-
