### PR TITLE
fix: 승인 과정에서 발생하는 npe 처리

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -3,6 +3,8 @@ name: Build and Deploy to Develop
 on:
   push:
     branches: [ "develop" ]
+  pull_request: 
+    branches: [ "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -3,8 +3,6 @@ name: Build and Deploy to Develop
 on:
   push:
     branches: [ "develop" ]
-  pull_request:
-    branches: [ "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -3,7 +3,7 @@ name: Build and Deploy to Develop
 on:
   push:
     branches: [ "develop" ]
-  pull_request: 
+  pull_request:
     branches: [ "develop" ]
 
 jobs:

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -63,7 +63,7 @@ public class AdminMemberService {
 
     @Transactional
     public MemberGrantResponse grantMember(MemberGrantRequest request) {
-        Map<Boolean, List<Member>> classifiedMember = memberRepository.groupByVerified(request);
+        Map<Boolean, List<Member>> classifiedMember = memberRepository.groupByVerified(request.memberIdList());
         List<Member> verifiedMembers = classifiedMember.get(true);
         verifiedMembers.forEach(Member::grant);
         return MemberGrantResponse.from(classifiedMember);

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
@@ -3,7 +3,6 @@ package com.gdschongik.gdsc.domain.member.dao;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import com.gdschongik.gdsc.domain.member.domain.RequirementStatus;
-import com.gdschongik.gdsc.domain.member.dto.request.MemberGrantRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
 import java.util.List;
 import java.util.Map;
@@ -22,5 +21,5 @@ public interface MemberCustomRepository {
 
     Page<Member> findAllByPaymentStatus(RequirementStatus paymentStatus, Pageable pageable);
 
-    Map<Boolean, List<Member>> groupByVerified(MemberGrantRequest memberIdList);
+    Map<Boolean, List<Member>> groupByVerified(List<Long> memberIdList);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -116,6 +116,10 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
                 .where(member.id.in(memberIdList))
                 .transform(groupBy(requirementVerified()).as(list(member)));
 
+        return ensureNonNull(groupByVerified);
+    }
+
+    private Map<Boolean, List<Member>> ensureNonNull(Map<Boolean, List<Member>> groupByVerified) {
         Map<Boolean, List<Member>> classifiedMember = new HashMap<>();
         List<Member> emptyList = new ArrayList<>();
         classifiedMember.put(true, groupByVerified.getOrDefault(true, emptyList));

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -15,6 +15,8 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.EnumPath;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -110,10 +112,15 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
 
     @Override
     public Map<Boolean, List<Member>> groupByVerified(MemberGrantRequest request) {
-        return queryFactory
+        Map<Boolean, List<Member>> groupByVerified = queryFactory
                 .selectFrom(member)
                 .where(member.id.in(request.memberIdList()))
                 .transform(groupBy(requirementVerified()).as(list(member)));
+
+        Map<Boolean, List<Member>> classifiedMember = new HashMap<>();
+        classifiedMember.put(true, groupByVerified.getOrDefault(true, new ArrayList<>()));
+        classifiedMember.put(false, groupByVerified.getOrDefault(false, new ArrayList<>()));
+        return classifiedMember;
     }
 
     private BooleanExpression eqRole(MemberRole role) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -116,10 +116,10 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
                 .where(member.id.in(memberIdList))
                 .transform(groupBy(requirementVerified()).as(list(member)));
 
-        return ensureNonNull(groupByVerified);
+        return replaceNullByEmptyList(groupByVerified);
     }
 
-    private Map<Boolean, List<Member>> ensureNonNull(Map<Boolean, List<Member>> groupByVerified) {
+    private Map<Boolean, List<Member>> replaceNullByEmptyList(Map<Boolean, List<Member>> groupByVerified) {
         Map<Boolean, List<Member>> classifiedMember = new HashMap<>();
         List<Member> emptyList = new ArrayList<>();
         classifiedMember.put(true, groupByVerified.getOrDefault(true, emptyList));

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -8,7 +8,6 @@ import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import com.gdschongik.gdsc.domain.member.domain.MemberStatus;
 import com.gdschongik.gdsc.domain.member.domain.RequirementStatus;
-import com.gdschongik.gdsc.domain.member.dto.request.MemberGrantRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -111,10 +110,10 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
     }
 
     @Override
-    public Map<Boolean, List<Member>> groupByVerified(MemberGrantRequest request) {
+    public Map<Boolean, List<Member>> groupByVerified(List<Long> memberIdList) {
         Map<Boolean, List<Member>> groupByVerified = queryFactory
                 .selectFrom(member)
-                .where(member.id.in(request.memberIdList()))
+                .where(member.id.in(memberIdList))
                 .transform(groupBy(requirementVerified()).as(list(member)));
 
         Map<Boolean, List<Member>> classifiedMember = new HashMap<>();

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -118,8 +118,9 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
                 .transform(groupBy(requirementVerified()).as(list(member)));
 
         Map<Boolean, List<Member>> classifiedMember = new HashMap<>();
-        classifiedMember.put(true, groupByVerified.getOrDefault(true, new ArrayList<>()));
-        classifiedMember.put(false, groupByVerified.getOrDefault(false, new ArrayList<>()));
+        List<Member> emptyList = new ArrayList<>();
+        classifiedMember.put(true, groupByVerified.getOrDefault(true, emptyList));
+        classifiedMember.put(false, groupByVerified.getOrDefault(false, emptyList));
         return classifiedMember;
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #107

## 📌 작업 내용 및 특이사항
- querydsl의 transform에서는 해당하는 원소가 없으면 빈 리스트가 아니라 null을 반환하기 때문에 발생하는 NPE가 있음을 확인하고 수정했습니다.

## 📝 참고사항
-

## 📚 기타
-
