### PR TITLE
test: 가입조건에 따른 승인 가능 멤버 조회 테스트

### DIFF
--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -46,7 +46,7 @@ class MemberRepositoryTest extends RepositoryTest {
         }
 
         @Test
-        void 재학생_인증_미완료시_조회_실패한다() {
+        void 재학생_인증_미완료시_조회되지_않는다() {
             // given
             Member member = getMember();
             member.getRequirement().verifyDiscord();
@@ -61,7 +61,7 @@ class MemberRepositoryTest extends RepositoryTest {
         }
 
         @Test
-        void 디스코드_인증_미완료시_조회_실패한다() {
+        void 디스코드_인증_미완료시_조회되지_않는다() {
             // given
             Member member = getMember();
             member.getRequirement().updateUnivStatus(VERIFIED);
@@ -76,7 +76,7 @@ class MemberRepositoryTest extends RepositoryTest {
         }
 
         @Test
-        void 회비납부_미완료시_조회_실패한다() {
+        void 회비납부_미완료시_조회되지_않는다() {
             // given
             Member member = getMember();
             member.getRequirement().updateUnivStatus(VERIFIED);
@@ -91,7 +91,7 @@ class MemberRepositoryTest extends RepositoryTest {
         }
 
         @Test
-        void Bevy_연동_미완료시_조회_실패한다() {
+        void Bevy_연동_미완료시_조회되지_않는다() {
             // given
             Member member = getMember();
             member.getRequirement().updateUnivStatus(VERIFIED);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -1,0 +1,108 @@
+package com.gdschongik.gdsc.domain.member.dao;
+
+import static com.gdschongik.gdsc.domain.member.domain.RequirementStatus.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryOption;
+import com.gdschongik.gdsc.repository.RepositoryTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+class MemberRepositoryTest extends RepositoryTest {
+
+    private static final String TEST_OAUTH_ID = "testOauthId";
+    private static final MemberQueryOption EMPTY_QUERY_OPTION =
+            new MemberQueryOption(null, null, null, null, null, null, null);
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member getMember() {
+        Member member = Member.createGuestMember(TEST_OAUTH_ID);
+        return memberRepository.save(member);
+    }
+
+    @Nested
+    class 승인_가능_멤버_조회 {
+
+        @Test
+        void 가입조건_모두_충족했다면_조회_성공한다() {
+            // given
+            Member member = getMember();
+            member.getRequirement().updateUnivStatus(VERIFIED);
+            member.getRequirement().verifyDiscord();
+            member.getRequirement().updatePaymentStatus(VERIFIED);
+            member.getRequirement().verifyBevy();
+
+            // when
+            Page<Member> members = memberRepository.findAllGrantable(EMPTY_QUERY_OPTION, PageRequest.of(0, 10));
+
+            // then
+            assertThat(members).contains(member);
+        }
+
+        @Test
+        void 재학생_인증_미완료시_조회_실패한다() {
+            // given
+            Member member = getMember();
+            member.getRequirement().verifyDiscord();
+            member.getRequirement().updatePaymentStatus(VERIFIED);
+            member.getRequirement().verifyBevy();
+
+            // when
+            Page<Member> members = memberRepository.findAllGrantable(EMPTY_QUERY_OPTION, PageRequest.of(0, 10));
+
+            // then
+            assertThat(members).doesNotContain(member);
+        }
+
+        @Test
+        void 디스코드_인증_미완료시_조회_실패한다() {
+            // given
+            Member member = getMember();
+            member.getRequirement().updateUnivStatus(VERIFIED);
+            member.getRequirement().updatePaymentStatus(VERIFIED);
+            member.getRequirement().verifyBevy();
+
+            // when
+            Page<Member> members = memberRepository.findAllGrantable(EMPTY_QUERY_OPTION, PageRequest.of(0, 10));
+
+            // then
+            assertThat(members).doesNotContain(member);
+        }
+
+        @Test
+        void 회비납부_미완료시_조회_실패한다() {
+            // given
+            Member member = getMember();
+            member.getRequirement().updateUnivStatus(VERIFIED);
+            member.getRequirement().verifyDiscord();
+            member.getRequirement().verifyBevy();
+
+            // when
+            Page<Member> members = memberRepository.findAllGrantable(EMPTY_QUERY_OPTION, PageRequest.of(0, 10));
+
+            // then
+            assertThat(members).doesNotContain(member);
+        }
+
+        @Test
+        void Bevy_연동_미완료시_조회_실패한다() {
+            // given
+            Member member = getMember();
+            member.getRequirement().updateUnivStatus(VERIFIED);
+            member.getRequirement().verifyDiscord();
+            member.getRequirement().updatePaymentStatus(VERIFIED);
+
+            // when
+            Page<Member> members = memberRepository.findAllGrantable(EMPTY_QUERY_OPTION, PageRequest.of(0, 10));
+
+            // then
+            assertThat(members).doesNotContain(member);
+        }
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #292 

## 📌 작업 내용 및 특이사항
- `findAllGrantable` 메서드에 대한 테스트를 아래 case에 따라 작성했습니다.
   - 모든 가입조건을 충족한 경우
   - 하나만을 미충족한 경우
      - 디스코드만 인증되지 않은 경우
      - 재학생 여부만 인증되지 않은 경우
      - 회비 납부 여부만 확인되지 않은 경우
      - Bevy 연동만 확인되지 않은 경우
## 📝 참고사항
-

## 📚 기타
- 최초에 이슈를 너무 크게 생성한 것 같아서 PR 크기를 줄이고자 이슈 크기를 줄였습니다.
