### PR TITLE
feat: 회비 미납 회원 목록 조회 api 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
@@ -72,4 +72,11 @@ public class AdminMemberController {
         Page<MemberFindAllResponse> response = adminMemberService.getGrantableMembers(pageable);
         return ResponseEntity.ok().body(response);
     }
+
+    @Operation(summary = "회비 미납 회원 전체 조회", description = "회비 미납 상태인 회원 전체를 조회합니다.")
+    @GetMapping("/unpaid")
+    public ResponseEntity<Page<MemberFindAllResponse>> getUnpaidMembers(Pageable pageable) {
+        Page<MemberFindAllResponse> response = adminMemberService.getUnpaidMembers(pageable);
+        return ResponseEntity.ok().body(response);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.member.api;
 
 import com.gdschongik.gdsc.domain.member.application.AdminMemberService;
+import com.gdschongik.gdsc.domain.member.domain.RequirementStatus;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberGrantRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberUpdateRequest;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Admin Member", description = "어드민 회원 관리 API입니다.")
@@ -74,9 +76,10 @@ public class AdminMemberController {
     }
 
     @Operation(summary = "회비 미납 회원 전체 조회", description = "회비 미납 상태인 회원 전체를 조회합니다.")
-    @GetMapping("/unpaid")
-    public ResponseEntity<Page<MemberFindAllResponse>> getUnpaidMembers(Pageable pageable) {
-        Page<MemberFindAllResponse> response = adminMemberService.getUnpaidMembers(pageable);
+    @GetMapping("/payment")
+    public ResponseEntity<Page<MemberFindAllResponse>> getMembersByPaymentStatus(
+            @RequestParam(name = "status") RequirementStatus paymentStatus, Pageable pageable) {
+        Page<MemberFindAllResponse> response = adminMemberService.getMembersByPaymentStatus(paymentStatus, pageable);
         return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -5,6 +5,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.domain.member.domain.RequirementStatus;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberGrantRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberUpdateRequest;
@@ -79,8 +80,8 @@ public class AdminMemberService {
         return members.map(MemberFindAllResponse::of);
     }
 
-    public Page<MemberFindAllResponse> getUnpaidMembers(Pageable pageable) {
-        Page<Member> members = memberRepository.findAllUnpaid(pageable);
+    public Page<MemberFindAllResponse> getMembersByPaymentStatus(RequirementStatus paymentStatus, Pageable pageable) {
+        Page<Member> members = memberRepository.findAllByPaymentStatus(paymentStatus, pageable);
         return members.map(MemberFindAllResponse::of);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -78,4 +78,9 @@ public class AdminMemberService {
         Page<Member> members = memberRepository.findAllGrantable(pageable);
         return members.map(MemberFindAllResponse::of);
     }
+
+    public Page<MemberFindAllResponse> getUnpaidMembers(Pageable pageable) {
+        Page<Member> members = memberRepository.findAllUnpaid(pageable);
+        return members.map(MemberFindAllResponse::of);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.domain.member.dao;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.domain.member.domain.RequirementStatus;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -18,5 +19,5 @@ public interface MemberCustomRepository {
 
     Page<Member> findAllByRole(MemberRole role, Pageable pageable);
 
-    Page<Member> findAllUnpaid(Pageable pageable);
+    Page<Member> findAllByPaymentStatus(RequirementStatus paymentStatus, Pageable pageable);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
@@ -17,4 +17,6 @@ public interface MemberCustomRepository {
     Page<Member> findAllGrantable(Pageable pageable);
 
     Page<Member> findAllByRole(MemberRole role, Pageable pageable);
+
+    Page<Member> findAllUnpaid(Pageable pageable);
 }

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
 
     // Requirement
     UNIV_NOT_VERIFIED(HttpStatus.CONFLICT, "재학생 인증이 되지 않았습니다."),
+    REQUIREMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 가입조건이 없습니다."),
 
     // Discord (Always 500)
     DISCORD_INVALID_CODE_RANGE(HttpStatus.INTERNAL_SERVER_ERROR, "디스코드 인증코드는 4자리 숫자여야 합니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #78

## 📌 작업 내용 및 특이사항
- 회비 미납 회원 조회 api를 구현했습니다.
- 기존에 RepositoryImpl에서 사용하던 `paymentVerified`메서드를 `eqPaymentStatus`로 수정하여 재활용 가능하도록 했습니다.

## 📝 참고사항
-

## 📚 기타
-
