### PR TITLE
chore: id를 빌드 단계로 이동

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -42,7 +42,6 @@ jobs:
 
       # Gradle 빌드
       - name: Setup Gradle
-        id: gradle
         uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }} # feature 브랜치는 캐시를 읽기 전용으로 설정
@@ -53,6 +52,7 @@ jobs:
           build-scan-terms-of-use-agree: "yes"
 
       - name: Build with Gradle
+        id: gradle
         run: ./gradlew build --configuration-cache
 
       # Dockerhub 로그인

--- a/.github/workflows/production_build_deploy.yml
+++ b/.github/workflows/production_build_deploy.yml
@@ -46,7 +46,6 @@ jobs:
 
       # Gradle 빌드
       - name: Setup Gradle
-        id: gradle
         uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }} # feature 브랜치는 캐시를 읽기 전용으로 설정
@@ -57,6 +56,7 @@ jobs:
           build-scan-terms-of-use-agree: "yes"
 
       - name: Build with Gradle
+        id: gradle
         run: ./gradlew build --configuration-cache
 
       # Dockerhub 로그인


### PR DESCRIPTION
## 🌱 관련 이슈
- close #311

## 📌 작업 내용 및 특이사항
- build-scan-report가 생성은 되는데 슬랙으로 전송되지 않는 문제였습니다.
- Issue #308 에서 빌드를 Setup 단계와 분리했으므로 build-scan-report도 분리된 빌드 단계에서 생성됩니다. 이에 따라 `id: gradle`을 `Build with Gradle` 단계로 옮겼습니다.

## 📝 참고사항
-

## 📚 기타
-
