### PR TITLE
refactor: 회비 납부 정보를 전체, 미납, 납부로 나누어 볼 수 있도록 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
@@ -7,6 +7,7 @@ import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberUpdateRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberFindAllResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberGrantResponse;
+import com.gdschongik.gdsc.domain.member.dto.response.MemberPaymentFindAllResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberPendingFindAllResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -75,11 +76,12 @@ public class AdminMemberController {
         return ResponseEntity.ok().body(response);
     }
 
-    @Operation(summary = "회비 미납 회원 전체 조회", description = "회비 미납 상태인 회원 전체를 조회합니다.")
+    @Operation(summary = "회원 회비 납부 정보 전체 조회", description = "회원 회비 납부 정보 전체를 조회합니다.")
     @GetMapping("/payment")
-    public ResponseEntity<Page<MemberFindAllResponse>> getMembersByPaymentStatus(
-            @RequestParam(name = "status") RequirementStatus paymentStatus, Pageable pageable) {
-        Page<MemberFindAllResponse> response = adminMemberService.getMembersByPaymentStatus(paymentStatus, pageable);
+    public ResponseEntity<Page<MemberPaymentFindAllResponse>> getMembersByPaymentStatus(
+            @RequestParam(name = "status", required = false) RequirementStatus paymentStatus, Pageable pageable) {
+        Page<MemberPaymentFindAllResponse> response =
+                adminMemberService.getMembersByPaymentStatus(paymentStatus, pageable);
         return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
@@ -76,7 +76,7 @@ public class AdminMemberController {
         return ResponseEntity.ok().body(response);
     }
 
-    @Operation(summary = "회원 회비 납부 정보 전체 조회", description = "회원 회비 납부 정보 전체를 조회합니다.")
+    @Operation(summary = "회비 납부 상태에 따른 회원 전체 조회", description = "회비 납부 상태에 따라 회원 목록을 조회합니다.")
     @GetMapping("/payment")
     public ResponseEntity<Page<MemberPaymentFindAllResponse>> getMembersByPaymentStatus(
             @RequestParam(name = "status", required = false) RequirementStatus paymentStatus, Pageable pageable) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -11,6 +11,7 @@ import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberUpdateRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberFindAllResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberGrantResponse;
+import com.gdschongik.gdsc.domain.member.dto.response.MemberPaymentFindAllResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberPendingFindAllResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
@@ -80,8 +81,9 @@ public class AdminMemberService {
         return members.map(MemberFindAllResponse::of);
     }
 
-    public Page<MemberFindAllResponse> getMembersByPaymentStatus(RequirementStatus paymentStatus, Pageable pageable) {
+    public Page<MemberPaymentFindAllResponse> getMembersByPaymentStatus(
+            RequirementStatus paymentStatus, Pageable pageable) {
         Page<Member> members = memberRepository.findAllByPaymentStatus(paymentStatus, pageable);
-        return members.map(MemberFindAllResponse::of);
+        return members.map(MemberPaymentFindAllResponse::from);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -126,7 +126,7 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
 
     private BooleanExpression eqRequirementStatus(
             EnumPath<RequirementStatus> requirement, RequirementStatus requirementStatus) {
-        return requirement.eq(requirementStatus);
+        return requirementStatus != null ? requirement.eq(requirementStatus) : null;
     }
 
     private BooleanExpression eqId(Long id) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberPaymentFindAllResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberPaymentFindAllResponse.java
@@ -1,0 +1,24 @@
+package com.gdschongik.gdsc.domain.member.dto.response;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.RequirementStatus;
+
+public record MemberPaymentFindAllResponse(
+        Long memberId,
+        String studentId,
+        String name,
+        String phone,
+        String discordUsername,
+        String nickname,
+        RequirementStatus paymentStatus) {
+    public static MemberPaymentFindAllResponse from(Member member) {
+        return new MemberPaymentFindAllResponse(
+                member.getId(),
+                member.getStudentId(),
+                member.getName(),
+                member.getPhone(),
+                member.getDiscordUsername(),
+                member.getNickname(),
+                member.getRequirement().getPaymentStatus());
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #96

## 📌 작업 내용 및 특이사항
- status 쿼리 파라미터를 이용해 회비 납부 정보를 납부 상태에 따라 분리해서 볼 수 있도록 변경했습니다.

## 📝 참고사항
-

## 📚 기타
-
