### PR TITLE
refactor: 회원 승인 응답에 이름을 담도록 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -63,17 +63,24 @@ public class AdminMemberService {
 
     @Transactional
     public MemberGrantResponse grantMember(MemberGrantRequest request) {
-        List<Member> verifiedMembers = getVerifiedMembers(request);
+        List<Member> verifiedMembers = getVerifiedMembers(request.memberIdList());
+        List<Member> notVerifiedMembers = getNotVerifiedMembers(request.memberIdList(), verifiedMembers);
         verifiedMembers.forEach(Member::grant);
-        return MemberGrantResponse.of(verifiedMembers);
+        return MemberGrantResponse.of(verifiedMembers, notVerifiedMembers);
     }
 
-    private List<Member> getVerifiedMembers(MemberGrantRequest request) {
-        List<Long> memberIdList = request.memberIdList();
+    private List<Member> getVerifiedMembers(List<Long> memberIdList) {
         return memberIdList.stream()
                 .map(memberRepository::findVerifiedById)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
+                .toList();
+    }
+
+    private List<Member> getNotVerifiedMembers(List<Long> memberIdList, List<Member> verifiedMembers) {
+        List<Member> members = memberRepository.findAllById(memberIdList);
+        return members.stream()
+                .filter(member -> !verifiedMembers.contains(member))
                 .toList();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
@@ -3,7 +3,10 @@ package com.gdschongik.gdsc.domain.member.dao;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import com.gdschongik.gdsc.domain.member.domain.RequirementStatus;
+import com.gdschongik.gdsc.domain.member.dto.request.MemberGrantRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,11 +16,11 @@ public interface MemberCustomRepository {
 
     Optional<Member> findNormalByOauthId(String oauthId);
 
-    Optional<Member> findVerifiedById(Long id);
-
     Page<Member> findAllGrantable(Pageable pageable);
 
     Page<Member> findAllByRole(MemberRole role, Pageable pageable);
 
     Page<Member> findAllByPaymentStatus(RequirementStatus paymentStatus, Pageable pageable);
+
+    Map<Boolean, List<Member>> groupByVerified(MemberGrantRequest memberIdList);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -110,11 +110,10 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
 
     @Override
     public Map<Boolean, List<Member>> groupByVerified(MemberGrantRequest request) {
-        Map<Boolean, List<Member>> transform = queryFactory
+        return queryFactory
                 .selectFrom(member)
                 .where(member.id.in(request.memberIdList()))
                 .transform(groupBy(requirementVerified()).as(list(member)));
-        return transform;
     }
 
     private BooleanExpression eqRole(MemberRole role) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberGrantResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberGrantResponse.java
@@ -4,10 +4,14 @@ import com.gdschongik.gdsc.domain.member.domain.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-public record MemberGrantResponse(@Schema(description = "승인에 성공한 멤버 ID 리스트") List<Long> grantedMembers) {
-    public static MemberGrantResponse of(List<Member> grantedMembers) {
-        List<Long> grantedMemberIdList =
-                grantedMembers.stream().map(Member::getId).toList();
-        return new MemberGrantResponse(grantedMemberIdList);
+public record MemberGrantResponse(
+        @Schema(description = "승인에 성공한 멤버 이름 리스트") List<String> grantedMembers,
+        @Schema(description = "승인에 실패한 멤버 이름 리스트") List<String> notGrantedMembers) {
+    public static MemberGrantResponse of(List<Member> grantedMembers, List<Member> notGrantedMembers) {
+        List<String> grantedMemberIdList =
+                grantedMembers.stream().map(Member::getName).toList();
+        List<String> notGrantedMemberIdList =
+                notGrantedMembers.stream().map(Member::getName).toList();
+        return new MemberGrantResponse(grantedMemberIdList, notGrantedMemberIdList);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberGrantResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberGrantResponse.java
@@ -3,15 +3,16 @@ package com.gdschongik.gdsc.domain.member.dto.response;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import java.util.Map;
 
 public record MemberGrantResponse(
         @Schema(description = "승인에 성공한 멤버 이름 리스트") List<String> grantedMembers,
         @Schema(description = "승인에 실패한 멤버 이름 리스트") List<String> notGrantedMembers) {
-    public static MemberGrantResponse of(List<Member> grantedMembers, List<Member> notGrantedMembers) {
+    public static MemberGrantResponse from(Map<Boolean, List<Member>> grantResult) {
         List<String> grantedMemberIdList =
-                grantedMembers.stream().map(Member::getName).toList();
+                grantResult.get(true).stream().map(Member::getName).toList();
         List<String> notGrantedMemberIdList =
-                notGrantedMembers.stream().map(Member::getName).toList();
+                grantResult.get(false).stream().map(Member::getName).toList();
         return new MemberGrantResponse(grantedMemberIdList, notGrantedMemberIdList);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/config/QuerydslConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/QuerydslConfig.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.global.config;
 
+import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -13,6 +14,6 @@ public class QuerydslConfig {
 
     @Bean
     public JPAQueryFactory jpaQueryFactory() {
-        return new JPAQueryFactory(entityManager);
+        return new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #105

## 📌 작업 내용 및 특이사항
- 프론트의 요청에 따라 승인된 멤버와 승인되지 않은 멤버를 모두 응답에 담도록 수정했습니다.
- pk보다 직관적인 name을 담도록 수정했습니다.

## 📝 참고사항
-

## 📚 기타
-
