### PR TITLE
feat: 2차 모집 기간 마감 시 LandingStatus 조건 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/global/security/LandingStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/LandingStatus.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.global.security;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -22,6 +23,12 @@ public enum LandingStatus {
 
         // 2차 모집기간 종료일 12시 30분 이후, 신청서 미제출 상태면 마감 페이지로 랜딩
         if (LocalDateTime.now().isAfter(Constants.SECOND_RECRUITMENT_END_DATE.atTime(0, 30)) && !member.isApplied()) {
+            return ONBOARDING_CLOSED;
+        }
+
+        // 2차 모집기간 종료일 1시 이후, Guest를 마감 페이지로 랜딩.
+        if (LocalDateTime.now().isAfter(Constants.SECOND_RECRUITMENT_END_DATE.atTime(1, 0))
+                && member.getRole().equals(MemberRole.GUEST)) {
             return ONBOARDING_CLOSED;
         }
 

--- a/src/main/java/com/gdschongik/gdsc/global/security/LandingStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/LandingStatus.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 
 public enum LandingStatus {
     ONBOARDING_NOT_OPENED, // 대기 페이지로 랜딩
+    ONBOARDING_CLOSED, // 모집 기간 마감
     TO_STUDENT_AUTHENTICATION, // 재학생 인증 페이지로 랜딩
     TO_REGISTRATION, // 가입신청 페이지로 랜딩
     TO_DASHBOARD, // 대시보드로 랜딩
@@ -19,9 +20,9 @@ public enum LandingStatus {
             return ONBOARDING_NOT_OPENED;
         }
 
-        // 2차 모집기간 종료 이후 가입했다면 대기 페이지로 랜딩
-        if (member.getCreatedAt().isAfter(Constants.SECOND_RECRUITMENT_END_DATE.atStartOfDay())) {
-            return ONBOARDING_NOT_OPENED;
+        // 2차 모집기간 종료일 12시 30분 이후, 신청서 미제출 상태면 마감 페이지로 랜딩
+        if (LocalDateTime.now().isAfter(Constants.SECOND_RECRUITMENT_END_DATE.atTime(0, 30)) && !member.isApplied()) {
+            return ONBOARDING_CLOSED;
         }
 
         // 아직 재학생 인증을 하지 않았다면 재학생 인증 페이지로 랜딩
@@ -31,7 +32,7 @@ public enum LandingStatus {
 
         // 재학생 인증은 했지만 가입신청을 하지 않았다면 가입신청 페이지로 랜딩
         // 가입신청 여부는 학번 존재여부로 판단
-        if (member.getStudentId() == null) {
+        if (!member.isApplied()) {
             return TO_REGISTRATION;
         }
 

--- a/src/main/java/com/gdschongik/gdsc/global/security/LandingStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/LandingStatus.java
@@ -19,6 +19,11 @@ public enum LandingStatus {
             return ONBOARDING_NOT_OPENED;
         }
 
+        // 2차 모집기간 종료 이후 가입했다면 대기 페이지로 랜딩
+        if (member.getCreatedAt().isAfter(Constants.SECOND_RECRUITMENT_END_DATE.atStartOfDay())) {
+            return ONBOARDING_NOT_OPENED;
+        }
+
         // 아직 재학생 인증을 하지 않았다면 재학생 인증 페이지로 랜딩
         if (!member.getRequirement().isUnivVerified()) {
             return TO_STUDENT_AUTHENTICATION;
@@ -37,5 +42,6 @@ public enum LandingStatus {
     private static class Constants {
         private static final LocalDate FIRST_RECRUITMENT_END_DATE = LocalDate.of(2024, 3, 2);
         private static final LocalDate SECOND_RECRUITMENT_START_DATE = LocalDate.of(2024, 3, 4);
+        private static final LocalDate SECOND_RECRUITMENT_END_DATE = LocalDate.of(2024, 3, 9);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #277

## 📌 작업 내용 및 특이사항
- 2차 모집 기간 후 대기 페이지로 랜딩하도록 조건 추가했습니다.

## 📝 참고사항
-

## 📚 기타
- 다음 온보딩 때는 1차 모집 마감과 2차 모집 마감의 LandingStatus를 다른 enum 값으로 관리하는게 좋을 것 같네요. 
