### PR TITLE
refactor: 대기중인 멤버 조회 API에서 가입 신청서를 작성하지 않은 멤버 제외

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -84,7 +84,7 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
     public Page<Member> findAllByRole(MemberQueryRequest queryRequest, MemberRole role, Pageable pageable) {
         List<Member> fetch = queryFactory
                 .selectFrom(member)
-                .where(queryOption(queryRequest), eqRole(role), eqStatus(MemberStatus.NORMAL))
+                .where(queryOption(queryRequest), eqRole(role), eqStatus(MemberStatus.NORMAL), isStudentIdNotNull())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(member.createdAt.desc())

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -93,7 +93,7 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
         JPAQuery<Long> countQuery = queryFactory
                 .select(member.count())
                 .from(member)
-                .where(queryOption(queryRequest), eqRole(role), eqStatus(MemberStatus.NORMAL));
+                .where(queryOption(queryRequest), eqRole(role), eqStatus(MemberStatus.NORMAL), isStudentIdNotNull());
 
         return PageableExecutionUtils.getPage(fetch, pageable, countQuery::fetchOne);
     }
@@ -119,7 +119,8 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
                 .where(
                         queryOption(queryRequest),
                         eqStatus(MemberStatus.NORMAL),
-                        eqRequirementStatus(member.requirement.paymentStatus, paymentStatus));
+                        eqRequirementStatus(member.requirement.paymentStatus, paymentStatus),
+                        isStudentIdNotNull());
 
         return PageableExecutionUtils.getPage(fetch, pageable, countQuery::fetchOne);
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #230

## 📌 작업 내용 및 특이사항
- 대기중인 멤버 조회 api에서 가입 신청서를 작성하지 않은 멤버 제외했습니다. (학번의 유무로 판단)
- count query가 실제 쿼리와 같은 조건을 갖도록 수정했습니다.

## 📝 참고사항
-

## 📚 기타
-
