### PR TITLE
fix: 메일 전송 설정 시 프로토콜도 설정하도록 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/global/config/JavaMailSenderConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/JavaMailSenderConfig.java
@@ -21,6 +21,7 @@ public class JavaMailSenderConfig {
         javaMailSender.setHost(emailProperty.getHost());
         javaMailSender.setPort(emailProperty.getPort());
         javaMailSender.setDefaultEncoding(emailProperty.getEncoding());
+        javaMailSender.setProtocol(emailProperty.getProtocol());
 
         setGmailProperty(javaMailSender);
         setJavaMailProperties(javaMailSender);

--- a/src/main/java/com/gdschongik/gdsc/global/property/email/EmailProperty.java
+++ b/src/main/java/com/gdschongik/gdsc/global/property/email/EmailProperty.java
@@ -13,6 +13,7 @@ public class EmailProperty {
     private final Gmail gmail;
     private final String host;
     private final int port;
+    private final String protocol;
     private final String encoding;
     private final Map<String, Object> javaMailProperty;
 

--- a/src/main/resources/application-email.yml
+++ b/src/main/resources/application-email.yml
@@ -6,6 +6,7 @@ email:
   host: "smtp.gmail.com"
   port: 465
   encoding: "UTF-8"
+  protocol: "smtps"
 
   java-mail-property:
     smtp-auth:


### PR DESCRIPTION
## 🌱 관련 이슈
- close #142

## 📌 작업 내용 및 특이사항
- JavaMailSenderConfig에서 protocol을 설정하지 않아 발생하는 connection fail을 해결했습니다.

## 📝 참고사항
-

## 📚 기타
-
