### PR TITLE
test: 통합 테스트 환경 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,11 +31,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/src/test/java/com/gdschongik/gdsc/config/TestQuerydslConfig.java
+++ b/src/test/java/com/gdschongik/gdsc/config/TestQuerydslConfig.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.config;
 
+import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -13,6 +14,6 @@ public class TestQuerydslConfig {
 
     @Bean
     public JPAQueryFactory jpaQueryFactory() {
-        return new JPAQueryFactory(entityManager);
+        return new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
@@ -8,14 +8,12 @@ import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberUpdateRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
+import com.gdschongik.gdsc.integration.IntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
-@ActiveProfiles("test")
-class AdminMemberServiceTest {
+class AdminMemberServiceTest extends IntegrationTest {
+
     @Autowired
     private MemberRepository memberRepository;
 

--- a/src/test/java/com/gdschongik/gdsc/integration/DatabaseCleaner.java
+++ b/src/test/java/com/gdschongik/gdsc/integration/DatabaseCleaner.java
@@ -1,0 +1,48 @@
+package com.gdschongik.gdsc.integration;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.metamodel.EntityType;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import org.hibernate.Session;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatabaseCleaner implements InitializingBean {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    private List<String> tableNames;
+
+    @Override
+    public void afterPropertiesSet() {
+        em.unwrap(Session.class).doWork(this::extractTableNames);
+    }
+
+    private void extractTableNames(Connection conn) throws SQLException {
+        tableNames = em.getMetamodel().getEntities().stream()
+                .map(EntityType::getName)
+                .toList();
+    }
+
+    public void execute() {
+        em.unwrap(Session.class).doWork(this::cleanTables);
+    }
+
+    private void cleanTables(Connection conn) throws SQLException {
+        Statement statement = conn.createStatement();
+        statement.executeUpdate("SET REFERENTIAL_INTEGRITY FALSE");
+
+        for (String name : tableNames) {
+            statement.executeUpdate(String.format("TRUNCATE TABLE %s", name));
+            statement.executeUpdate(String.format("ALTER TABLE %s ALTER COLUMN %s_id RESTART WITH 1", name, name));
+        }
+
+        statement.executeUpdate("SET REFERENTIAL_INTEGRITY TRUE");
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/integration/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/integration/IntegrationTest.java
@@ -1,0 +1,19 @@
+package com.gdschongik.gdsc.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public abstract class IntegrationTest {
+
+    @Autowired
+    protected DatabaseCleaner databaseCleaner;
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.execute();
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #267 

## 📌 작업 내용 및 특이사항
- 통합 테스트 템플릿 구현
    - 모든 통합 테스트는 해당 `IntegrationTest` 를 상속받아서 사용합니다. 
- 데이터베이스 클리너 구현
    - 테이블 데이터를 모두 truncate 한 뒤 pk 시작 순서를 다시 1부터 지정하는 유틸리티 
    - 스프링 컨테이너를 다시 생성하지 않으므로 테스트 성능 개선에 도움이 됨

## 📝 참고사항
-

## 📚 기타
-
