### PR TITLE
feat: 승인된 멤버 조회 API 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
@@ -95,4 +95,12 @@ public class AdminMemberController {
         adminMemberService.updatePaymentStatus(memberId, request);
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "승인된 회원 전체 조회", description = "승인된 회원 전체를 조회합니다.")
+    @GetMapping("/granted")
+    public ResponseEntity<Page<AdminMemberResponse>> getGrantedMembers(
+            MemberQueryRequest queryRequest, Pageable pageable) {
+        Page<AdminMemberResponse> response = adminMemberService.findAllGrantedMembers(queryRequest, pageable);
+        return ResponseEntity.ok().body(response);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -30,7 +30,7 @@ public class AdminMemberService {
     private final MemberRepository memberRepository;
 
     public Page<AdminMemberResponse> findAll(MemberQueryRequest queryRequest, Pageable pageable) {
-        Page<Member> members = memberRepository.findAll(queryRequest, pageable);
+        Page<Member> members = memberRepository.findAllByRole(queryRequest, pageable, null);
         return members.map(AdminMemberResponse::from);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -1,10 +1,10 @@
 package com.gdschongik.gdsc.domain.member.application;
 
+import static com.gdschongik.gdsc.domain.member.domain.MemberRole.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import com.gdschongik.gdsc.domain.member.domain.RequirementStatus;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberGrantRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberPaymentRequest;
@@ -55,7 +55,7 @@ public class AdminMemberService {
     }
 
     public Page<AdminMemberResponse> findAllPendingMembers(MemberQueryRequest queryRequest, Pageable pageable) {
-        Page<Member> members = memberRepository.findAllByRole(queryRequest, MemberRole.GUEST, pageable);
+        Page<Member> members = memberRepository.findAllByRole(queryRequest, pageable, GUEST);
         return members.map(AdminMemberResponse::from);
     }
 
@@ -82,5 +82,10 @@ public class AdminMemberService {
     public void updatePaymentStatus(Long memberId, MemberPaymentRequest request) {
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
         member.updatePaymentStatus(request.status());
+    }
+
+    public Page<AdminMemberResponse> findAllGrantedMembers(MemberQueryRequest queryRequest, Pageable pageable) {
+        Page<Member> members = memberRepository.findAllByRole(queryRequest, pageable, USER);
+        return members.map(AdminMemberResponse::from);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
@@ -4,6 +4,7 @@ import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import com.gdschongik.gdsc.domain.member.domain.RequirementStatus;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
+import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -17,7 +18,7 @@ public interface MemberCustomRepository {
 
     Page<Member> findAllGrantable(MemberQueryRequest queryRequest, Pageable pageable);
 
-    Page<Member> findAllByRole(MemberQueryRequest queryRequest, MemberRole role, Pageable pageable);
+    Page<Member> findAllByRole(MemberQueryRequest queryRequest, Pageable pageable, @Nullable MemberRole role);
 
     Page<Member> findAllByPaymentStatus(
             MemberQueryRequest queryRequest, RequirementStatus paymentStatus, Pageable pageable);

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
@@ -12,8 +12,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface MemberCustomRepository {
-    Page<Member> findAll(MemberQueryRequest queryRequest, Pageable pageable);
-
     Optional<Member> findNormalByOauthId(String oauthId);
 
     Page<Member> findAllGrantable(MemberQueryRequest queryRequest, Pageable pageable);

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -32,22 +32,6 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Member> findAll(MemberQueryRequest queryRequest, Pageable pageable) {
-        List<Member> fetch = queryFactory
-                .selectFrom(member)
-                .where(queryOption(queryRequest), eqStatus(MemberStatus.NORMAL))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .orderBy(member.createdAt.desc())
-                .fetch();
-
-        JPAQuery<Long> countQuery =
-                queryFactory.select(member.count()).from(member).where(queryOption(queryRequest));
-
-        return PageableExecutionUtils.getPage(fetch, pageable, countQuery::fetchOne);
-    }
-
-    @Override
     public Optional<Member> findNormalByOauthId(String oauthId) {
         return Optional.ofNullable(queryFactory
                 .selectFrom(member)

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -15,6 +15,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.EnumPath;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -81,7 +82,7 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
     }
 
     @Override
-    public Page<Member> findAllByRole(MemberQueryRequest queryRequest, MemberRole role, Pageable pageable) {
+    public Page<Member> findAllByRole(MemberQueryRequest queryRequest, Pageable pageable, @Nullable MemberRole role) {
         List<Member> fetch = queryFactory
                 .selectFrom(member)
                 .where(queryOption(queryRequest), eqRole(role), eqStatus(MemberStatus.NORMAL))
@@ -143,7 +144,7 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
     }
 
     private BooleanExpression eqRole(MemberRole role) {
-        return member.role.eq(role);
+        return role != null ? member.role.eq(role) : null;
     }
 
     private BooleanBuilder requirementVerified() {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #229 

## 📌 작업 내용 및 특이사항
- 승인된 멤버를 조회하는 api를 구현했습니다.
- service에서 repository로 넘어가는 부분에서 합칠 수 있는 메서드가 있어서 repository의 메서드를 정리했습니다. '전체 멤버 조회' 시 사용하던 `MemberCustomRepository.findAll`을 `MemberCustomRepository.findAllByRole`로 대체했고, `MemberCustomRepository.findAllByRole`의 parameter MemberRole을 `@Nullable`로 수정했습니다.

## 📝 참고사항
-

## 📚 기타
-
