### PR TITLE
test: SQLRestriction에 대한 테스트 추가

### DIFF
--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -28,7 +28,7 @@ class MemberRepositoryTest extends RepositoryTest {
     }
 
     @Nested
-    class 승인_가능_멤버_조회 {
+    class 승인_가능_멤버를_조회할때 {
 
         @Test
         void 가입조건_모두_충족했다면_조회_성공한다() {
@@ -108,7 +108,7 @@ class MemberRepositoryTest extends RepositoryTest {
     }
 
     @Nested
-    class 멤버_상태에_따른_조회 {
+    class 멤버_상태로_조회할때 {
         @Test
         void NORMAL이라면_조회_성공한다() {
             // given

--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.*;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryOption;
 import com.gdschongik.gdsc.repository.RepositoryTest;
+import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -100,6 +101,34 @@ class MemberRepositoryTest extends RepositoryTest {
 
             // when
             Page<Member> members = memberRepository.findAllGrantable(EMPTY_QUERY_OPTION, PageRequest.of(0, 10));
+
+            // then
+            assertThat(members).doesNotContain(member);
+        }
+    }
+
+    @Nested
+    class 멤버_상태에_따른_조회 {
+        @Test
+        void NORMAL이라면_조회_성공한다() {
+            // given
+            Member member = getMember();
+
+            // when
+            List<Member> members = memberRepository.findAll();
+
+            // then
+            assertThat(members).contains(member);
+        }
+
+        @Test
+        void DELETED라면_조회되지_않는다() {
+            // given
+            Member member = getMember();
+            member.withdraw();
+
+            // when
+            List<Member> members = memberRepository.findAll();
 
             // then
             assertThat(members).doesNotContain(member);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #298

## 📌 작업 내용 및 특이사항
- `@SQLRestriction`에 따라 `MemberStatus.NORMAL`인 회원만 조회되어야 하므로 이에 대한 테스트를 작성했습니다.
- 모든 조회 메서드에 대해 테스트를 하는 것은 비효율적이므로 `findAll` 메서드에 대해서만 테스트를 작성했습니다.
- 멤버 상태를 `MemberStatus.FORBIDDEN`으로 바꾸는 도메인 메서드가 없기 때문에 이에 대한 테스트는 작성하지 않았습니다. 향후 메서드가 구현되면 테스트를 작성하면 좋을 것 같습니다.

## 📝 참고사항
-

## 📚 기타
-
