### PR TITLE
chore: 디스코드 연동 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
+    // Discord
+    implementation 'net.dv8tion:JDA:5.0.0-beta.20'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/listener/PingpongListener.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/listener/PingpongListener.java
@@ -1,0 +1,30 @@
+package com.gdschongik.gdsc.domain.discord.listener;
+
+import com.gdschongik.gdsc.global.discord.Listener;
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+@Slf4j
+@Listener
+public class PingpongListener extends ListenerAdapter {
+
+    @Override
+    public void onMessageReceived(MessageReceivedEvent event) {
+        User author = event.getAuthor();
+        TextChannel channel = event.getChannel().asTextChannel();
+        Message message = event.getMessage();
+        String content = message.getContentRaw(); // get only textual content of message
+
+        log.info("Message from {} in {}: {}", author.getName(), channel.getName(), message.getContentDisplay());
+
+        if (author.isBot()) return;
+
+        if (content.equals("!ping")) {
+            channel.sendMessage("Pong!").queue();
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
@@ -24,4 +24,9 @@ public class DiscordConfig {
                 .setMemberCachePolicy(MemberCachePolicy.ALL)
                 .build();
     }
+
+    @Bean
+    public ListenerBeanPostProcessor listenerBeanPostProcessor(JDA jda) {
+        return new ListenerBeanPostProcessor(jda);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
@@ -1,0 +1,20 @@
+package com.gdschongik.gdsc.global.config;
+
+import com.gdschongik.gdsc.global.property.DiscordProperty;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.JDABuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class DiscordConfig {
+
+    private final DiscordProperty discordProperty;
+
+    @Bean
+    public JDA discord() {
+        return JDABuilder.createDefault(discordProperty.getToken()).build();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
@@ -4,6 +4,9 @@ import com.gdschongik.gdsc.global.property.DiscordProperty;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.entities.Activity;
+import net.dv8tion.jda.api.requests.GatewayIntent;
+import net.dv8tion.jda.api.utils.MemberCachePolicy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,7 +17,11 @@ public class DiscordConfig {
     private final DiscordProperty discordProperty;
 
     @Bean
-    public JDA discord() {
-        return JDABuilder.createDefault(discordProperty.getToken()).build();
+    public JDA jda() {
+        return JDABuilder.createDefault(discordProperty.getToken())
+                .setActivity(Activity.playing("테스트"))
+                .enableIntents(GatewayIntent.GUILD_MESSAGES, GatewayIntent.MESSAGE_CONTENT, GatewayIntent.GUILD_MEMBERS)
+                .setMemberCachePolicy(MemberCachePolicy.ALL)
+                .build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.global.config;
 
+import com.gdschongik.gdsc.global.discord.ListenerBeanPostProcessor;
 import com.gdschongik.gdsc.global.property.DiscordProperty;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.JDA;
@@ -7,6 +8,8 @@ import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.utils.MemberCachePolicy;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -17,6 +20,7 @@ public class DiscordConfig {
     private final DiscordProperty discordProperty;
 
     @Bean
+    @ConditionalOnProperty(value = "discord.enabled", havingValue = "true", matchIfMissing = true)
     public JDA jda() {
         return JDABuilder.createDefault(discordProperty.getToken())
                 .setActivity(Activity.playing("테스트"))

--- a/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
@@ -30,6 +30,7 @@ public class DiscordConfig {
     }
 
     @Bean
+    @ConditionalOnBean(JDA.class)
     public ListenerBeanPostProcessor listenerBeanPostProcessor(JDA jda) {
         return new ListenerBeanPostProcessor(jda);
     }

--- a/src/main/java/com/gdschongik/gdsc/global/config/PropertyConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/PropertyConfig.java
@@ -1,11 +1,12 @@
 package com.gdschongik.gdsc.global.config;
 
+import com.gdschongik.gdsc.global.property.DiscordProperty;
 import com.gdschongik.gdsc.global.property.JwtProperty;
 import com.gdschongik.gdsc.global.property.RedisProperty;
 import com.gdschongik.gdsc.global.property.SwaggerProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-@EnableConfigurationProperties({JwtProperty.class, RedisProperty.class, SwaggerProperty.class})
+@EnableConfigurationProperties({JwtProperty.class, RedisProperty.class, SwaggerProperty.class, DiscordProperty.class})
 @Configuration
 public class PropertyConfig {}

--- a/src/main/java/com/gdschongik/gdsc/global/discord/Listener.java
+++ b/src/main/java/com/gdschongik/gdsc/global/discord/Listener.java
@@ -1,0 +1,12 @@
+package com.gdschongik.gdsc.global.discord;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.stereotype.Component;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Component
+public @interface Listener {}

--- a/src/main/java/com/gdschongik/gdsc/global/discord/ListenerBeanPostProcessor.java
+++ b/src/main/java/com/gdschongik/gdsc/global/discord/ListenerBeanPostProcessor.java
@@ -1,0 +1,21 @@
+package com.gdschongik.gdsc.global.discord;
+
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.JDA;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ListenerBeanPostProcessor implements BeanPostProcessor {
+
+    private final JDA jda;
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) {
+        if (bean.getClass().isAnnotationPresent(Listener.class)) {
+            jda.addEventListener(bean);
+        }
+        return bean;
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/discord/ListenerBeanPostProcessor.java
+++ b/src/main/java/com/gdschongik/gdsc/global/discord/ListenerBeanPostProcessor.java
@@ -3,9 +3,7 @@ package com.gdschongik.gdsc.global.discord;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.JDA;
 import org.springframework.beans.factory.config.BeanPostProcessor;
-import org.springframework.stereotype.Component;
 
-@Component
 @RequiredArgsConstructor
 public class ListenerBeanPostProcessor implements BeanPostProcessor {
 

--- a/src/main/java/com/gdschongik/gdsc/global/property/DiscordProperty.java
+++ b/src/main/java/com/gdschongik/gdsc/global/property/DiscordProperty.java
@@ -1,0 +1,13 @@
+package com.gdschongik.gdsc.global.property;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@AllArgsConstructor
+@ConfigurationProperties(prefix = "discord")
+public class DiscordProperty {
+
+    private final String token;
+}

--- a/src/main/resources/application-discord.yml
+++ b/src/main/resources/application-discord.yml
@@ -1,0 +1,2 @@
+discord:
+  token: ${DISCORD_BOT_TOKEN:}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,13 +2,14 @@ spring:
   profiles:
     group:
       test: "test"
-      local: "local, datasource, discord"
-      dev: "dev, datasource, discord"
+      local: "local, datasource"
+      dev: "dev, datasource"
     include:
       - redis
       - security
       - swagger
       - actuator
+      - discord
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,14 +2,13 @@ spring:
   profiles:
     group:
       test: "test"
-      local: "local, datasource"
-      dev: "dev, datasource"
+      local: "local, datasource, discord"
+      dev: "dev, datasource, discord"
     include:
       - redis
       - security
       - swagger
       - actuator
-      - discord
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,7 @@ spring:
       - security
       - swagger
       - actuator
+      - discord
 
 logging:
   level:

--- a/src/test/java/com/gdschongik/gdsc/GdscApplicationTests.java
+++ b/src/test/java/com/gdschongik/gdsc/GdscApplicationTests.java
@@ -2,8 +2,10 @@ package com.gdschongik.gdsc;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class GdscApplicationTests {
 
     @Test

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
@@ -10,8 +10,10 @@ import com.gdschongik.gdsc.global.exception.ErrorCode;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class AdminMemberServiceTest {
     @Autowired
     private MemberRepository memberRepository;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -5,3 +5,6 @@ spring:
 
   datasource:
     url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
+
+discord:
+  enabled: false


### PR DESCRIPTION
## 🌱 관련 이슈
- close #27

## 📌 작업 내용 및 특이사항
- JDA 관련 세팅을 완료했습니다.
- 디스코드 봇은 기본적으로 리스너 기반으로 작동합니다.
- 해당 리스너를 컴포넌트로 추가합니다. 이때 빈 후처리기를 통해 `@Listener` 로 annotated 된 빈을 `jda.addEventListener` 을 통해 동적으로 리스너로 등록되도록 해주었습니다.
- 이렇게 하면 매번 리스너를 구현할 때마다 jda config에서 리스너를 추가할 필요가 없습니다.
- 테스트에 필요한 핑퐁 리스너를 추가해두었습니다. GDSC 개발채널 링크로 테스트 서버 접속하셔서 `!ping` 으로 테스트 가능합니다.

## 📝 참고사항
### 테스트 관련 이슈
- 리스너 빈 후처리기(`ListnerBeanPostProcessor`)의 경우 JDA 외부 의존성을 주입받습니다. 따라서 `@Component` 가 아니라 `DiscordConfig` 에서 `@Bean` 으로 등록해주어야 합니다.
- 이떄 테스트 환경에서 디스코드 봇 토큰 값을 주입받을 수 없으므로 JDA 초기화에 실패합니다. 따라서 테스트 환경에서는 `discord.enabled: false` 를 설정하고 `@ConditionalOnProperty` 를 통해 로드하지 않도록 설정합니다.
- 한편 리스너 빈 후처리기의 경우 JDA가 존재하지 않은 경우 초기화되지 않아야 하므로 `@ConditionalOnBean` 으로 설정해두었습니다.

## 📚 기타
-
