### PR TITLE
feat: 디스코드 서버 닉네임 변경 시 자동으로 원복하는 기능 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/CommonDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/CommonDiscordService.java
@@ -1,0 +1,24 @@
+package com.gdschongik.gdsc.domain.discord.application;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommonDiscordService {
+
+    private final MemberRepository memberRepository;
+
+    public String getNicknameByDiscordUsername(String discordUsername) {
+        Member member = memberRepository
+                .findByDiscordUsername(discordUsername)
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+        return member.getNickname();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/CommonDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/CommonDiscordService.java
@@ -1,10 +1,7 @@
 package com.gdschongik.gdsc.domain.discord.application;
 
-import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
-
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,10 +12,9 @@ public class CommonDiscordService {
     private final MemberRepository memberRepository;
 
     public String getNicknameByDiscordUsername(String discordUsername) {
-        Member member = memberRepository
+        return memberRepository
                 .findByDiscordUsername(discordUsername)
-                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
-
-        return member.getNickname();
+                .map(Member::getNickname)
+                .orElse(null);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/handler/NicknameModifyHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/handler/NicknameModifyHandler.java
@@ -25,8 +25,17 @@ public class NicknameModifyHandler implements DiscordEventHandler {
         String discordUsername = member.getUser().getName();
 
         String originalNickname = commonDiscordService.getNicknameByDiscordUsername(discordUsername);
+        String newNickname = event.getNewNickname();
 
         if (originalNickname == null) {
+            return;
+        }
+
+        if (newNickname == null) {
+            return;
+        }
+
+        if (newNickname.equals(originalNickname)) {
             return;
         }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/handler/NicknameModifyHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/handler/NicknameModifyHandler.java
@@ -1,0 +1,31 @@
+package com.gdschongik.gdsc.domain.discord.handler;
+
+import com.gdschongik.gdsc.domain.discord.application.CommonDiscordService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.events.GenericEvent;
+import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateNicknameEvent;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NicknameModifyHandler implements DiscordEventHandler {
+
+    private final CommonDiscordService commonDiscordService;
+
+    @Override
+    public void delegate(GenericEvent genericEvent) {
+        GuildMemberUpdateNicknameEvent event = (GuildMemberUpdateNicknameEvent) genericEvent;
+
+        Member member = event.getMember();
+        Guild guild = event.getGuild();
+        String discordUsername = member.getUser().getName();
+
+        String originalNickname = commonDiscordService.getNicknameByDiscordUsername(discordUsername);
+
+        guild.modifyNickname(member, originalNickname).queue();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/handler/NicknameModifyHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/handler/NicknameModifyHandler.java
@@ -1,6 +1,8 @@
 package com.gdschongik.gdsc.domain.discord.handler;
 
 import com.gdschongik.gdsc.domain.discord.application.CommonDiscordService;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.entities.Guild;
@@ -27,8 +29,12 @@ public class NicknameModifyHandler implements DiscordEventHandler {
         String originalNickname = commonDiscordService.getNicknameByDiscordUsername(discordUsername);
         String newNickname = event.getNewNickname();
 
-        if (originalNickname == null || newNickname == null) {
-            return;
+        if (originalNickname == null) {
+            throw new CustomException(ErrorCode.DISCORD_NOT_SIGNUP);
+        }
+
+        if (newNickname == null) {
+            throw new CustomException(ErrorCode.DISCORD_NICKNAME_NOTNULL);
         }
 
         if (newNickname.equals(originalNickname)) {

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/handler/NicknameModifyHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/handler/NicknameModifyHandler.java
@@ -27,11 +27,7 @@ public class NicknameModifyHandler implements DiscordEventHandler {
         String originalNickname = commonDiscordService.getNicknameByDiscordUsername(discordUsername);
         String newNickname = event.getNewNickname();
 
-        if (originalNickname == null) {
-            return;
-        }
-
-        if (newNickname == null) {
+        if (originalNickname == null || newNickname == null) {
             return;
         }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/handler/NicknameModifyHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/handler/NicknameModifyHandler.java
@@ -26,6 +26,10 @@ public class NicknameModifyHandler implements DiscordEventHandler {
 
         String originalNickname = commonDiscordService.getNicknameByDiscordUsername(discordUsername);
 
+        if (originalNickname == null) {
+            return;
+        }
+
         guild.modifyNickname(member, originalNickname).queue();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.domain.member.domain;
 
+import static com.gdschongik.gdsc.domain.member.domain.MemberRole.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.model.BaseTimeEntity;
@@ -234,7 +235,7 @@ public class Member extends BaseTimeEntity {
     // 데이터 전달 로직
 
     public boolean isGranted() {
-        return role.equals(MemberRole.USER);
+        return role.equals(USER) || role.equals(MemberRole.ADMIN);
     }
 
     public boolean isGrantAvailable() {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -212,25 +212,6 @@ public class Member extends BaseTimeEntity {
         requirement.updateUnivStatus(RequirementStatus.VERIFIED);
     }
 
-    //    private void validateStatusUpdatable() {
-    //        if (isDeleted()) {
-    //            throw new CustomException(MEMBER_DELETED);
-    //        }
-    //        if (isForbidden()) {
-    //            throw new CustomException(MEMBER_FORBIDDEN);
-    //        }
-    //    }
-
-    //    private void validateUnivStatus() {
-    //        if (this.requirement.isUnivPending()) {
-    //            throw new CustomException(UNIV_NOT_VERIFIED);
-    //        }
-    //    }
-
-    //    public void grant() {
-    //        this.role = MemberRole.USER;
-    //    }
-
     // 가입조건 인증 로직
     public void verifyDiscord(String discordUsername, String nickname) {
         validateStatusUpdatable();

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -173,7 +173,7 @@ public class Member extends BaseTimeEntity {
         validateStatusUpdatable();
         validateGrantAvailable();
 
-        this.role = MemberRole.USER;
+        this.role = USER;
     }
 
     /**

--- a/src/main/java/com/gdschongik/gdsc/global/discord/exception/DiscordEventHandlerAspect.java
+++ b/src/main/java/com/gdschongik/gdsc/global/discord/exception/DiscordEventHandlerAspect.java
@@ -1,4 +1,4 @@
-package com.gdschongik.gdsc.global.discord;
+package com.gdschongik.gdsc.global.discord.exception;
 
 import com.gdschongik.gdsc.global.exception.CustomException;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/gdschongik/gdsc/global/discord/exception/DiscordEventHandlerAspect.java
+++ b/src/main/java/com/gdschongik/gdsc/global/discord/exception/DiscordEventHandlerAspect.java
@@ -1,36 +1,28 @@
 package com.gdschongik.gdsc.global.discord.exception;
 
-import com.gdschongik.gdsc.global.exception.CustomException;
-import lombok.extern.slf4j.Slf4j;
+import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.events.GenericEvent;
-import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionEvent;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Aspect
 @Component
+@RequiredArgsConstructor
 public class DiscordEventHandlerAspect {
+
+    private final DiscordExceptionDispatcher discordExceptionDispatcher;
 
     @Around(
             "execution(* com.gdschongik.gdsc.domain.discord.handler.DiscordEventHandler.delegate(*)) && args(genericEvent)")
     public Object doAround(ProceedingJoinPoint joinPoint, GenericEvent genericEvent) throws Throwable {
         // TODO: 외부 의존성인 디스코드 클래스에 대한 어댑터 추가
-        // TODO: 이벤트 객체를 인자로 받는 디스코드 에러 핸들러 추가
 
         try {
             return joinPoint.proceed();
-        } catch (CustomException e) {
-            log.error("DiscordException: {}", e.getMessage());
-            GenericCommandInteractionEvent event = (GenericCommandInteractionEvent) genericEvent;
-            event.getHook().sendMessage(e.getMessage()).setEphemeral(true).queue();
-            return null;
         } catch (Exception e) {
-            log.error("Exception: {}", e.getMessage());
-            GenericCommandInteractionEvent event = (GenericCommandInteractionEvent) genericEvent;
-            event.getHook().sendMessage("알 수 없는 오류가 발생했습니다.").setEphemeral(true).queue();
+            discordExceptionDispatcher.dispatch(e, genericEvent);
             return null;
         }
     }

--- a/src/main/java/com/gdschongik/gdsc/global/discord/exception/DiscordExceptionDispatcher.java
+++ b/src/main/java/com/gdschongik/gdsc/global/discord/exception/DiscordExceptionDispatcher.java
@@ -1,0 +1,29 @@
+package com.gdschongik.gdsc.global.discord.exception;
+
+import com.gdschongik.gdsc.global.discord.exception.handler.CommandExceptionHandler;
+import com.gdschongik.gdsc.global.discord.exception.handler.DefaultExceptionHandler;
+import com.gdschongik.gdsc.global.discord.exception.handler.DiscordExceptionHandler;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.events.GenericEvent;
+import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionEvent;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DiscordExceptionDispatcher {
+
+    private static final Map<Class<? extends GenericEvent>, DiscordExceptionHandler> exceptionHandlerMap =
+            Map.of(GenericCommandInteractionEvent.class, new CommandExceptionHandler());
+
+    private static final DefaultExceptionHandler defaultExceptionHandler = new DefaultExceptionHandler();
+
+    public void dispatch(Exception exception, Object context) {
+        log.error("DiscordException: {}", exception.getMessage());
+        DiscordExceptionHandler exceptionHandler =
+                exceptionHandlerMap.getOrDefault(context.getClass(), defaultExceptionHandler);
+        exceptionHandler.handle(exception, context);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/discord/exception/DiscordExceptionDispatcher.java
+++ b/src/main/java/com/gdschongik/gdsc/global/discord/exception/DiscordExceptionDispatcher.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.events.GenericEvent;
-import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 public class DiscordExceptionDispatcher {
 
     private static final Map<Class<? extends GenericEvent>, DiscordExceptionHandler> exceptionHandlerMap =
-            Map.of(GenericCommandInteractionEvent.class, new CommandExceptionHandler());
+            Map.of(SlashCommandInteractionEvent.class, new CommandExceptionHandler());
 
     private static final DefaultExceptionHandler defaultExceptionHandler = new DefaultExceptionHandler();
 

--- a/src/main/java/com/gdschongik/gdsc/global/discord/exception/DiscordExceptionDispatcher.java
+++ b/src/main/java/com/gdschongik/gdsc/global/discord/exception/DiscordExceptionDispatcher.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class DiscordExceptionDispatcher {
 
+    // TODO: instanceof로 대체
+
     private static final Map<Class<? extends GenericEvent>, DiscordExceptionHandler> exceptionHandlerMap =
             Map.of(SlashCommandInteractionEvent.class, new CommandExceptionHandler());
 

--- a/src/main/java/com/gdschongik/gdsc/global/discord/exception/DiscordExceptionMessageGenerator.java
+++ b/src/main/java/com/gdschongik/gdsc/global/discord/exception/DiscordExceptionMessageGenerator.java
@@ -1,0 +1,14 @@
+package com.gdschongik.gdsc.global.discord.exception;
+
+import com.gdschongik.gdsc.global.exception.CustomException;
+
+public class DiscordExceptionMessageGenerator {
+
+    public static String generate(Exception exception) {
+        if (exception instanceof CustomException) {
+            return exception.getMessage();
+        }
+
+        return "알 수 없는 오류가 발생했습니다.";
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/discord/exception/handler/CommandExceptionHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/global/discord/exception/handler/CommandExceptionHandler.java
@@ -1,0 +1,14 @@
+package com.gdschongik.gdsc.global.discord.exception.handler;
+
+import com.gdschongik.gdsc.global.discord.exception.DiscordExceptionMessageGenerator;
+import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionEvent;
+
+public class CommandExceptionHandler implements DiscordExceptionHandler {
+
+    @Override
+    public void handle(Exception exception, Object context) {
+        GenericCommandInteractionEvent event = (GenericCommandInteractionEvent) context;
+        String message = DiscordExceptionMessageGenerator.generate(exception);
+        event.getHook().sendMessage(message).setEphemeral(true).queue();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/discord/exception/handler/DefaultExceptionHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/global/discord/exception/handler/DefaultExceptionHandler.java
@@ -1,0 +1,9 @@
+package com.gdschongik.gdsc.global.discord.exception.handler;
+
+public class DefaultExceptionHandler implements DiscordExceptionHandler {
+
+    @Override
+    public void handle(Exception exception, Object context) {
+        // do nothing
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/discord/exception/handler/DiscordExceptionHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/global/discord/exception/handler/DiscordExceptionHandler.java
@@ -1,0 +1,6 @@
+package com.gdschongik.gdsc.global.discord.exception.handler;
+
+public interface DiscordExceptionHandler {
+
+    void handle(Exception exception, Object context);
+}

--- a/src/main/java/com/gdschongik/gdsc/global/discord/listener/NicknameModifyListener.java
+++ b/src/main/java/com/gdschongik/gdsc/global/discord/listener/NicknameModifyListener.java
@@ -1,0 +1,20 @@
+package com.gdschongik.gdsc.global.discord.listener;
+
+import com.gdschongik.gdsc.domain.discord.handler.NicknameModifyHandler;
+import com.gdschongik.gdsc.global.discord.Listener;
+import jakarta.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateNicknameEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+@Listener
+@RequiredArgsConstructor
+public class NicknameModifyListener extends ListenerAdapter {
+
+    private final NicknameModifyHandler nicknameModifyHandler;
+
+    @Override
+    public void onGuildMemberUpdateNickname(@Nonnull GuildMemberUpdateNicknameEvent event) {
+        nicknameModifyHandler.delegate(event);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -49,6 +49,8 @@ public enum ErrorCode {
     DISCORD_CODE_MISMATCH(HttpStatus.CONFLICT, "디스코드 인증코드가 일치하지 않습니다."),
     DISCORD_ROLE_UNASSIGNABLE(HttpStatus.INTERNAL_SERVER_ERROR, "디스코드 역할 부여가 불가능합니다. 가입 조건을 확인해주세요."),
     DISCORD_ROLE_NOT_FOUND(HttpStatus.NOT_FOUND, "디스코드 역할을 찾을 수 없습니다."),
+    DISCORD_NOT_SIGNUP(HttpStatus.INTERNAL_SERVER_ERROR, "아직 가입신청서를 작성하지 않은 회원입니다."),
+    DISCORD_NICKNAME_NOTNULL(HttpStatus.INTERNAL_SERVER_ERROR, "닉네임은 빈 값이 될 수 없습니다."),
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #117 

## 📌 작업 내용 및 특이사항
- 서버 닉네임 변경 이벤트가 발생한 경우 트리거됩니다.
- 닉네임 변경 이벤트는 다음 상황에서 발생합니다.
    - `/가입하기` 커맨드로 닉네임을 변경시키는 경우
    - 본인이 직접 서버 프로필을 수정하는 경우
- 닉네임 변경 이벤트가 발생한 경우, 다음과 같이 작동합니다.
    - 디비에 저장된 멤버인 경우
        - 디비에 닉네임이 존재하는 경우
            - 바꾸려는 닉네임이 현재 디비 닉네임인 경우 -> 패스
            - 디비 닉네임과 바꾸려는 닉네임이 다른 경우 ->
        - 디비에 닉네임이 존재하지 않는 경우 -> 패스
   - 디비에 저장되지 않은 멤버인 경우
        - 패스 
- 디스코드 예외 처리기 리팩토링
   - 디스코드 AOP의 경우 try-catch around만 수행하고 실제 예외처리는 디스패쳐에서 예외 핸들러를 디스패치 한 후 핸들링을 수행하도록 변경 

## 📝 참고사항
-

## 📚 기타
-
