### PR TITLE
feat: 디스코드 가입하기 핸들러에 서버 닉네임 업데이트 로직 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
@@ -6,6 +6,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.discord.dao.DiscordVerificationCodeRepository;
 import com.gdschongik.gdsc.domain.discord.domain.DiscordVerificationCode;
 import com.gdschongik.gdsc.domain.discord.dto.request.DiscordLinkRequest;
+import com.gdschongik.gdsc.domain.discord.dto.response.DiscordNicknameResponse;
 import com.gdschongik.gdsc.domain.discord.dto.response.DiscordVerificationCodeResponse;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
@@ -83,7 +84,7 @@ public class OnboardingDiscordService {
         }
     }
 
-    public void checkDiscordRoleAssignable(String discordUsername) {
+    public DiscordNicknameResponse checkDiscordRoleAssignable(String discordUsername) {
         Member member = memberRepository
                 .findByDiscordUsername(discordUsername)
                 .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
@@ -91,5 +92,7 @@ public class OnboardingDiscordService {
         if (!member.isGranted()) {
             throw new CustomException(DISCORD_ROLE_UNASSIGNABLE);
         }
+
+        return DiscordNicknameResponse.of(member.getNickname());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/dto/response/DiscordNicknameResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/dto/response/DiscordNicknameResponse.java
@@ -1,0 +1,8 @@
+package com.gdschongik.gdsc.domain.discord.dto.response;
+
+public record DiscordNicknameResponse(String nickname) {
+
+    public static DiscordNicknameResponse of(String nickname) {
+        return new DiscordNicknameResponse(nickname);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/handler/JoinCommandHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/handler/JoinCommandHandler.java
@@ -35,6 +35,7 @@ public class JoinCommandHandler implements DiscordEventHandler {
         Guild guild = Objects.requireNonNull(event.getGuild());
 
         guild.addRoleToMember(member, role).queue();
+        guild.modifyNickname(member, response.nickname()).queue();
 
         event.getHook().sendMessage(REPLY_MESSAGE_JOIN).setEphemeral(true).queue();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/handler/JoinCommandHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/handler/JoinCommandHandler.java
@@ -8,8 +8,8 @@ import com.gdschongik.gdsc.global.util.DiscordUtil;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.GenericEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import org.springframework.stereotype.Component;
@@ -30,11 +30,11 @@ public class JoinCommandHandler implements DiscordEventHandler {
         String discordUsername = event.getUser().getName();
         DiscordNicknameResponse response = onboardingDiscordService.checkDiscordRoleAssignable(discordUsername);
 
-        User user = event.getUser();
+        Member member = event.getMember();
         Role role = discordUtil.findRoleByName(MEMBER_ROLE_NAME);
         Guild guild = Objects.requireNonNull(event.getGuild());
 
-        guild.addRoleToMember(user, role).queue();
+        guild.addRoleToMember(member, role).queue();
 
         event.getHook().sendMessage(REPLY_MESSAGE_JOIN).setEphemeral(true).queue();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/handler/JoinCommandHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/handler/JoinCommandHandler.java
@@ -3,6 +3,7 @@ package com.gdschongik.gdsc.domain.discord.handler;
 import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.*;
 
 import com.gdschongik.gdsc.domain.discord.application.OnboardingDiscordService;
+import com.gdschongik.gdsc.domain.discord.dto.response.DiscordNicknameResponse;
 import com.gdschongik.gdsc.global.util.DiscordUtil;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +28,7 @@ public class JoinCommandHandler implements DiscordEventHandler {
         event.deferReply().setEphemeral(true).setContent(DEFER_MESSAGE_JOIN).queue();
 
         String discordUsername = event.getUser().getName();
-        onboardingDiscordService.checkDiscordRoleAssignable(discordUsername);
+        DiscordNicknameResponse response = onboardingDiscordService.checkDiscordRoleAssignable(discordUsername);
 
         User user = event.getUser();
         Role role = discordUtil.findRoleByName(MEMBER_ROLE_NAME);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #118 

## 📌 작업 내용 및 특이사항
- 역할 할당 가능한지 체크하는 서비스 메서드가 디스코드 닉네임 응답 DTO를 변환하도록 변경했습니다.

## 📝 참고사항
-

## 📚 기타
-
