### PR TITLE
refactor: QueryDSL 쿼리 조건을 별도 클래스로 분리

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -4,14 +4,10 @@ import static com.gdschongik.gdsc.domain.member.domain.QMember.*;
 import static com.gdschongik.gdsc.domain.member.domain.RequirementStatus.*;
 import static com.querydsl.core.group.GroupBy.*;
 
-import com.gdschongik.gdsc.domain.member.domain.Department;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import com.gdschongik.gdsc.domain.member.domain.RequirementStatus;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
-import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.EnumPath;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.annotation.Nullable;
@@ -26,7 +22,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
 @RequiredArgsConstructor
-public class MemberCustomRepositoryImpl implements MemberCustomRepository {
+public class MemberCustomRepositoryImpl extends MemberQueryMethod implements MemberCustomRepository {
 
     private final JPAQueryFactory queryFactory;
 
@@ -124,69 +120,5 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
         return classifiedMember;
     }
 
-    private BooleanExpression eqRole(MemberRole role) {
-        return role != null ? member.role.eq(role) : null;
-    }
-
-    private BooleanBuilder requirementVerified() {
-        return new BooleanBuilder()
-                .and(eqRequirementStatus(member.requirement.discordStatus, VERIFIED))
-                .and(eqRequirementStatus(member.requirement.univStatus, VERIFIED))
-                .and(eqRequirementStatus(member.requirement.paymentStatus, VERIFIED))
-                .and(eqRequirementStatus(member.requirement.bevyStatus, VERIFIED));
-    }
-
-    private BooleanExpression eqRequirementStatus(
-            EnumPath<RequirementStatus> requirement, RequirementStatus requirementStatus) {
-        return requirementStatus != null ? requirement.eq(requirementStatus) : null;
-    }
-
-    private BooleanExpression eqOauthId(String oauthId) {
-        return member.oauthId.eq(oauthId);
-    }
-
-    private BooleanBuilder queryOption(MemberQueryRequest queryRequest) {
-        BooleanBuilder booleanBuilder = new BooleanBuilder();
-
-        return booleanBuilder
-                .and(eqStudentId(queryRequest.studentId()))
-                .and(eqName(queryRequest.name()))
-                .and(eqPhone(queryRequest.phone()))
-                .and(inDepartmentList(Department.getDepartmentCodes(queryRequest.department())))
-                .and(eqEmail(queryRequest.email()))
-                .and(eqDiscordUsername(queryRequest.discordUsername()))
-                .and(eqNickname(queryRequest.nickname()));
-    }
-
-    private BooleanExpression inDepartmentList(List<Department> departmentCodes) {
-        return departmentCodes != null ? member.department.in(departmentCodes) : null;
-    }
-
-    private BooleanExpression eqStudentId(String studentId) {
-        return studentId != null ? member.studentId.containsIgnoreCase(studentId) : null;
-    }
-
-    private BooleanExpression eqName(String name) {
-        return name != null ? member.name.containsIgnoreCase(name) : null;
-    }
-
-    private BooleanExpression eqPhone(String phone) {
-        return phone != null ? member.phone.contains(phone.replaceAll("-", "")) : null;
-    }
-
-    private BooleanExpression eqEmail(String email) {
-        return email != null ? member.email.containsIgnoreCase(email) : null;
-    }
-
-    private BooleanExpression eqDiscordUsername(String discordUsername) {
-        return discordUsername != null ? member.discordUsername.containsIgnoreCase(discordUsername) : null;
-    }
-
-    private BooleanExpression eqNickname(String nickname) {
-        return nickname != null ? member.nickname.containsIgnoreCase(nickname) : null;
-    }
-
-    private BooleanExpression isStudentIdNotNull() {
-        return member.studentId.isNotNull();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -103,15 +103,6 @@ public class MemberCustomRepositoryImpl extends MemberQueryMethod implements Mem
         return replaceNullByEmptyList(groupByVerified);
     }
 
-    @Override
-    public List<Member> findAllByRole(MemberRole role) {
-        return queryFactory
-                .selectFrom(member)
-                .where(eqRole(role), isStudentIdNotNull())
-                .orderBy(member.studentId.asc(), member.name.asc())
-                .fetch();
-    }
-
     private Map<Boolean, List<Member>> replaceNullByEmptyList(Map<Boolean, List<Member>> groupByVerified) {
         Map<Boolean, List<Member>> classifiedMember = new HashMap<>();
         List<Member> emptyList = new ArrayList<>();
@@ -120,5 +111,12 @@ public class MemberCustomRepositoryImpl extends MemberQueryMethod implements Mem
         return classifiedMember;
     }
 
+    @Override
+    public List<Member> findAllByRole(MemberRole role) {
+        return queryFactory
+                .selectFrom(member)
+                .where(eqRole(role), isStudentIdNotNull())
+                .orderBy(member.studentId.asc(), member.name.asc())
+                .fetch();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberQueryMethod.java
@@ -1,0 +1,80 @@
+package com.gdschongik.gdsc.domain.member.dao;
+
+import static com.gdschongik.gdsc.domain.member.domain.QMember.*;
+import static com.gdschongik.gdsc.domain.member.domain.RequirementStatus.*;
+
+import com.gdschongik.gdsc.domain.member.domain.Department;
+import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.domain.member.domain.RequirementStatus;
+import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryRequest;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.EnumPath;
+import java.util.List;
+
+public class MemberQueryMethod {
+
+    protected BooleanExpression eqRole(MemberRole role) {
+        return role != null ? member.role.eq(role) : null;
+    }
+
+    protected BooleanExpression eqStudentId(String studentId) {
+        return studentId != null ? member.studentId.containsIgnoreCase(studentId) : null;
+    }
+
+    protected BooleanExpression eqName(String name) {
+        return name != null ? member.name.containsIgnoreCase(name) : null;
+    }
+
+    protected BooleanExpression eqPhone(String phone) {
+        return phone != null ? member.phone.contains(phone.replaceAll("-", "")) : null;
+    }
+
+    protected BooleanExpression eqEmail(String email) {
+        return email != null ? member.email.containsIgnoreCase(email) : null;
+    }
+
+    protected BooleanExpression eqDiscordUsername(String discordUsername) {
+        return discordUsername != null ? member.discordUsername.containsIgnoreCase(discordUsername) : null;
+    }
+
+    protected BooleanExpression eqNickname(String nickname) {
+        return nickname != null ? member.nickname.containsIgnoreCase(nickname) : null;
+    }
+
+    protected BooleanExpression eqOauthId(String oauthId) {
+        return member.oauthId.eq(oauthId);
+    }
+
+    protected BooleanExpression eqRequirementStatus(
+            EnumPath<RequirementStatus> requirement, RequirementStatus requirementStatus) {
+        return requirementStatus != null ? requirement.eq(requirementStatus) : null;
+    }
+
+    protected BooleanExpression inDepartmentList(List<Department> departmentCodes) {
+        return departmentCodes != null ? member.department.in(departmentCodes) : null;
+    }
+
+    protected BooleanExpression isStudentIdNotNull() {
+        return member.studentId.isNotNull();
+    }
+
+    protected BooleanBuilder requirementVerified() {
+        return new BooleanBuilder()
+                .and(eqRequirementStatus(member.requirement.discordStatus, VERIFIED))
+                .and(eqRequirementStatus(member.requirement.univStatus, VERIFIED))
+                .and(eqRequirementStatus(member.requirement.paymentStatus, VERIFIED))
+                .and(eqRequirementStatus(member.requirement.bevyStatus, VERIFIED));
+    }
+
+    protected BooleanBuilder queryOption(MemberQueryRequest queryRequest) {
+        return new BooleanBuilder()
+                .and(eqStudentId(queryRequest.studentId()))
+                .and(eqName(queryRequest.name()))
+                .and(eqPhone(queryRequest.phone()))
+                .and(inDepartmentList(Department.getDepartmentCodes(queryRequest.department())))
+                .and(eqEmail(queryRequest.email()))
+                .and(eqDiscordUsername(queryRequest.discordUsername()))
+                .and(eqNickname(queryRequest.nickname()));
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberQueryMethod.java
@@ -72,7 +72,7 @@ public class MemberQueryMethod {
                 .and(eqStudentId(queryRequest.studentId()))
                 .and(eqName(queryRequest.name()))
                 .and(eqPhone(queryRequest.phone()))
-                .and(inDepartmentList(Department.getDepartmentCodes(queryRequest.department())))
+                .and(inDepartmentList(Department.searchDepartments(queryRequest.department())))
                 .and(eqEmail(queryRequest.email()))
                 .and(eqDiscordUsername(queryRequest.discordUsername()))
                 .and(eqNickname(queryRequest.nickname()));

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Department.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Department.java
@@ -1,8 +1,8 @@
 package com.gdschongik.gdsc.domain.member.domain;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -89,11 +89,13 @@ public enum Department {
 
     private String departmentName;
 
-    public static List<Department> getDepartmentCodes(String keyword) {
-        return Optional.ofNullable(keyword)
-                .map(s -> Arrays.stream(Department.values())
-                        .filter(department -> department.getDepartmentName().contains(s))
-                        .toList())
-                .orElse(null);
+    public static List<Department> searchDepartments(String keyword) {
+        if (keyword == null) {
+            return Collections.emptyList();
+        }
+
+        return Arrays.stream(Department.values())
+                .filter(department -> department.getDepartmentName().contains(keyword))
+                .toList();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Department.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Department.java
@@ -87,7 +87,7 @@ public enum Department {
     D076("역사교육과"),
     D077("영어교육과");
 
-    private String departmentName;
+    private final String departmentName;
 
     public static List<Department> searchDepartments(String keyword) {
         if (keyword == null) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #272

## 📌 작업 내용 및 특이사항
- `MemberRepositoryCustomImpl` 은 인터페이스의 구현 메서드만 존재하도록 하고, 그 외 where 절 조건에 해당하는 표현식은 별도 클래스로 분리하도록 개선
- 단순 조건이 아닌 핵심 로직을 추출한 것은 제외 (ex: `replaceNullByEmptyList`)

## 📝 참고사항
-

## 📚 기타
-
