### PR TITLE
chore: setup-gradle 업그레이드 대응

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -52,8 +52,8 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
           add-job-summary-as-pr-comment: always
           build-scan-publish: true
-          build-scan-terms-of-service-url: "https://gradle.com/terms-of-service"
-          build-scan-terms-of-service-agree: "yes"
+          build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
+          build-scan-terms-of-use-agree: "yes"
 
       # Dockerhub 로그인
       - name: Login to Dockerhub

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -41,19 +41,19 @@ jobs:
         run: docker-compose -f ./docker-compose-test.yaml up -d
 
       # Gradle 빌드
-      - name: Build with Gradle
+      - name: Setup Gradle
         id: gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          arguments: |
-            build
-            --configuration-cache
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }} # feature 브랜치는 캐시를 읽기 전용으로 설정
           cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
           add-job-summary-as-pr-comment: always
           build-scan-publish: true
           build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
           build-scan-terms-of-use-agree: "yes"
+
+      - name: Build with Gradle
+        run: ./gradlew build --configuration-cache
 
       # Dockerhub 로그인
       - name: Login to Dockerhub

--- a/.github/workflows/production_build_deploy.yml
+++ b/.github/workflows/production_build_deploy.yml
@@ -45,19 +45,19 @@ jobs:
         run: docker-compose -f ./docker-compose-test.yaml up -d
 
       # Gradle 빌드
-      - name: Build with Gradle
+      - name: Setup Gradle
         id: gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          arguments: |
-            build
-            --configuration-cache
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }} # feature 브랜치는 캐시를 읽기 전용으로 설정
           cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
           add-job-summary-as-pr-comment: always
           build-scan-publish: true
           build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
           build-scan-terms-of-use-agree: "yes"
+
+      - name: Build with Gradle
+        run: ./gradlew build --configuration-cache
 
       # Dockerhub 로그인
       - name: Login to Dockerhub

--- a/.github/workflows/production_build_deploy.yml
+++ b/.github/workflows/production_build_deploy.yml
@@ -56,8 +56,8 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
           add-job-summary-as-pr-comment: always
           build-scan-publish: true
-          build-scan-terms-of-service-url: "https://gradle.com/terms-of-service"
-          build-scan-terms-of-service-agree: "yes"
+          build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
+          build-scan-terms-of-use-agree: "yes"
 
       # Dockerhub 로그인
       - name: Login to Dockerhub

--- a/.github/workflows/pull_request_gradle_build.yml
+++ b/.github/workflows/pull_request_gradle_build.yml
@@ -39,5 +39,5 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
           add-job-summary-as-pr-comment: always
           build-scan-publish: true
-          build-scan-terms-of-service-url: "https://gradle.com/terms-of-service"
-          build-scan-terms-of-service-agree: "yes"
+          build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
+          build-scan-terms-of-use-agree: "yes"

--- a/.github/workflows/pull_request_gradle_build.yml
+++ b/.github/workflows/pull_request_gradle_build.yml
@@ -28,16 +28,16 @@ jobs:
       - name: Start containers
         run: docker-compose -f ./docker-compose-test.yaml up -d
 
-      - name: Build with Gradle
+      - name: Setup Gradle
         id: gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          arguments: |
-            check
-            --configuration-cache
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }} # feature 브랜치는 캐시를 읽기 전용으로 설정
           cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
           add-job-summary-as-pr-comment: always
           build-scan-publish: true
           build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
           build-scan-terms-of-use-agree: "yes"
+
+      - name: Check with Gradle
+        run: ./gradlew check --configuration-cache


### PR DESCRIPTION
## 🌱 관련 이슈
- close #308

## 📌 작업 내용 및 특이사항
- [Using the action to execute Gradle via the `arguments` parameter is deprecated](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated)
   - setup-gradle에서 argument로 test, build, check 등을 할 수 있었지만, v4부터는 argument가 deprecate되므로 `./gradlew build`와 같이 별도의 단계로 분리했습니다.
-  [The `build-scan-terms-of-service` input parameters have been renamed](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-build-scan-terms-of-service-input-parameters-have-been-renamed)
   - setup-gradle 액션의 parameter 중 rename된 것들을 수정했습니다. 'service'가 'use'로 rename 되었습니다.

## 📝 참고사항
- <https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-build-scan-terms-of-service-input-parameters-have-been-renamed>

## 📚 기타
-
