### PR TITLE
feat: 디스코드 연동하기 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/api/OnboardingDiscordController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/api/OnboardingDiscordController.java
@@ -1,11 +1,13 @@
 package com.gdschongik.gdsc.domain.discord.api;
 
 import com.gdschongik.gdsc.domain.discord.application.OnboardingDiscordService;
-import com.gdschongik.gdsc.domain.discord.dto.response.LinkDiscordResponse;
+import com.gdschongik.gdsc.domain.discord.dto.request.DiscordLinkRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,9 +20,9 @@ public class OnboardingDiscordController {
     private final OnboardingDiscordService onboardingDiscordService;
 
     @Operation(summary = "디스코드 연동하기", description = "디스코드 봇으로 발급받은 인증코드와 현재 사용자의 디스코드 계정을 연동합니다.")
-    @RequestMapping("/link-discord")
-    public ResponseEntity<LinkDiscordResponse> linkDiscord() {
-        // TODO: 디스코드 연동하기
-        return ResponseEntity.ok(new LinkDiscordResponse());
+    @PostMapping("/link-discord")
+    public ResponseEntity<Void> linkDiscord(@Valid DiscordLinkRequest request) {
+        onboardingDiscordService.verifyDiscordCode(request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/api/OnboardingDiscordController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/api/OnboardingDiscordController.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,7 +22,7 @@ public class OnboardingDiscordController {
 
     @Operation(summary = "디스코드 연동하기", description = "디스코드 봇으로 발급받은 인증코드와 현재 사용자의 디스코드 계정을 연동합니다.")
     @PostMapping("/link-discord")
-    public ResponseEntity<Void> linkDiscord(@Valid DiscordLinkRequest request) {
+    public ResponseEntity<Void> linkDiscord(@Valid @RequestBody DiscordLinkRequest request) {
         onboardingDiscordService.verifyDiscordCode(request);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
@@ -29,7 +29,7 @@ public class OnboardingDiscordService {
     @Transactional
     public DiscordVerificationCodeResponse createVerificationCode(String discordUsername) {
 
-        Long code = generateRandomCode();
+        Integer code = generateRandomCode();
         DiscordVerificationCode discordVerificationCode =
                 DiscordVerificationCode.create(discordUsername, code, DISCORD_CODE_TTL_SECONDS);
 
@@ -39,9 +39,9 @@ public class OnboardingDiscordService {
     }
 
     @SneakyThrows
-    private static Long generateRandomCode() {
+    private static Integer generateRandomCode() {
         return SecureRandom.getInstanceStrong()
-                .longs(MIN_CODE_RANGE, MAX_CODE_RANGE + 1L)
+                .ints(MIN_CODE_RANGE, MAX_CODE_RANGE + 1)
                 .findFirst()
                 .orElseThrow();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
@@ -78,7 +78,7 @@ public class OnboardingDiscordService {
 
     private void validateDiscordCodeMatches(
             DiscordLinkRequest request, DiscordVerificationCode discordVerificationCode) {
-        if (!Objects.equals(discordVerificationCode.getCode(), request.code())) {
+        if (!discordVerificationCode.matchesCode(request.code())) {
             throw new CustomException(ErrorCode.DISCORD_CODE_MISMATCH);
         }
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
@@ -11,6 +11,7 @@ import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.security.SecureRandom;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.stereotype.Service;
@@ -62,7 +63,7 @@ public class OnboardingDiscordService {
 
     private void validateDiscordCodeMatches(
             DiscordLinkRequest request, DiscordVerificationCode discordVerificationCode) {
-        if (!discordVerificationCode.getCode().equals(request.code())) {
+        if (!Objects.equals(discordVerificationCode.getCode(), request.code())) {
             throw new CustomException(ErrorCode.DISCORD_CODE_MISMATCH);
         }
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.discord.application;
 
 import static com.gdschongik.gdsc.domain.discord.domain.DiscordVerificationCode.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.discord.dao.DiscordVerificationCodeRepository;
 import com.gdschongik.gdsc.domain.discord.domain.DiscordVerificationCode;
@@ -9,7 +10,6 @@ import com.gdschongik.gdsc.domain.discord.dto.response.DiscordVerificationCodeRe
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.security.SecureRandom;
 import lombok.RequiredArgsConstructor;
@@ -52,7 +52,7 @@ public class OnboardingDiscordService {
     public void verifyDiscordCode(DiscordLinkRequest request) {
         DiscordVerificationCode discordVerificationCode = discordVerificationCodeRepository
                 .findById(request.discordUsername())
-                .orElseThrow(() -> new CustomException(ErrorCode.DISCORD_CODE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(DISCORD_CODE_NOT_FOUND));
 
         validateDiscordCodeMatches(request, discordVerificationCode);
         validateDiscordUsernameDuplicate(request.discordUsername());
@@ -66,20 +66,20 @@ public class OnboardingDiscordService {
 
     private void validateDiscordUsernameDuplicate(String discordUsername) {
         if (memberRepository.existsByDiscordUsername(discordUsername)) {
-            throw new CustomException(ErrorCode.MEMBER_DISCORD_USERNAME_DUPLICATE);
+            throw new CustomException(MEMBER_DISCORD_USERNAME_DUPLICATE);
         }
     }
 
     private void validateNicknameDuplicate(String nickname) {
         if (memberRepository.existsByNickname(nickname)) {
-            throw new CustomException(ErrorCode.MEMBER_NICKNAME_DUPLICATE);
+            throw new CustomException(MEMBER_NICKNAME_DUPLICATE);
         }
     }
 
     private void validateDiscordCodeMatches(
             DiscordLinkRequest request, DiscordVerificationCode discordVerificationCode) {
         if (!discordVerificationCode.matchesCode(request.code())) {
-            throw new CustomException(ErrorCode.DISCORD_CODE_MISMATCH);
+            throw new CustomException(DISCORD_CODE_MISMATCH);
         }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
@@ -57,7 +57,7 @@ public class OnboardingDiscordService {
         discordVerificationCodeRepository.delete(discordVerificationCode);
 
         final Member currentMember = memberUtil.getCurrentMember();
-        currentMember.verifyDiscord(request.discordUsername(), request.discordUsername());
+        currentMember.verifyDiscord(request.discordUsername(), request.nickname());
     }
 
     private void validateDiscordCodeMatches(

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/domain/DiscordVerificationCode.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/domain/DiscordVerificationCode.java
@@ -44,4 +44,8 @@ public class DiscordVerificationCode {
                 .ttl(ttl)
                 .build();
     }
+
+    public boolean matchesCode(Integer code) {
+        return this.code.equals(code);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/domain/DiscordVerificationCode.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/domain/DiscordVerificationCode.java
@@ -18,26 +18,26 @@ public class DiscordVerificationCode {
     @Id
     private String discordUsername;
 
-    private Long code;
+    private Integer code;
 
     @TimeToLive
     private Long ttl;
 
     @Builder
-    private DiscordVerificationCode(String discordUsername, Long code, Long ttl) {
+    private DiscordVerificationCode(String discordUsername, Integer code, Long ttl) {
         validateCodeRange(code);
         this.discordUsername = discordUsername;
         this.code = code;
         this.ttl = ttl;
     }
 
-    private static void validateCodeRange(Long code) {
+    private static void validateCodeRange(Integer code) {
         if (code < MIN_CODE_RANGE || code > MAX_CODE_RANGE) {
             throw new CustomException(ErrorCode.DISCORD_INVALID_CODE_RANGE);
         }
     }
 
-    public static DiscordVerificationCode create(String discordUsername, Long code, Long ttl) {
+    public static DiscordVerificationCode create(String discordUsername, Integer code, Long ttl) {
         return DiscordVerificationCode.builder()
                 .discordUsername(discordUsername)
                 .code(code)

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/dto/request/DiscordLinkRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/dto/request/DiscordLinkRequest.java
@@ -1,0 +1,12 @@
+package com.gdschongik.gdsc.domain.discord.dto.request;
+
+import static com.gdschongik.gdsc.domain.discord.domain.DiscordVerificationCode.*;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public record DiscordLinkRequest(
+        @NotBlank @Schema(description = "디스코드 유저네임") String discordUsername,
+        @Min(MIN_CODE_RANGE) @Max(MAX_CODE_RANGE) @Schema(description = "디스코드 인증코드") Integer code) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/dto/request/DiscordLinkRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/dto/request/DiscordLinkRequest.java
@@ -1,12 +1,18 @@
 package com.gdschongik.gdsc.domain.discord.dto.request;
 
 import static com.gdschongik.gdsc.domain.discord.domain.DiscordVerificationCode.*;
+import static com.gdschongik.gdsc.global.common.constant.RegexConstant.*;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public record DiscordLinkRequest(
         @NotBlank @Schema(description = "디스코드 유저네임") String discordUsername,
+        @NotBlank
+                @Pattern(regexp = NICKNAME, message = "닉네임은 " + NICKNAME + " 형식이어야 합니다.")
+                @Schema(description = "커뮤니티 닉네임", pattern = NICKNAME)
+                String nickname,
         @Min(MIN_CODE_RANGE) @Max(MAX_CODE_RANGE) @Schema(description = "디스코드 인증코드") Integer code) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/dto/request/DiscordLinkRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/dto/request/DiscordLinkRequest.java
@@ -4,10 +4,9 @@ import static com.gdschongik.gdsc.domain.discord.domain.DiscordVerificationCode.
 import static com.gdschongik.gdsc.global.common.constant.RegexConstant.*;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import org.hibernate.validator.constraints.Range;
 
 public record DiscordLinkRequest(
         @NotBlank @Schema(description = "디스코드 유저네임") String discordUsername,
@@ -15,4 +14,4 @@ public record DiscordLinkRequest(
                 @Pattern(regexp = NICKNAME, message = "닉네임은 " + NICKNAME + " 형식이어야 합니다.")
                 @Schema(description = "커뮤니티 닉네임", pattern = NICKNAME)
                 String nickname,
-        @Min(MIN_CODE_RANGE) @Max(MAX_CODE_RANGE) @Schema(description = "디스코드 인증코드") Integer code) {}
+        @Range(min = MIN_CODE_RANGE, max = MAX_CODE_RANGE) @Schema(description = "디스코드 인증코드") Integer code) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/dto/response/DiscordVerificationCodeResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/dto/response/DiscordVerificationCodeResponse.java
@@ -2,9 +2,9 @@ package com.gdschongik.gdsc.domain.discord.dto.response;
 
 import java.time.Duration;
 
-public record DiscordVerificationCodeResponse(Long code, Duration ttl) {
+public record DiscordVerificationCodeResponse(Integer code, Duration ttl) {
 
-    public static DiscordVerificationCodeResponse of(Long code, Long ttlSeconds) {
+    public static DiscordVerificationCodeResponse of(Integer code, Long ttlSeconds) {
         return new DiscordVerificationCodeResponse(code, Duration.ofSeconds(ttlSeconds));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/dto/response/LinkDiscordResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/dto/response/LinkDiscordResponse.java
@@ -1,3 +1,0 @@
-package com.gdschongik.gdsc.domain.discord.dto.response;
-
-public record LinkDiscordResponse() {}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
@@ -32,6 +32,7 @@ public class OnboardingMemberController {
         return ResponseEntity.ok().build();
     }
 
+    @Deprecated
     @Operation(summary = "디스코드 회원 정보 수정", description = "디스코드 회원 정보를 수정합니다.")
     @PutMapping("/me/discord")
     public ResponseEntity<Void> updateMember(@Valid @RequestBody OnboardingMemberUpdateRequest request) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -89,6 +89,6 @@ public class AdminMemberService {
     @Transactional
     public void verifyPayment(Long memberId, MemberPaymentRequest request) {
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
-        member.verifyPayment(request.status());
+        member.updatePaymentStatus(request.status());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
@@ -1,10 +1,13 @@
 package com.gdschongik.gdsc.domain.member.application;
 
+import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberSignupRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.OnboardingMemberUpdateRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberInfoResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberUnivStatusResponse;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class OnboardingMemberService {
 
     private final MemberUtil memberUtil;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public void signupMember(MemberSignupRequest request) {
@@ -27,7 +31,14 @@ public class OnboardingMemberService {
     @Transactional
     public void updateMember(OnboardingMemberUpdateRequest request) {
         Member currentMember = memberUtil.getCurrentMember();
+        validateDiscordUsernameDuplicate(currentMember);
         currentMember.updateDiscordInfo(request.discordUsername(), request.nickname());
+    }
+
+    private void validateDiscordUsernameDuplicate(Member member) {
+        if (memberRepository.existsByDiscordUsername(member.getDiscordUsername())) {
+            throw new CustomException(ErrorCode.MEMBER_DISCORD_USERNAME_DUPLICATE);
+        }
     }
 
     public MemberInfoResponse getMemberInfo() {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
@@ -28,11 +28,12 @@ public class OnboardingMemberService {
                 request.studentId(), request.name(), request.phone(), request.department(), request.email());
     }
 
+    @Deprecated
     @Transactional
     public void updateMember(OnboardingMemberUpdateRequest request) {
         Member currentMember = memberUtil.getCurrentMember();
         validateDiscordUsernameDuplicate(currentMember);
-        currentMember.updateDiscordInfo(request.discordUsername(), request.nickname());
+        currentMember.verifyDiscord(request.discordUsername(), request.nickname());
     }
 
     private void validateDiscordUsernameDuplicate(Member member) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
     boolean existsByDiscordUsername(String discordUsername);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
@@ -3,4 +3,6 @@ package com.gdschongik.gdsc.domain.member.dao;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {}
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
+    boolean existsByDiscordUsername(String discordUsername);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -174,8 +174,8 @@ public class Member extends BaseTimeEntity {
         return this.requirement.getUnivStatus();
     }
 
-    public void verifyPayment(RequirementStatus status) {
+    public void updatePaymentStatus(RequirementStatus status) {
         validateStatusUpdatable();
-        this.requirement.verifyPayment(status);
+        this.requirement.updatePaymentStatus(status);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -162,9 +162,10 @@ public class Member extends BaseTimeEntity {
         this.role = MemberRole.USER;
     }
 
-    public void updateDiscordInfo(String discordUsername, String nickname) {
+    public void verifyDiscord(String discordUsername, String nickname) {
         validateStatusUpdatable();
 
+        this.requirement.verifyDiscord();
         this.discordUsername = discordUsername;
         this.nickname = nickname;
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Requirement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Requirement.java
@@ -43,4 +43,8 @@ public class Requirement {
     public boolean isUnivPending() {
         return this.univStatus == PENDING;
     }
+
+    public void verifyDiscord() {
+        this.discordStatus = VERIFIED;
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Requirement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Requirement.java
@@ -44,7 +44,7 @@ public class Requirement {
         return this.univStatus == PENDING;
     }
 
-    public void verifyPayment(RequirementStatus status) {
+    public void updatePaymentStatus(RequirementStatus status) {
         this.paymentStatus = status;
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberQueryRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberQueryRequest.java
@@ -10,5 +10,5 @@ public record MemberQueryRequest(
         @Schema(description = "전화번호", pattern = PHONE) String phone,
         @Schema(description = "학과") String department,
         @Schema(description = "이메일") String email,
-        @Schema(description = "discord username") String discordUsername,
+        @Schema(description = "디스코드 유저네임") String discordUsername,
         @Schema(description = "커뮤니티 닉네임", pattern = NICKNAME) String nickname) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberUpdateRequest.java
@@ -19,7 +19,7 @@ public record MemberUpdateRequest(
                 String phone,
         @NotBlank @Schema(description = "학과") String department,
         @NotBlank @Email @Schema(description = "이메일") String email,
-        @NotBlank @Schema(description = "discord username") String discordUsername,
+        @NotBlank @Schema(description = "디스코드 유저네임") String discordUsername,
         @NotBlank
                 @Pattern(regexp = NICKNAME, message = "닉네임은 " + NICKNAME + " 형식이어야 합니다.")
                 @Schema(description = "커뮤니티 닉네임", pattern = NICKNAME)

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/OnboardingMemberUpdateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/OnboardingMemberUpdateRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record OnboardingMemberUpdateRequest(
-        @NotBlank @Schema(description = "discord username") String discordUsername,
+        @NotBlank @Schema(description = "디스코드 유저네임") String discordUsername,
         @NotBlank
                 @Pattern(regexp = NICKNAME, message = "닉네임은 " + NICKNAME + " 형식이어야 합니다.")
                 @Schema(description = "커뮤니티 닉네임", pattern = NICKNAME)

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
     MEMBER_DELETED(HttpStatus.CONFLICT, "탈퇴한 회원입니다."),
     MEMBER_FORBIDDEN(HttpStatus.CONFLICT, "차단된 회원입니다."),
+    MEMBER_DISCORD_USERNAME_DUPLICATE(HttpStatus.CONFLICT, "이미 등록된 디스코드 유저네임입니다."),
 
     // Parameter
     INVALID_QUERY_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 쿼리 파라미터입니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
     MEMBER_DELETED(HttpStatus.CONFLICT, "탈퇴한 회원입니다."),
     MEMBER_FORBIDDEN(HttpStatus.CONFLICT, "차단된 회원입니다."),
+    MEMBER_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 인증된 상태입니다."),
     MEMBER_DISCORD_USERNAME_DUPLICATE(HttpStatus.CONFLICT, "이미 등록된 디스코드 유저네임입니다."),
 
     // Parameter
@@ -31,8 +32,10 @@ public enum ErrorCode {
     UNIV_NOT_VERIFIED(HttpStatus.CONFLICT, "재학생 인증이 되지 않았습니다."),
     REQUIREMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 가입조건이 없습니다."),
 
-    // Discord (Always 500)
+    // Discord
     DISCORD_INVALID_CODE_RANGE(HttpStatus.INTERNAL_SERVER_ERROR, "디스코드 인증코드는 4자리 숫자여야 합니다."),
+    DISCORD_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저네임으로 발급된 디스코드 인증코드가 존재하지 않습니다."),
+    DISCORD_CODE_MISMATCH(HttpStatus.CONFLICT, "디스코드 인증코드가 일치하지 않습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     MEMBER_FORBIDDEN(HttpStatus.CONFLICT, "차단된 회원입니다."),
     MEMBER_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 인증된 상태입니다."),
     MEMBER_DISCORD_USERNAME_DUPLICATE(HttpStatus.CONFLICT, "이미 등록된 디스코드 유저네임입니다."),
+    MEMBER_NICKNAME_DUPLICATE(HttpStatus.CONFLICT, "이미 사용중인 닉네임입니다."),
 
     // Parameter
     INVALID_QUERY_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 쿼리 파라미터입니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #90

## 📌 작업 내용 및 특이사항
- 인증코드 4자리, 닉네임, 디스코드 유저네임을 받아서 디스코드 연동을 수행합니다. 인증번호가 일치하는 경우 닉네임과 디스코드 유저네임을 해당 멤버 정보에 업데이트해주고, 연동상태를 `VERIFIED` 로 변경합니다.
- 인증코드의 타입을 `Long` 에서 `Integer` 로 변경했습니다.
- `verifyPayment` 메서드를 `updatePaymentStatus` 로 이름을 변경했습니다.

## 📝 참고사항
-

## 📚 기타
-
