### PR TITLE
refactor: 탈퇴 회원을 조회 api에서 제외

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.member.dao;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -14,4 +15,6 @@ public interface MemberCustomRepository {
     Optional<Member> findVerifiedById(Long id);
 
     Page<Member> findAllGrantable(Pageable pageable);
+
+    Page<Member> findAllByRole(MemberRole role, Pageable pageable);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -27,7 +27,7 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
     public Page<Member> findAll(MemberQueryRequest queryRequest, Pageable pageable) {
         List<Member> fetch = queryFactory
                 .selectFrom(member)
-                .where(queryOption(queryRequest))
+                .where(queryOption(queryRequest), eqStatus(MemberStatus.NORMAL))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -71,6 +71,21 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
         return PageableExecutionUtils.getPage(fetch, pageable, countQuery::fetchOne);
     }
 
+    @Override
+    public Page<Member> findAllByRole(MemberRole role, Pageable pageable) {
+        List<Member> fetch = queryFactory
+                .selectFrom(member)
+                .where(eqRole(role), eqStatus(MemberStatus.NORMAL))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery =
+                queryFactory.select(member.count()).from(member).where(eqRole(role), eqStatus(MemberStatus.NORMAL));
+
+        return PageableExecutionUtils.getPage(fetch, pageable, countQuery::fetchOne);
+    }
+
     private BooleanExpression eqRole(MemberRole role) {
         return member.role.eq(role);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
@@ -3,7 +3,4 @@ package com.gdschongik.gdsc.domain.member.dao;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
-
-    Page<Member> findAllByRole(MemberRole role, Pageable pageable);
-}
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
@@ -1,9 +1,6 @@
 package com.gdschongik.gdsc.domain.member.dao;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.member.domain.MemberRole;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #81 

## 📌 작업 내용 및 특이사항
- 쿼리에 eqStatus를 추가했습니다.
- 대기중인 멤버 조회 기능의 repository 메서드는 querydsl로 변경했습니다.

## 📝 참고사항
-

## 📚 기타
-
