### PR TITLE
feat: 디스코드 인증코드 발급하기 기능 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/api/OnboardingDiscordController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/api/OnboardingDiscordController.java
@@ -1,0 +1,27 @@
+package com.gdschongik.gdsc.domain.discord.api;
+
+import com.gdschongik.gdsc.domain.discord.application.OnboardingDiscordService;
+import com.gdschongik.gdsc.domain.discord.dto.response.DiscordVerificationCodeResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Onboarding Discord", description = "온보딩 서비스의 디스코드 관련 API입니다.")
+@RestController
+@RequestMapping("/onboarding")
+@RequiredArgsConstructor
+public class OnboardingDiscordController {
+
+    private final OnboardingDiscordService onboardingDiscordService;
+
+    @Operation(summary = "디스코드 연동 인증코드 발급하기", description = "디스코드 연동을 위한 인증코드를 발급합니다.")
+    @GetMapping("/discord-verification-code")
+    public ResponseEntity<DiscordVerificationCodeResponse> getVerificationCode() {
+        DiscordVerificationCodeResponse response = onboardingDiscordService.createVerificationCode();
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/api/OnboardingDiscordController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/api/OnboardingDiscordController.java
@@ -1,12 +1,11 @@
 package com.gdschongik.gdsc.domain.discord.api;
 
 import com.gdschongik.gdsc.domain.discord.application.OnboardingDiscordService;
-import com.gdschongik.gdsc.domain.discord.dto.response.DiscordVerificationCodeResponse;
+import com.gdschongik.gdsc.domain.discord.dto.response.LinkDiscordResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,10 +17,10 @@ public class OnboardingDiscordController {
 
     private final OnboardingDiscordService onboardingDiscordService;
 
-    @Operation(summary = "디스코드 연동 인증코드 발급하기", description = "디스코드 연동을 위한 인증코드를 발급합니다.")
-    @GetMapping("/discord-verification-code")
-    public ResponseEntity<DiscordVerificationCodeResponse> getVerificationCode() {
-        DiscordVerificationCodeResponse response = onboardingDiscordService.createVerificationCode();
-        return ResponseEntity.ok().body(response);
+    @Operation(summary = "디스코드 연동하기", description = "디스코드 봇으로 발급받은 인증코드와 현재 사용자의 디스코드 계정을 연동합니다.")
+    @RequestMapping("/link-discord")
+    public ResponseEntity<LinkDiscordResponse> linkDiscord() {
+        // TODO: 디스코드 연동하기
+        return ResponseEntity.ok(new LinkDiscordResponse());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
@@ -5,7 +5,6 @@ import static com.gdschongik.gdsc.domain.discord.domain.DiscordVerificationCode.
 import com.gdschongik.gdsc.domain.discord.dao.DiscordVerificationCodeRepository;
 import com.gdschongik.gdsc.domain.discord.domain.DiscordVerificationCode;
 import com.gdschongik.gdsc.domain.discord.dto.response.DiscordVerificationCodeResponse;
-import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.security.SecureRandom;
 import lombok.RequiredArgsConstructor;
@@ -24,17 +23,15 @@ public class OnboardingDiscordService {
     private final DiscordVerificationCodeRepository discordVerificationCodeRepository;
 
     @Transactional
-    public DiscordVerificationCodeResponse createVerificationCode() {
-        Member member = memberUtil.getCurrentMember();
+    public DiscordVerificationCodeResponse createVerificationCode(String discordUsername) {
 
-        String discordUsername = member.getDiscordUsername();
         Long code = generateRandomCode();
         DiscordVerificationCode discordVerificationCode =
                 DiscordVerificationCode.create(discordUsername, code, DISCORD_CODE_TTL_SECONDS);
 
         discordVerificationCodeRepository.save(discordVerificationCode);
 
-        return DiscordVerificationCodeResponse.of(code);
+        return DiscordVerificationCodeResponse.of(code, DISCORD_CODE_TTL_SECONDS);
     }
 
     @SneakyThrows

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
@@ -40,7 +40,6 @@ public class OnboardingDiscordService {
                 .orElseThrow();
     }
 
-
     // TODO: 디스코드 연동하기 피쳐에서 구현
     public void verifyDiscordCode(String discordUsername, String code) {
         DiscordVerificationCode discordVerificationCode =

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
@@ -45,4 +45,15 @@ public class OnboardingDiscordService {
                 .orElseThrow();
     }
 
+    public void verifyDiscordCode(String discordUsername, String code) {
+        DiscordVerificationCode discordVerificationCode =
+                discordVerificationCodeRepository.findById(discordUsername).orElseThrow();
+
+        // TODO: 4자리 숫자의 문자열로 비교
+        if (!discordVerificationCode.getCode().toString().equals(code)) {
+            // TODO: throw exception
+        }
+
+        discordVerificationCodeRepository.delete(discordVerificationCode);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
@@ -1,0 +1,48 @@
+package com.gdschongik.gdsc.domain.discord.application;
+
+import static com.gdschongik.gdsc.domain.discord.domain.DiscordVerificationCode.*;
+
+import com.gdschongik.gdsc.domain.discord.dao.DiscordVerificationCodeRepository;
+import com.gdschongik.gdsc.domain.discord.domain.DiscordVerificationCode;
+import com.gdschongik.gdsc.domain.discord.dto.response.DiscordVerificationCodeResponse;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.global.util.MemberUtil;
+import java.security.SecureRandom;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OnboardingDiscordService {
+
+    public static final long DISCORD_CODE_TTL_SECONDS = 300L;
+
+    private final MemberUtil memberUtil;
+    private final DiscordVerificationCodeRepository discordVerificationCodeRepository;
+
+    @Transactional
+    public DiscordVerificationCodeResponse createVerificationCode() {
+        Member member = memberUtil.getCurrentMember();
+
+        String discordUsername = member.getDiscordUsername();
+        Long code = generateRandomCode();
+        DiscordVerificationCode discordVerificationCode =
+                DiscordVerificationCode.create(discordUsername, code, DISCORD_CODE_TTL_SECONDS);
+
+        discordVerificationCodeRepository.save(discordVerificationCode);
+
+        return DiscordVerificationCodeResponse.of(code);
+    }
+
+    @SneakyThrows
+    private static Long generateRandomCode() {
+        return SecureRandom.getInstanceStrong()
+                .longs(MIN_CODE_RANGE, MAX_CODE_RANGE + 1)
+                .findFirst()
+                .orElseThrow();
+    }
+
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
@@ -5,7 +5,6 @@ import static com.gdschongik.gdsc.domain.discord.domain.DiscordVerificationCode.
 import com.gdschongik.gdsc.domain.discord.dao.DiscordVerificationCodeRepository;
 import com.gdschongik.gdsc.domain.discord.domain.DiscordVerificationCode;
 import com.gdschongik.gdsc.domain.discord.dto.response.DiscordVerificationCodeResponse;
-import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.security.SecureRandom;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
@@ -19,7 +18,6 @@ public class OnboardingDiscordService {
 
     public static final long DISCORD_CODE_TTL_SECONDS = 300L;
 
-    private final MemberUtil memberUtil;
     private final DiscordVerificationCodeRepository discordVerificationCodeRepository;
 
     @Transactional

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
@@ -35,7 +35,7 @@ public class OnboardingDiscordService {
     @SneakyThrows
     private static Long generateRandomCode() {
         return SecureRandom.getInstanceStrong()
-                .longs(MIN_CODE_RANGE, MAX_CODE_RANGE + 1)
+                .longs(MIN_CODE_RANGE, MAX_CODE_RANGE + 1L)
                 .findFirst()
                 .orElseThrow();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
@@ -40,6 +40,8 @@ public class OnboardingDiscordService {
                 .orElseThrow();
     }
 
+
+    // TODO: 디스코드 연동하기 피쳐에서 구현
     public void verifyDiscordCode(String discordUsername, String code) {
         DiscordVerificationCode discordVerificationCode =
                 discordVerificationCodeRepository.findById(discordUsername).orElseThrow();

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/dao/DiscordVerificationCodeRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/dao/DiscordVerificationCodeRepository.java
@@ -1,0 +1,6 @@
+package com.gdschongik.gdsc.domain.discord.dao;
+
+import com.gdschongik.gdsc.domain.discord.domain.DiscordVerificationCode;
+import org.springframework.data.repository.CrudRepository;
+
+public interface DiscordVerificationCodeRepository extends CrudRepository<DiscordVerificationCode, String> {}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/domain/DiscordVerificationCode.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/domain/DiscordVerificationCode.java
@@ -1,0 +1,47 @@
+package com.gdschongik.gdsc.domain.discord.domain;
+
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.exception.ErrorCode;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@RedisHash("discordVerificationCode")
+public class DiscordVerificationCode {
+
+    public static final int MIN_CODE_RANGE = 1000;
+    public static final int MAX_CODE_RANGE = 9999;
+
+    @Id
+    private String discordUsername;
+
+    private Long code;
+
+    @TimeToLive
+    private Long ttl;
+
+    @Builder
+    private DiscordVerificationCode(String discordUsername, Long code, Long ttl) {
+        validateCodeRange(code);
+        this.discordUsername = discordUsername;
+        this.code = code;
+        this.ttl = ttl;
+    }
+
+    private static void validateCodeRange(Long code) {
+        if (code < MIN_CODE_RANGE || code > MAX_CODE_RANGE) {
+            throw new CustomException(ErrorCode.DISCORD_INVALID_CODE_RANGE);
+        }
+    }
+
+    public static DiscordVerificationCode create(String discordUsername, Long code, Long ttl) {
+        return DiscordVerificationCode.builder()
+                .discordUsername(discordUsername)
+                .code(code)
+                .ttl(ttl)
+                .build();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/dto/response/DiscordVerificationCodeResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/dto/response/DiscordVerificationCodeResponse.java
@@ -1,0 +1,8 @@
+package com.gdschongik.gdsc.domain.discord.dto.response;
+
+public record DiscordVerificationCodeResponse(Long code) {
+
+    public static DiscordVerificationCodeResponse of(Long code) {
+        return new DiscordVerificationCodeResponse(code);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/dto/response/DiscordVerificationCodeResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/dto/response/DiscordVerificationCodeResponse.java
@@ -1,8 +1,10 @@
 package com.gdschongik.gdsc.domain.discord.dto.response;
 
-public record DiscordVerificationCodeResponse(Long code) {
+import java.time.Duration;
 
-    public static DiscordVerificationCodeResponse of(Long code) {
-        return new DiscordVerificationCodeResponse(code);
+public record DiscordVerificationCodeResponse(Long code, Duration ttl) {
+
+    public static DiscordVerificationCodeResponse of(Long code, Long ttlSeconds) {
+        return new DiscordVerificationCodeResponse(code, Duration.ofSeconds(ttlSeconds));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/dto/response/LinkDiscordResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/dto/response/LinkDiscordResponse.java
@@ -1,0 +1,3 @@
+package com.gdschongik.gdsc.domain.discord.dto.response;
+
+public record LinkDiscordResponse() {}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/listener/RegisterCommandListener.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/listener/RegisterCommandListener.java
@@ -1,0 +1,46 @@
+package com.gdschongik.gdsc.domain.discord.listener;
+
+import com.gdschongik.gdsc.domain.discord.application.OnboardingDiscordService;
+import com.gdschongik.gdsc.global.discord.Listener;
+import jakarta.annotation.Nonnull;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.components.ActionRow;
+import net.dv8tion.jda.api.interactions.components.text.TextInput;
+import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
+import net.dv8tion.jda.api.interactions.modals.Modal;
+
+@Listener
+@RequiredArgsConstructor
+public class RegisterCommandListener extends ListenerAdapter {
+
+    private final OnboardingDiscordService onboardingDiscordService;
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        if (event.getName().equals("register")) {
+            TextInput input = TextInput.create("code", "인증코드를 입력해주세요.", TextInputStyle.SHORT)
+                    .setPlaceholder("발급받은 4자리 인증코드")
+                    .setMinLength(4)
+                    .setMaxLength(4)
+                    .build();
+
+            Modal modal = Modal.create("registerModal", "디스코드 연동 인증코드 입력")
+                    .addComponents(ActionRow.of(input))
+                    .build();
+
+            event.replyModal(modal).queue();
+        }
+    }
+
+    @Override
+    public void onModalInteraction(@Nonnull ModalInteractionEvent event) {
+        if (event.getModalId().equals("registerModal")) {
+            String code = Objects.requireNonNull(event.getValue("code")).getAsString();
+            onboardingDiscordService.verifyDiscordCode(event.getUser().getName(), code);
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/listener/RegisterCommandListener.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/listener/RegisterCommandListener.java
@@ -1,17 +1,14 @@
 package com.gdschongik.gdsc.domain.discord.listener;
 
+import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.*;
+
 import com.gdschongik.gdsc.domain.discord.application.OnboardingDiscordService;
+import com.gdschongik.gdsc.domain.discord.dto.response.DiscordVerificationCodeResponse;
 import com.gdschongik.gdsc.global.discord.Listener;
-import jakarta.annotation.Nonnull;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.dv8tion.jda.api.interactions.components.ActionRow;
-import net.dv8tion.jda.api.interactions.components.text.TextInput;
-import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
-import net.dv8tion.jda.api.interactions.modals.Modal;
+import org.jetbrains.annotations.NotNull;
 
 @Listener
 @RequiredArgsConstructor
@@ -20,27 +17,23 @@ public class RegisterCommandListener extends ListenerAdapter {
     private final OnboardingDiscordService onboardingDiscordService;
 
     @Override
-    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
-        if (event.getName().equals("register")) {
-            TextInput input = TextInput.create("code", "인증코드를 입력해주세요.", TextInputStyle.SHORT)
-                    .setPlaceholder("발급받은 4자리 인증코드")
-                    .setMinLength(4)
-                    .setMaxLength(4)
-                    .build();
+    public void onSlashCommandInteraction(@NotNull SlashCommandInteractionEvent event) {
+        if (event.getName().equals(COMMAND_NAME_ISSUING_CODE)) {
+            event.deferReply()
+                    .setEphemeral(true)
+                    .setContent(DEFER_MESSAGE_ISSUING_CODE)
+                    .queue();
 
-            Modal modal = Modal.create("registerModal", "디스코드 연동 인증코드 입력")
-                    .addComponents(ActionRow.of(input))
-                    .build();
+            String discordUsername = event.getUser().getName();
+            DiscordVerificationCodeResponse verificationCode =
+                    onboardingDiscordService.createVerificationCode(discordUsername);
 
-            event.replyModal(modal).queue();
-        }
-    }
+            String message = String.format(
+                    REPLY_MESSAGE_ISSUING_CODE,
+                    verificationCode.code(),
+                    verificationCode.ttl().toMinutes());
 
-    @Override
-    public void onModalInteraction(@Nonnull ModalInteractionEvent event) {
-        if (event.getModalId().equals("registerModal")) {
-            String code = Objects.requireNonNull(event.getValue("code")).getAsString();
-            onboardingDiscordService.verifyDiscordCode(event.getUser().getName(), code);
+            event.getHook().sendMessage(message).setEphemeral(true).queue();
         }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/DiscordConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/DiscordConstant.java
@@ -1,0 +1,11 @@
+package com.gdschongik.gdsc.global.common.constant;
+
+public class DiscordConstant {
+
+    private DiscordConstant() {}
+
+    public static final String COMMAND_NAME_ISSUING_CODE = "인증코드";
+    public static final String COMMAND_DESCRIPTION_ISSUING_CODE = "디스코드 연동을 위한 인증코드를 발급받습니다.";
+    public static final String DEFER_MESSAGE_ISSUING_CODE = "인증코드를 발급받는 중입니다...";
+    public static final String REPLY_MESSAGE_ISSUING_CODE = "인증코드는 %d 입니다. 인증코드는 %d분 동안 유효합니다.";
+}

--- a/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
@@ -1,11 +1,16 @@
 package com.gdschongik.gdsc.global.config;
 
+import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.*;
+
 import com.gdschongik.gdsc.global.discord.ListenerBeanPostProcessor;
 import com.gdschongik.gdsc.global.property.DiscordProperty;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.entities.Activity;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.utils.MemberCachePolicy;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -20,13 +25,22 @@ public class DiscordConfig {
     private final DiscordProperty discordProperty;
 
     @Bean
+    @SneakyThrows
     @ConditionalOnProperty(value = "discord.enabled", havingValue = "true", matchIfMissing = true)
     public JDA jda() {
-        return JDABuilder.createDefault(discordProperty.getToken())
+        JDA jda = JDABuilder.createDefault(discordProperty.getToken())
                 .setActivity(Activity.playing("테스트"))
                 .enableIntents(GatewayIntent.GUILD_MESSAGES, GatewayIntent.MESSAGE_CONTENT, GatewayIntent.GUILD_MEMBERS)
                 .setMemberCachePolicy(MemberCachePolicy.ALL)
                 .build();
+
+        // TODO: ready 후 리스너 빈이 초기화되면 이벤트 수신 불가하므로, @PostConstruct로 ReadyListener 사용할 수 있도록 변경
+        Objects.requireNonNull(jda.awaitReady().getGuildById(discordProperty.getServerId()))
+                .updateCommands()
+                .addCommands(Commands.slash(COMMAND_NAME_ISSUING_CODE, COMMAND_DESCRIPTION_ISSUING_CODE))
+                .queue();
+
+        return jda;
     }
 
     @Bean

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -29,7 +29,7 @@ public enum ErrorCode {
     // Requirement
     UNIV_NOT_VERIFIED(HttpStatus.CONFLICT, "재학생 인증이 되지 않았습니다."),
 
-    // Discord
+    // Discord (Always 500)
     DISCORD_INVALID_CODE_RANGE(HttpStatus.INTERNAL_SERVER_ERROR, "디스코드 인증코드는 4자리 숫자여야 합니다."),
     ;
 

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -27,7 +27,11 @@ public enum ErrorCode {
     INVALID_QUERY_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 쿼리 파라미터입니다."),
 
     // Requirement
-    UNIV_NOT_VERIFIED(HttpStatus.CONFLICT, "재학생 인증이 되지 않았습니다.");
+    UNIV_NOT_VERIFIED(HttpStatus.CONFLICT, "재학생 인증이 되지 않았습니다."),
+
+    // Discord
+    DISCORD_INVALID_CODE_RANGE(HttpStatus.INTERNAL_SERVER_ERROR, "디스코드 인증코드는 4자리 숫자여야 합니다."),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/gdschongik/gdsc/global/property/DiscordProperty.java
+++ b/src/main/java/com/gdschongik/gdsc/global/property/DiscordProperty.java
@@ -10,4 +10,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class DiscordProperty {
 
     private final String token;
+    private final String serverId;
 }

--- a/src/main/resources/application-discord.yml
+++ b/src/main/resources/application-discord.yml
@@ -1,2 +1,3 @@
 discord:
   token: ${DISCORD_BOT_TOKEN:}
+  server-id: ${DISCORD_SERVER_ID:}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #48

## 📌 작업 내용 및 특이사항
- 디스코드 인증코드 발급 기능을 구현했습니다.
    - `/인증코드` 커맨드를 서버에 추가합니다. jda 구성 시 수행됩니다. 
    - `/인증코드` 로 커맨드를 실행합니다. 
        - 이때 비즈니스 로직 처리를 위해 `deferReply` 를 사용합니다.
        - 해당 기능은 `인증코드를 발급받는 중입니다...` 와 같이 로딩 메세지를 출력하여 최종 응답을 지연시킵니다.
        - `setEphemeral(true)` 를 통해 자신에게만 메세지가 보이도록 설정합니다.
    - 4자리로 된 랜덤 코드를 발급합니다. 이때 보안을 위해 `SecureRandom` 으로 발급합니다. 
    - 커맨드를 실행한 유저 정보로부터 디스코드 유저네임(핸들명)을 받아옵니다.
    - 유저네임을 키로, 랜덤코드를 값으로 하여 레디스에 저장합니다. ttl은 5분으로 설정합니다.
    - `getHook().sendMessage()`로 지연된 요청에 대하여 응답을 보냅니다.
        - `setEphemeral(true)` 를 통해 자신에게만 메세지가 보이도록 설정합니다.

## 📝 참고사항
- 디스코드 전용 상수 클래스를 추가하여, 1) 커맨드 이름 2) 커맨드 설명 3) 디스코드 클라이언트에 출력될 메세지 등을 해당 클래스에서 관리하도록 했습니다.

## 📚 기타
- 디스코드 커맨드 전용 채널이 필요합니다.
- 커맨드 외 일반 메세지를 보낼 경우 자동으로 삭제 처리하는 기능이 필요합니다.
- 테스트 디스코드 서버와 실제 디스코드 서버 간 환경을 맞춰줘야 합니다. (특히 채널이름, 역할 정책 관련)
