### PR TITLE
chore: 수동 배포 워크플로우 작성

### DIFF
--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -16,14 +16,14 @@ jobs:
         uses: appleboy/ssh-action@master
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_IMAGE_TAG: ${{ github.event.inputs.commit_hash }}
+          IMAGE_FULL_URL: ${{ secrets.DOCKERHUB_USERNAME }}/gdsc-server:${{ github.event.inputs.commit_hash }}
         with:
-            host: ${{ secrets.EC2_HOST }}
-            username: ${{ secrets.EC2_USERNAME }}
-            key: ${{ secrets.EC2_PRIVATE_KEY }}
-            envs: DOCKERHUB_USERNAME,DOCKERHUB_IMAGE_TAG  # docker-compose.yml 에서 사용할 환경 변수
-            script: |
-              echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
-              docker pull ${{ env.DOCKERHUB_USERNAME }}/gdsc-server:${{ env.DOCKERHUB_IMAGE_TAG }}
-              docker compose -f /home/ubuntu/docker-compose.yml up -d
-              docker image prune -a -f
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          envs: IMAGE_FULL_URL  # docker-compose.yml 에서 사용할 환경 변수
+          script: |
+            echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+            docker pull ${{ env.IMAGE_FULL_URL }}
+            docker compose up -d
+            docker image prune -a -f

--- a/.github/workflows/production_deploy.yml
+++ b/.github/workflows/production_deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy to Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      semver:
+        description: 'semver without v'
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Deploy to EC2 Server
+        uses: appleboy/ssh-action@master
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          IMAGE_FULL_URL: ${{ secrets.DOCKERHUB_USERNAME }}/gdsc-server:${{ github.event.inputs.semver }}
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          envs: IMAGE_FULL_URL  # docker-compose.yml 에서 사용할 환경 변수
+          script: |
+            echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+            docker pull ${{ env.IMAGE_FULL_URL }}
+            docker-compose up -d
+            docker image prune -a -f


### PR DESCRIPTION
## 🌱 관련 이슈
- close #244

## 📌 작업 내용 및 특이사항
- 개발서버 수동배포 -> 도커허브 커밋해시 태그를 인풋으로 배포
- 상용서버 수동배포 -> 도커허브 semver 태그를 인풋으로 배포

이제 번거롭게 ec2 접속해서 export로 변수 설정하고 docker compose up 할 필요 없습니다

## 📝 참고사항
-

## 📚 기타
-
