### PR TITLE
hotfix: 학과 쿼리 메서드 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberQueryMethod.java
@@ -52,7 +52,7 @@ public class MemberQueryMethod {
     }
 
     protected BooleanExpression inDepartmentList(List<Department> departmentCodes) {
-        return departmentCodes != null ? member.department.in(departmentCodes) : null;
+        return departmentCodes.isEmpty() ? null :  member.department.in(departmentCodes);
     }
 
     protected BooleanExpression isStudentIdNotNull() {


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
- department 리팩토링 후 학과 검색어가 null일 경우 반환하는 타입이 변경되어 발생한 이슈였습니다.

## 📝 참고사항
-

## 📚 기타
-
