### PR TITLE
fix: 로컬 스웨거가 작동하지 않는 문제 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/global/annotation/ConditionalOnProfile.java
+++ b/src/main/java/com/gdschongik/gdsc/global/annotation/ConditionalOnProfile.java
@@ -1,0 +1,15 @@
+package com.gdschongik.gdsc.global.annotation;
+
+import com.gdschongik.gdsc.global.common.constant.EnvironmentConstant;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.context.annotation.Conditional;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Conditional({OnProfileCondition.class})
+public @interface ConditionalOnProfile {
+    EnvironmentConstant[] value() default {EnvironmentConstant.LOCAL};
+}

--- a/src/main/java/com/gdschongik/gdsc/global/annotation/OnProfileCondition.java
+++ b/src/main/java/com/gdschongik/gdsc/global/annotation/OnProfileCondition.java
@@ -1,0 +1,29 @@
+package com.gdschongik.gdsc.global.annotation;
+
+import static java.util.Objects.*;
+
+import com.gdschongik.gdsc.global.common.constant.EnvironmentConstant;
+import java.util.Arrays;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+public class OnProfileCondition implements Condition {
+
+    @Override
+    public boolean matches(ConditionContext context, @NotNull AnnotatedTypeMetadata metadata) {
+        String[] activeProfiles = context.getEnvironment().getActiveProfiles();
+        EnvironmentConstant[] targetProfiles = getTargetProfiles(metadata);
+
+        return Arrays.stream(targetProfiles)
+                .anyMatch(targetProfile -> Arrays.asList(activeProfiles).contains(targetProfile.getValue()));
+    }
+
+    private EnvironmentConstant[] getTargetProfiles(AnnotatedTypeMetadata metadata) {
+        Map<String, Object> attributes =
+                requireNonNull(metadata.getAnnotationAttributes(ConditionalOnProfile.class.getName()));
+        return (EnvironmentConstant[]) attributes.get("value");
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/EnvironmentConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/EnvironmentConstant.java
@@ -1,13 +1,27 @@
 package com.gdschongik.gdsc.global.common.constant;
 
+import static com.gdschongik.gdsc.global.common.constant.EnvironmentConstant.Constants.*;
+
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-public class EnvironmentConstant {
+@Getter
+@AllArgsConstructor
+public enum EnvironmentConstant {
+    PROD(PROD_ENV),
+    DEV(DEV_ENV),
+    LOCAL(LOCAL_ENV);
 
-    private EnvironmentConstant() {}
+    private final String value;
 
-    public static final String PROD = "prod";
-    public static final String DEV = "dev";
-    public static final String LOCAL = "local";
-    public static final List<String> PROD_AND_DEV = List.of(PROD, DEV);
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Constants {
+        public static final String PROD_ENV = "prod";
+        public static final String DEV_ENV = "dev";
+        public static final String LOCAL_ENV = "local";
+        public static final List<String> PROD_AND_DEV_ENV = List.of(PROD_ENV, DEV_ENV);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/SwaggerUrlConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/SwaggerUrlConstant.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.global.common.constant;
 
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,4 +13,10 @@ public enum SwaggerUrlConstant {
     ;
 
     private final String value;
+
+    public static String[] getSwaggerUrls() {
+        return Arrays.stream(SwaggerUrlConstant.values())
+                .map(SwaggerUrlConstant::getValue)
+                .toArray(String[]::new);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/config/SwaggerConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/SwaggerConfig.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.global.config;
 
-import static com.gdschongik.gdsc.global.common.constant.EnvironmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.EnvironmentConstant.Constants.*;
 import static com.gdschongik.gdsc.global.common.constant.UrlConstant.*;
 import static org.springframework.http.HttpHeaders.*;
 
@@ -36,8 +36,8 @@ public class SwaggerConfig {
 
     private String getServerUrl() {
         return switch (environmentUtil.getCurrentProfile()) {
-            case PROD -> PROD_SERVER_URL;
-            case DEV -> DEV_SERVER_URL;
+            case PROD_ENV -> PROD_SERVER_URL;
+            case DEV_ENV -> DEV_SERVER_URL;
             default -> LOCAL_SERVER_URL;
         };
     }

--- a/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.global.config;
 
+import static com.gdschongik.gdsc.global.common.constant.EnvironmentConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.UrlConstant.*;
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.security.config.Customizer.*;
@@ -7,6 +8,7 @@ import static org.springframework.security.config.Customizer.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gdschongik.gdsc.domain.auth.application.JwtService;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
+import com.gdschongik.gdsc.global.annotation.ConditionalOnProfile;
 import com.gdschongik.gdsc.global.common.constant.SwaggerUrlConstant;
 import com.gdschongik.gdsc.global.property.SwaggerProperty;
 import com.gdschongik.gdsc.global.security.CustomSuccessHandler;
@@ -17,7 +19,6 @@ import com.gdschongik.gdsc.global.util.CookieUtil;
 import com.gdschongik.gdsc.global.util.EnvironmentUtil;
 import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -59,7 +60,7 @@ public class WebSecurityConfig {
 
     @Bean
     @Order(1)
-    @ConditionalOnProperty(name = "spring.profiles.active", havingValue = "dev")
+    @ConditionalOnProfile({DEV, LOCAL})
     public SecurityFilterChain swaggerFilterChain(HttpSecurity http) throws Exception {
         defaultFilterChain(http);
 

--- a/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
@@ -66,8 +66,12 @@ public class WebSecurityConfig {
 
         http.securityMatcher(getSwaggerUrls())
                 .oauth2Login(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
                 .httpBasic(withDefaults());
+
+        http.authorizeHttpRequests(
+                environmentUtil.isDevProfile()
+                        ? authorize -> authorize.anyRequest().authenticated()
+                        : authorize -> authorize.anyRequest().permitAll());
 
         return http.build();
     }

--- a/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.global.config;
 
 import static com.gdschongik.gdsc.global.common.constant.EnvironmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.SwaggerUrlConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.UrlConstant.*;
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.security.config.Customizer.*;
@@ -9,7 +10,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gdschongik.gdsc.domain.auth.application.JwtService;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.global.annotation.ConditionalOnProfile;
-import com.gdschongik.gdsc.global.common.constant.SwaggerUrlConstant;
 import com.gdschongik.gdsc.global.property.SwaggerProperty;
 import com.gdschongik.gdsc.global.security.CustomSuccessHandler;
 import com.gdschongik.gdsc.global.security.CustomUserService;
@@ -17,7 +17,6 @@ import com.gdschongik.gdsc.global.security.JwtExceptionFilter;
 import com.gdschongik.gdsc.global.security.JwtFilter;
 import com.gdschongik.gdsc.global.util.CookieUtil;
 import com.gdschongik.gdsc.global.util.EnvironmentUtil;
-import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -104,12 +103,6 @@ public class WebSecurityConfig {
                 .authenticated());
 
         return http.build();
-    }
-
-    private static String[] getSwaggerUrls() {
-        return Arrays.stream(SwaggerUrlConstant.values())
-                .map(SwaggerUrlConstant::getValue)
-                .toArray(String[]::new);
     }
 
     @Bean

--- a/src/main/java/com/gdschongik/gdsc/global/util/EnvironmentUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/EnvironmentUtil.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.global.util;
 
-import static com.gdschongik.gdsc.global.common.constant.EnvironmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.EnvironmentConstant.Constants.*;
 
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -15,21 +15,21 @@ public class EnvironmentUtil {
 
     public String getCurrentProfile() {
         return getActiveProfiles()
-                .filter(profile -> profile.equals(PROD) || profile.equals(DEV))
+                .filter(profile -> profile.equals(PROD_ENV) || profile.equals(DEV_ENV))
                 .findFirst()
-                .orElse(LOCAL);
+                .orElse(LOCAL_ENV);
     }
 
     public boolean isProdProfile() {
-        return getActiveProfiles().anyMatch(PROD::equals);
+        return getActiveProfiles().anyMatch(PROD_ENV::equals);
     }
 
     public boolean isDevProfile() {
-        return getActiveProfiles().anyMatch(DEV::equals);
+        return getActiveProfiles().anyMatch(DEV_ENV::equals);
     }
 
     public boolean isProdAndDevProfile() {
-        return getActiveProfiles().anyMatch(PROD_AND_DEV::contains);
+        return getActiveProfiles().anyMatch(PROD_AND_DEV_ENV::contains);
     }
 
     private Stream<String> getActiveProfiles() {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #94

## 📌 작업 내용 및 특이사항
- 문제 원인
    - `@ConditionalOnProperty(name = "spring.profiles.active", havingValue = "dev") ` 에서 local인 경우에는 필터체인을 타지 않아 발생하는 문제. local인 경우에도 스웨거 필터체인 빈이 로드되도록 해야 함
- 프로파일에 따라 빈 등록 여부를 결정할 수 있는 `@ConditionalOnProfile` 구현
    - `@ConditionalOnProfile({DEV, LOCAL})` 와 같이 dev, local 환경인 경우 로드되도록 함
    - 인자로 `EnvironmentConstants` enum 상수 배열을 전달할 수 있음.
    - 해당 상수가 가지고 있는 환경변수 리터럴 값과 / 현재 실행 환경변수 값이 일치하는 경우 애플리케이션 컨텍스트에 로드함
- `EnvironmentConstants` 를 enum 클래스로 리팩토링
    - 단 기존 상수 리터럴도 사용할 수 있도록 inner static class로 정의함. 이때 초기화 막기 위해 private 기본 생성자 정의.

## 📝 참고사항
-

## 📚 기타
-
