### PR TITLE
refactor: findNormalByOauthId 메서드를 쿼리 메서드로 대체

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
@@ -7,13 +7,10 @@ import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryOption;
 import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface MemberCustomRepository {
-    Optional<Member> findNormalByOauthId(String oauthId);
-
     Page<Member> findAllGrantable(MemberQueryOption queryOption, Pageable pageable);
 
     Page<Member> findAllByRole(MemberQueryOption queryOption, Pageable pageable, @Nullable MemberRole role);

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,12 +23,6 @@ import org.springframework.data.support.PageableExecutionUtils;
 public class MemberCustomRepositoryImpl extends MemberQueryMethod implements MemberCustomRepository {
 
     private final JPAQueryFactory queryFactory;
-
-    @Override
-    public Optional<Member> findNormalByOauthId(String oauthId) {
-        return Optional.ofNullable(
-                queryFactory.selectFrom(member).where(eqOauthId(oauthId)).fetchOne());
-    }
 
     @Override
     public Page<Member> findAllGrantable(MemberQueryOption queryOption, Pageable pageable) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
@@ -13,5 +13,7 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberCus
 
     Optional<Member> findByUnivEmail(String univEmail);
 
+    Optional<Member> findByOauthId(String oauthId);
+
     Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/gdschongik/gdsc/global/security/CustomUserService.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/CustomUserService.java
@@ -29,7 +29,7 @@ public class CustomUserService extends DefaultOAuth2UserService {
     }
 
     private Member fetchOrCreate(OAuth2User oAuth2User) {
-        return memberRepository.findNormalByOauthId(oAuth2User.getName()).orElseGet(() -> registerMember(oAuth2User));
+        return memberRepository.findByOauthId(oAuth2User.getName()).orElseGet(() -> registerMember(oAuth2User));
     }
 
     private Member registerMember(OAuth2User oAuth2User) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #299

## 📌 작업 내용 및 특이사항
- `@SQLRestriction` 도입으로 querydsl 사용이 무의미해진 메서드를 쿼리 메서드로 대체했습니다.

## 📝 참고사항
-

## 📚 기타
-
