### PR TITLE
refactor: 회비 납부 여부 조회 시 가입 신청서 작성한 회원만 포함

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -106,7 +106,8 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
                 .where(
                         queryOption(queryRequest),
                         eqStatus(MemberStatus.NORMAL),
-                        eqRequirementStatus(member.requirement.paymentStatus, paymentStatus))
+                        eqRequirementStatus(member.requirement.paymentStatus, paymentStatus),
+                        isStudentIdNotNull())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(member.createdAt.desc())
@@ -209,5 +210,9 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
 
     private BooleanExpression eqNickname(String nickname) {
         return nickname != null ? member.nickname.containsIgnoreCase(nickname) : null;
+    }
+
+    private BooleanExpression isStudentIdNotNull() {
+        return member.studentId.isNotNull();
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #226

## 📌 작업 내용 및 특이사항
- 회비 납부 여부 조회 시 가입 신청서 작성한 회원만 포함하도록 수정했습니다.

## 📝 참고사항
-

## 📚 기타
-
