### PR TITLE
feat: 온보딩 멤버 정보 수정하기

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
@@ -2,12 +2,14 @@ package com.gdschongik.gdsc.domain.member.api;
 
 import com.gdschongik.gdsc.domain.member.application.OnboardingMemberService;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberSignupRequest;
+import com.gdschongik.gdsc.domain.member.dto.request.OnboardingMemberUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,6 +26,13 @@ public class OnboardingMemberController {
     @PostMapping
     public ResponseEntity<Void> signupMember(@Valid @RequestBody MemberSignupRequest request) {
         onboardingMemberService.signupMember(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "회원 정보 수정", description = "회원 정보를 수정합니다.")
+    @PutMapping
+    public ResponseEntity<Void> updateMember(@Valid @RequestBody OnboardingMemberUpdateRequest request) {
+        onboardingMemberService.updateMember(request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
@@ -29,8 +29,8 @@ public class OnboardingMemberController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "회원 정보 수정", description = "회원 정보를 수정합니다.")
-    @PutMapping
+    @Operation(summary = "디스코드 회원 정보 수정", description = "디스코드 회원 정보를 수정합니다.")
+    @PutMapping("/me/discord")
     public ResponseEntity<Void> updateMember(@Valid @RequestBody OnboardingMemberUpdateRequest request) {
         onboardingMemberService.updateMember(request);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.domain.member.application;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberSignupRequest;
+import com.gdschongik.gdsc.domain.member.dto.request.OnboardingMemberUpdateRequest;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,5 +20,11 @@ public class OnboardingMemberService {
         Member currentMember = memberUtil.getCurrentMember();
         currentMember.signup(
                 request.studentId(), request.name(), request.phone(), request.department(), request.email());
+    }
+
+    @Transactional
+    public void updateMember(OnboardingMemberUpdateRequest request) {
+        Member currentMember = memberUtil.getCurrentMember();
+        currentMember.updateDiscordInfo(request.discordUsername(), request.nickname());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -161,4 +161,11 @@ public class Member extends BaseTimeEntity {
     public void grant() {
         this.role = MemberRole.USER;
     }
+
+    public void updateDiscordInfo(String discordUsername, String nickname) {
+        validateStatusUpdatable();
+
+        this.discordUsername = discordUsername;
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/OnboardingMemberUpdateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/OnboardingMemberUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.gdschongik.gdsc.domain.member.dto.request;
+
+import static com.gdschongik.gdsc.global.common.constant.RegexConstant.*;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record OnboardingMemberUpdateRequest(
+        @NotBlank @Schema(description = "discord username") String discordUsername,
+        @NotBlank
+                @Pattern(regexp = NICKNAME, message = "닉네임은 " + NICKNAME + " 형식이어야 합니다.")
+                @Schema(description = "커뮤니티 닉네임", pattern = NICKNAME)
+                String nickname) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #52

## 📌 작업 내용 및 특이사항
- 변경된 기획 내용에 따라 username, nickname 두 가지만 수정하도록 했습니다.
- endpoint에서 memberId를 제거했는데 이 부분에 대해 의견 부탁드립니다. 활용하지 않더라고 경로에 있는게 맞을지 모르겠습니다.

## 📝 참고사항
-

## 📚 기타
-
