### PR TITLE
fix: 디스코드 연동 전에도 다른 값들을 수정할 수 있도록 DTO 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberUpdateRequest.java
@@ -21,8 +21,7 @@ public record MemberUpdateRequest(
                 String phone,
         @NotNull @Schema(description = "학과") Department department,
         @NotBlank @Email @Schema(description = "이메일") String email,
-        @NotBlank @Schema(description = "디스코드 유저네임") String discordUsername,
-        @NotBlank
-                @Pattern(regexp = NICKNAME, message = "닉네임은 " + NICKNAME + " 형식이어야 합니다.")
+        @Schema(description = "디스코드 유저네임") String discordUsername,
+        @Pattern(regexp = NICKNAME, message = "닉네임은 " + NICKNAME + " 형식이어야 합니다.")
                 @Schema(description = "커뮤니티 닉네임", pattern = NICKNAME)
                 String nickname) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #250 

## 📌 작업 내용 및 특이사항
- 디코 연동 전에는 discordUsername과 nickname이 null이므로 `@NotBlank`조건을 제거했습니다.

## 📝 참고사항
-

## 📚 기타
-
