### PR TITLE
test: MemberRole에 대한 멤버 레포지토리 테스트

### DIFF
--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -29,6 +29,11 @@ class MemberRepositoryTest extends RepositoryTest {
         return memberRepository.save(member);
     }
 
+    private void flushAndClear() {
+        testEntityManager.flush();
+        testEntityManager.clear();
+    }
+
     @Nested
     class 승인_가능_멤버를_조회할때 {
 
@@ -154,10 +159,12 @@ class MemberRepositoryTest extends RepositoryTest {
             member.signup(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
 
             // when
+            flushAndClear();
             Page<Member> members = memberRepository.findAllByRole(EMPTY_QUERY_OPTION, PageRequest.of(0, 10), GUEST);
 
             // then
-            assertThat(members).contains(member);
+            Member guest = memberRepository.findById(1L).get();
+            assertThat(members).contains(guest);
         }
 
         @Test
@@ -168,10 +175,12 @@ class MemberRepositoryTest extends RepositoryTest {
             member.signup(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
 
             // when
+            flushAndClear();
             Page<Member> members = memberRepository.findAllByRole(EMPTY_QUERY_OPTION, PageRequest.of(0, 10), USER);
 
             // then
-            assertThat(members).doesNotContain(member);
+            Member guest = memberRepository.findById(1L).get();
+            assertThat(members).doesNotContain(guest);
         }
 
         @Test
@@ -186,10 +195,12 @@ class MemberRepositoryTest extends RepositoryTest {
             member.grant();
 
             // when
+            flushAndClear();
             Page<Member> members = memberRepository.findAllByRole(EMPTY_QUERY_OPTION, PageRequest.of(0, 10), USER);
 
             // then
-            assertThat(members).contains(member);
+            Member user = memberRepository.findById(1L).get();
+            assertThat(members).contains(user);
         }
 
         @Test
@@ -204,10 +215,12 @@ class MemberRepositoryTest extends RepositoryTest {
             member.grant();
 
             // when
+            flushAndClear();
             Page<Member> members = memberRepository.findAllByRole(EMPTY_QUERY_OPTION, PageRequest.of(0, 10), GUEST);
 
             // then
-            assertThat(members).doesNotContain(member);
+            Member user = memberRepository.findById(1L).get();
+            assertThat(members).doesNotContain(user);
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -29,7 +29,7 @@ class MemberRepositoryTest extends RepositoryTest {
         return memberRepository.save(member);
     }
 
-    private void flushAndClear() {
+    private void flushAndClearBeforeExecute() {
         testEntityManager.flush();
         testEntityManager.clear();
     }
@@ -158,8 +158,9 @@ class MemberRepositoryTest extends RepositoryTest {
             member.completeUnivEmailVerification(UNIV_EMAIL);
             member.signup(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
 
+            flushAndClearBeforeExecute();
+
             // when
-            flushAndClear();
             Page<Member> members = memberRepository.findAllByRole(EMPTY_QUERY_OPTION, PageRequest.of(0, 10), GUEST);
 
             // then
@@ -174,8 +175,9 @@ class MemberRepositoryTest extends RepositoryTest {
             member.completeUnivEmailVerification(UNIV_EMAIL);
             member.signup(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
 
+            flushAndClearBeforeExecute();
+
             // when
-            flushAndClear();
             Page<Member> members = memberRepository.findAllByRole(EMPTY_QUERY_OPTION, PageRequest.of(0, 10), USER);
 
             // then
@@ -194,8 +196,9 @@ class MemberRepositoryTest extends RepositoryTest {
             member.verifyBevy();
             member.grant();
 
+            flushAndClearBeforeExecute();
+
             // when
-            flushAndClear();
             Page<Member> members = memberRepository.findAllByRole(EMPTY_QUERY_OPTION, PageRequest.of(0, 10), USER);
 
             // then
@@ -214,8 +217,9 @@ class MemberRepositoryTest extends RepositoryTest {
             member.verifyBevy();
             member.grant();
 
+            flushAndClearBeforeExecute();
+
             // when
-            flushAndClear();
             Page<Member> members = memberRepository.findAllByRole(EMPTY_QUERY_OPTION, PageRequest.of(0, 10), GUEST);
 
             // then

--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -1,5 +1,7 @@
 package com.gdschongik.gdsc.domain.member.dao;
 
+import static com.gdschongik.gdsc.domain.member.domain.Department.*;
+import static com.gdschongik.gdsc.domain.member.domain.MemberRole.*;
 import static com.gdschongik.gdsc.domain.member.domain.RequirementStatus.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -129,6 +131,80 @@ class MemberRepositoryTest extends RepositoryTest {
 
             // when
             List<Member> members = memberRepository.findAll();
+
+            // then
+            assertThat(members).doesNotContain(member);
+        }
+    }
+
+    @Nested
+    class 역할로_조회할때 {
+        private static final String UNIV_EMAIL = "test@g.hongik.ac.kr";
+        private static final String DISCORD_USERNAME = "testDiscord";
+        private static final String NICKNAME = "testNickname";
+        private static final String NAME = "김홍익";
+        private static final String STUDENT_ID = "C123456";
+        private static final String PHONE_NUMBER = "01012345678";
+
+        @Test
+        void 승인전이라면_GUEST로_조회된다() {
+            // given
+            Member member = getMember();
+            member.completeUnivEmailVerification(UNIV_EMAIL);
+            member.signup(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
+
+            // when
+            Page<Member> members = memberRepository.findAllByRole(EMPTY_QUERY_OPTION, PageRequest.of(0, 10), GUEST);
+
+            // then
+            assertThat(members).contains(member);
+        }
+
+        @Test
+        void 승인전이라면_USER로_조회되지_않는다() {
+            // given
+            Member member = getMember();
+            member.completeUnivEmailVerification(UNIV_EMAIL);
+            member.signup(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
+
+            // when
+            Page<Member> members = memberRepository.findAllByRole(EMPTY_QUERY_OPTION, PageRequest.of(0, 10), USER);
+
+            // then
+            assertThat(members).doesNotContain(member);
+        }
+
+        @Test
+        void 승인후라면_USER로_조회된다() {
+            // given
+            Member member = getMember();
+            member.completeUnivEmailVerification(UNIV_EMAIL);
+            member.signup(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
+            member.updatePaymentStatus(VERIFIED);
+            member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
+            member.verifyBevy();
+            member.grant();
+
+            // when
+            Page<Member> members = memberRepository.findAllByRole(EMPTY_QUERY_OPTION, PageRequest.of(0, 10), USER);
+
+            // then
+            assertThat(members).contains(member);
+        }
+
+        @Test
+        void 승인후라면_GUEST로_조회되지_않는다() {
+            // given
+            Member member = getMember();
+            member.completeUnivEmailVerification(UNIV_EMAIL);
+            member.signup(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
+            member.updatePaymentStatus(VERIFIED);
+            member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
+            member.verifyBevy();
+            member.grant();
+
+            // when
+            Page<Member> members = memberRepository.findAllByRole(EMPTY_QUERY_OPTION, PageRequest.of(0, 10), GUEST);
 
             // then
             assertThat(members).doesNotContain(member);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #310 

## 📌 작업 내용 및 특이사항
- MemberRole에 대한 레포지토리 테스트를 작성했습니다.
- 승인 전과 후의 상황에 대해서, GUEST와 USER로 조회하는 상황을 테스트합니다.

## 📝 참고사항
```java
private static final String UNIV_EMAIL = "test@g.hongik.ac.kr";
private static final String DISCORD_USERNAME = "testDiscord";
private static final String NICKNAME = "testNickname";
private static final String NAME = "김홍익";
private static final String STUDENT_ID = "C123456";
private static final String PHONE_NUMBER = "01012345678";
```
- 멤버 토메인 테스트에서도 사용하는 상수들을 레포지토리 테스트에서도 똑같이 사용해야 합니다.
각 테스트에서 상수를 정의하기 보다는 상수 클래스를 활용하는 것이 좋을 것 같아, 
Issue #313 을 열었습니다.
## 📚 기타
-
