### PR TITLE
feat: 디스코드 명령어 채널에서 잘못 입력한 커맨드 삭제하는 기능

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/handler/NonCommandHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/handler/NonCommandHandler.java
@@ -1,0 +1,37 @@
+package com.gdschongik.gdsc.domain.discord.handler;
+
+import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.*;
+
+import com.gdschongik.gdsc.global.util.DiscordUtil;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.events.GenericEvent;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NonCommandHandler implements DiscordEventHandler {
+
+    private final DiscordUtil discordUtil;
+
+    @Override
+    public void delegate(GenericEvent genericEvent) {
+        MessageReceivedEvent event = (MessageReceivedEvent) genericEvent;
+        Role adminRole = discordUtil.findRoleByName(ADMIN_ROLE_NAME);
+
+        Member member = Objects.requireNonNull(event.getMember());
+
+        if (member.getUser().isBot()) {
+            return;
+        }
+
+        if (member.getRoles().contains(adminRole)) {
+            return;
+        }
+
+        event.getMessage().delete().queue();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/DiscordConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/DiscordConstant.java
@@ -6,6 +6,7 @@ public class DiscordConstant {
 
     // 공통 상수
     public static final String MEMBER_ROLE_NAME = "커뮤니티-멤버";
+    public static final String ADMIN_ROLE_NAME = "운영진";
 
     // 인증코드 발급 커맨드
     public static final String COMMAND_NAME_ISSUING_CODE = "인증코드";

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/DiscordConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/DiscordConstant.java
@@ -5,6 +5,7 @@ public class DiscordConstant {
     private DiscordConstant() {}
 
     // 공통 상수
+    public static final String DISCORD_BOT_STATUS_CONTENT = "정상영업";
     public static final String MEMBER_ROLE_NAME = "커뮤니티-멤버";
     public static final String ADMIN_ROLE_NAME = "운영진";
 

--- a/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
@@ -31,7 +31,7 @@ public class DiscordConfig {
     @ConditionalOnProperty(value = "discord.enabled", havingValue = "true", matchIfMissing = true)
     public JDA jda() {
         JDA jda = JDABuilder.createDefault(discordProperty.getToken())
-                .setActivity(Activity.playing("테스트"))
+                .setActivity(Activity.playing(DISCORD_BOT_STATUS_CONTENT))
                 .enableIntents(GatewayIntent.GUILD_MESSAGES, GatewayIntent.MESSAGE_CONTENT, GatewayIntent.GUILD_MEMBERS)
                 .setMemberCachePolicy(MemberCachePolicy.ALL)
                 .build();

--- a/src/main/java/com/gdschongik/gdsc/global/discord/listener/NonCommandListener.java
+++ b/src/main/java/com/gdschongik/gdsc/global/discord/listener/NonCommandListener.java
@@ -1,0 +1,26 @@
+package com.gdschongik.gdsc.global.discord.listener;
+
+import com.gdschongik.gdsc.domain.discord.handler.NonCommandHandler;
+import com.gdschongik.gdsc.global.discord.Listener;
+import com.gdschongik.gdsc.global.property.DiscordProperty;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.jetbrains.annotations.NotNull;
+
+@Listener
+@RequiredArgsConstructor
+public class NonCommandListener extends ListenerAdapter {
+
+    private final DiscordProperty discordProperty;
+    private final NonCommandHandler nonCommandHandler;
+
+    @Override
+    public void onMessageReceived(@NotNull MessageReceivedEvent event) {
+        String eventChannelId = event.getChannel().getId();
+
+        if (eventChannelId.equals(discordProperty.getCommandChannelId())) {
+            nonCommandHandler.delegate(event);
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/property/DiscordProperty.java
+++ b/src/main/java/com/gdschongik/gdsc/global/property/DiscordProperty.java
@@ -11,4 +11,5 @@ public class DiscordProperty {
 
     private final String token;
     private final String serverId;
+    private final String commandChannelId;
 }

--- a/src/main/resources/application-discord.yml
+++ b/src/main/resources/application-discord.yml
@@ -1,3 +1,4 @@
 discord:
   token: ${DISCORD_BOT_TOKEN:}
   server-id: ${DISCORD_SERVER_ID:}
+  command-channel-id: ${DISCORD_COMMAND_CHANNEL_ID:}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #191 
- close #192

## 📌 작업 내용 및 특이사항
- 명령어 채널에서 운영진 or 봇 제외한 유저가 채팅 올리는 경우 자동으로 삭제
- 명령어 채널 ID `.env` 에 넣어야 함
- 운영진 역할 이름은 `운영진`
- 삭제하기 전에 잠깐 보이긴 함. 한번에 여러 명이 스패밍하면 큐잉 딜레이 생기는데 어쩔 수 없음 -> 수동으로 막아야 함

## 📝 참고사항
-

## 📚 기타
-
