### PR TITLE
refactor: 검색 조건에서 학과를 문자열로 받도록 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -177,10 +177,14 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
                 .and(eqStudentId(queryRequest.studentId()))
                 .and(eqName(queryRequest.name()))
                 .and(eqPhone(queryRequest.phone()))
-                .and(eqDepartment(queryRequest.department()))
+                .and(inDepartmentList(queryRequest.getDepartmentCodes()))
                 .and(eqEmail(queryRequest.email()))
                 .and(eqDiscordUsername(queryRequest.discordUsername()))
                 .and(eqNickname(queryRequest.nickname()));
+    }
+
+    private BooleanExpression inDepartmentList(List<Department> departmentCodes) {
+        return departmentCodes != null ? member.department.in(departmentCodes) : null;
     }
 
     private BooleanExpression eqStudentId(String studentId) {
@@ -193,10 +197,6 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
 
     private BooleanExpression eqPhone(String phone) {
         return phone != null ? member.phone.contains(phone.replaceAll("-", "")) : null;
-    }
-
-    private BooleanExpression eqDepartment(Department department) {
-        return department != null ? member.department.eq(department) : null;
     }
 
     private BooleanExpression eqEmail(String email) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -177,7 +177,7 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
                 .and(eqStudentId(queryRequest.studentId()))
                 .and(eqName(queryRequest.name()))
                 .and(eqPhone(queryRequest.phone()))
-                .and(inDepartmentList(queryRequest.getDepartmentCodes()))
+                .and(inDepartmentList(Department.getDepartmentCodes(queryRequest.department())))
                 .and(eqEmail(queryRequest.email()))
                 .and(eqDiscordUsername(queryRequest.discordUsername()))
                 .and(eqNickname(queryRequest.nickname()));

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Department.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Department.java
@@ -1,5 +1,8 @@
 package com.gdschongik.gdsc.domain.member.domain;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -85,4 +88,12 @@ public enum Department {
     D077("영어교육과");
 
     private String departmentName;
+
+    public static List<Department> getDepartmentCodes(String keyword) {
+        return Optional.ofNullable(keyword)
+                .map(s -> Arrays.stream(Department.values())
+                        .filter(department -> department.getDepartmentName().contains(s))
+                        .toList())
+                .orElse(null);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberQueryRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberQueryRequest.java
@@ -2,11 +2,7 @@ package com.gdschongik.gdsc.domain.member.dto.request;
 
 import static com.gdschongik.gdsc.global.common.constant.RegexConstant.*;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.gdschongik.gdsc.domain.member.domain.Department;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.Arrays;
-import java.util.List;
 
 public record MemberQueryRequest(
         @Schema(description = "학번", pattern = STUDENT_ID) String studentId,
@@ -15,12 +11,4 @@ public record MemberQueryRequest(
         @Schema(description = "학과") String department,
         @Schema(description = "이메일") String email,
         @Schema(description = "디스코드 유저네임") String discordUsername,
-        @Schema(description = "커뮤니티 닉네임", pattern = NICKNAME) String nickname) {
-
-    @JsonIgnore
-    public List<Department> getDepartmentCodes() {
-        return Arrays.stream(Department.values())
-                .filter(department -> department.getDepartmentName().contains(department()))
-                .toList();
-    }
-}
+        @Schema(description = "커뮤니티 닉네임", pattern = NICKNAME) String nickname) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberQueryRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberQueryRequest.java
@@ -2,14 +2,25 @@ package com.gdschongik.gdsc.domain.member.dto.request;
 
 import static com.gdschongik.gdsc.global.common.constant.RegexConstant.*;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.gdschongik.gdsc.domain.member.domain.Department;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Arrays;
+import java.util.List;
 
 public record MemberQueryRequest(
         @Schema(description = "학번", pattern = STUDENT_ID) String studentId,
         @Schema(description = "이름") String name,
         @Schema(description = "전화번호", pattern = PHONE_WITHOUT_HYPHEN) String phone,
-        @Schema(description = "학과") Department department,
+        @Schema(description = "학과") String department,
         @Schema(description = "이메일") String email,
         @Schema(description = "디스코드 유저네임") String discordUsername,
-        @Schema(description = "커뮤니티 닉네임", pattern = NICKNAME) String nickname) {}
+        @Schema(description = "커뮤니티 닉네임", pattern = NICKNAME) String nickname) {
+
+    @JsonIgnore
+    public List<Department> getDepartmentCodes() {
+        return Arrays.stream(Department.values())
+                .filter(department -> department.getDepartmentName().contains(department()))
+                .toList();
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #201 

## 📌 작업 내용 및 특이사항
- 어드민에서 검색 조건을 학과로 설정하여 요청을 보낼 경우 유저는 학과 코드가 아닌 학과명을 입력하기 때문에 자료형을 String으로 수정했습니다.
- department로 "컴"만 들어온 경우 "컴"이 포함된 모든 코드를 사용해 쿼리가 나가도록 하기 위해 dto에 `List<Department>` 생성 메서드를 넣었습니다.

## 📝 참고사항
-

## 📚 기타
-
