### PR TITLE
feat: 가입 승인 시 자동으로 디스코드 역할을 부여하도록 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/common/model/BaseTimeEntity.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/model/BaseTimeEntity.java
@@ -7,12 +7,13 @@ import java.time.LocalDateTime;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.domain.AbstractAggregateRoot;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseTimeEntity {
+public abstract class BaseTimeEntity extends AbstractAggregateRoot<BaseTimeEntity> {
 
     @Column(updatable = false)
     @CreatedDate

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/DiscordEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/DiscordEventHandler.java
@@ -4,6 +4,5 @@ import net.dv8tion.jda.api.events.GenericEvent;
 
 public interface DiscordEventHandler {
 
-    // TODO: GenericEvent에 대한 어댑터 추가
     void delegate(GenericEvent genericEvent);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/JoinCommandHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/JoinCommandHandler.java
@@ -14,6 +14,7 @@ import net.dv8tion.jda.api.events.GenericEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import org.springframework.stereotype.Component;
 
+@Deprecated
 @Component
 @RequiredArgsConstructor
 public class JoinCommandHandler implements DiscordEventHandler {

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/MemberGrantEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/MemberGrantEventHandler.java
@@ -1,0 +1,28 @@
+package com.gdschongik.gdsc.domain.discord.application.handler;
+
+import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.*;
+
+import com.gdschongik.gdsc.domain.member.domain.MemberGrantEvent;
+import com.gdschongik.gdsc.global.util.DiscordUtil;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberGrantEventHandler implements SpringEventHandler {
+
+    private final DiscordUtil discordUtil;
+
+    @Override
+    public void delegate(Object context) {
+        MemberGrantEvent event = (MemberGrantEvent) context;
+        Guild guild = discordUtil.getCurrentGuild();
+        Member member = guild.getMemberById(event.discordUsername());
+        Role role = discordUtil.findRoleByName(MEMBER_ROLE_NAME);
+
+        guild.addRoleToMember(member, role).queue();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/MemberGrantEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/MemberGrantEventHandler.java
@@ -3,6 +3,8 @@ package com.gdschongik.gdsc.domain.discord.application.handler;
 import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.*;
 
 import com.gdschongik.gdsc.domain.member.domain.MemberGrantEvent;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.global.util.DiscordUtil;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.entities.Guild;
@@ -20,7 +22,8 @@ public class MemberGrantEventHandler implements SpringEventHandler {
     public void delegate(Object context) {
         MemberGrantEvent event = (MemberGrantEvent) context;
         Guild guild = discordUtil.getCurrentGuild();
-        Member member = guild.getMemberById(event.discordUsername());
+        // TODO: 이름이 아닌 ID로 찾기 위해 전체 멤버의 디스코드 사용자 ID를 저장해야 함
+        Member member = discordUtil.getMemberByUsername(event.discordUsername());
         Role role = discordUtil.findRoleByName(MEMBER_ROLE_NAME);
 
         guild.addRoleToMember(member, role).queue();

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/MemberGrantEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/MemberGrantEventHandler.java
@@ -3,8 +3,6 @@ package com.gdschongik.gdsc.domain.discord.application.handler;
 import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.*;
 
 import com.gdschongik.gdsc.domain.member.domain.MemberGrantEvent;
-import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.global.util.DiscordUtil;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.entities.Guild;

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/SpringEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/SpringEventHandler.java
@@ -1,0 +1,6 @@
+package com.gdschongik.gdsc.domain.discord.application.handler;
+
+public interface SpringEventHandler {
+
+    void delegate(Object context);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/JoinCommandListener.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/JoinCommandListener.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
+@Deprecated
 @Listener
 @RequiredArgsConstructor
 public class JoinCommandListener extends ListenerAdapter {

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/MemberGrantEventListener.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/MemberGrantEventListener.java
@@ -1,0 +1,21 @@
+package com.gdschongik.gdsc.domain.discord.application.listener;
+
+import com.gdschongik.gdsc.domain.discord.application.DiscordClientService;
+import com.gdschongik.gdsc.domain.member.domain.MemberGrantEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberGrantEventListener {
+
+    private final DiscordClientService discordClientService;
+
+    @TransactionalEventListener(MemberGrantEvent.class)
+    public void handleMemberGrantEvent(MemberGrantEvent event) {
+        discordClientService.assignMemberRole(event);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/MemberGrantEventListener.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/MemberGrantEventListener.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.discord.application.listener;
 
-import com.gdschongik.gdsc.domain.discord.application.DiscordClientService;
+import com.gdschongik.gdsc.domain.discord.application.handler.MemberGrantEventHandler;
 import com.gdschongik.gdsc.domain.member.domain.MemberGrantEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,10 +12,10 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class MemberGrantEventListener {
 
-    private final DiscordClientService discordClientService;
+    private final MemberGrantEventHandler memberGrantEventHandler;
 
     @TransactionalEventListener(MemberGrantEvent.class)
     public void handleMemberGrantEvent(MemberGrantEvent event) {
-        discordClientService.assignMemberRole(event);
+        memberGrantEventHandler.delegate(event);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/exception/DiscordEventHandlerAspect.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/exception/DiscordEventHandlerAspect.java
@@ -17,8 +17,6 @@ public class DiscordEventHandlerAspect {
     @Around(
             "execution(* com.gdschongik.gdsc.domain.discord.application.handler.DiscordEventHandler.delegate(*)) && args(genericEvent)")
     public Object doAround(ProceedingJoinPoint joinPoint, GenericEvent genericEvent) throws Throwable {
-        // TODO: 외부 의존성인 디스코드 클래스에 대한 어댑터 추가
-
         try {
             return joinPoint.proceed();
         } catch (Exception e) {

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/exception/SpringEventHandlerAspect.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/exception/SpringEventHandlerAspect.java
@@ -2,12 +2,14 @@ package com.gdschongik.gdsc.domain.discord.exception;
 
 import com.gdschongik.gdsc.global.util.DiscordUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Aspect
 @Component
 @RequiredArgsConstructor
@@ -15,12 +17,13 @@ public class SpringEventHandlerAspect {
 
     private final DiscordUtil discordUtil;
 
-	@Around(
+    @Around(
             "execution(* com.gdschongik.gdsc.domain.discord.application.handler.SpringEventHandler.delegate(*)) && args(ignoredContext)")
     public Object doAround(ProceedingJoinPoint joinPoint, Object ignoredContext) throws Throwable {
         try {
             return joinPoint.proceed();
         } catch (Exception e) {
+            log.error("[SpringEventHandlerAspect] Exception occurred in SpringEventHandler", e);
             sendErrorMessageToDiscord(e);
             return null;
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/exception/SpringEventHandlerAspect.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/exception/SpringEventHandlerAspect.java
@@ -1,0 +1,33 @@
+package com.gdschongik.gdsc.domain.discord.exception;
+
+import com.gdschongik.gdsc.global.util.DiscordUtil;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class SpringEventHandlerAspect {
+
+    private final DiscordUtil discordUtil;
+
+	@Around(
+            "execution(* com.gdschongik.gdsc.domain.discord.application.handler.SpringEventHandler.delegate(*)) && args(ignoredContext)")
+    public Object doAround(ProceedingJoinPoint joinPoint, Object ignoredContext) throws Throwable {
+        try {
+            return joinPoint.proceed();
+        } catch (Exception e) {
+            sendErrorMessageToDiscord(e);
+            return null;
+        }
+    }
+
+    private void sendErrorMessageToDiscord(Exception e) {
+        TextChannel channel = discordUtil.getAdminChannel();
+        channel.sendMessage(e.getMessage()).queue();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -67,6 +67,7 @@ public class AdminMemberService {
         Map<Boolean, List<Member>> classifiedMember = memberRepository.groupByVerified(request.memberIdList());
         List<Member> verifiedMembers = classifiedMember.get(true);
         verifiedMembers.forEach(Member::grant);
+        memberRepository.saveAll(verifiedMembers); // explicitly save to publish event
         return MemberGrantResponse.from(classifiedMember);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -176,6 +176,7 @@ public class Member extends BaseTimeEntity {
         validateGrantAvailable();
 
         this.role = USER;
+        registerEvent(new MemberGrantEvent(discordUsername, nickname));
     }
 
     /**

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberGrantEvent.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberGrantEvent.java
@@ -1,0 +1,3 @@
+package com.gdschongik.gdsc.domain.member.domain;
+
+public record MemberGrantEvent(String discordUsername, String nickname) {}

--- a/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
@@ -13,6 +13,7 @@ import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.requests.GatewayIntent;
+import net.dv8tion.jda.api.utils.ChunkingFilter;
 import net.dv8tion.jda.api.utils.MemberCachePolicy;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -33,6 +34,7 @@ public class DiscordConfig {
         JDA jda = JDABuilder.createDefault(discordProperty.getToken())
                 .setActivity(Activity.playing(DISCORD_BOT_STATUS_CONTENT))
                 .enableIntents(GatewayIntent.GUILD_MESSAGES, GatewayIntent.MESSAGE_CONTENT, GatewayIntent.GUILD_MEMBERS)
+                .setChunkingFilter(ChunkingFilter.ALL)
                 .setMemberCachePolicy(MemberCachePolicy.ALL)
                 .build();
 

--- a/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
@@ -54,13 +54,13 @@ public class DiscordConfig {
 
     @Bean
     @ConditionalOnBean(JDA.class)
-    public DiscordUtil discordUtil(JDA jda) {
-        return new DiscordUtil(jda);
+    public DiscordUtil discordUtil(JDA jda, DiscordProperty discordProperty) {
+        return new DiscordUtil(jda, discordProperty);
     }
 
     @Bean
     @Order(1)
     public DiscordUtil fallbackDiscordUtil() {
-        return new DiscordUtil(null);
+        return new DiscordUtil(null, null);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
     DISCORD_ROLE_NOT_FOUND(HttpStatus.NOT_FOUND, "디스코드 역할을 찾을 수 없습니다."),
     DISCORD_NOT_SIGNUP(HttpStatus.INTERNAL_SERVER_ERROR, "아직 가입신청서를 작성하지 않은 회원입니다."),
     DISCORD_NICKNAME_NOTNULL(HttpStatus.INTERNAL_SERVER_ERROR, "닉네임은 빈 값이 될 수 없습니다."),
+    DISCORD_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "디스코드 멤버를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/gdschongik/gdsc/global/property/DiscordProperty.java
+++ b/src/main/java/com/gdschongik/gdsc/global/property/DiscordProperty.java
@@ -12,4 +12,5 @@ public class DiscordProperty {
     private final String token;
     private final String serverId;
     private final String commandChannelId;
+    private final String adminChannelId;
 }

--- a/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
@@ -2,18 +2,30 @@ package com.gdschongik.gdsc.global.util;
 
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
+import com.gdschongik.gdsc.global.property.DiscordProperty;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 
 @RequiredArgsConstructor
 public class DiscordUtil {
 
     private final JDA jda;
+    private final DiscordProperty discordProperty;
 
     public Role findRoleByName(String roleName) {
         return jda.getRolesByName(roleName, true).stream()
                 .findFirst()
                 .orElseThrow(() -> new CustomException(ErrorCode.DISCORD_ROLE_NOT_FOUND));
+    }
+
+    public Guild getCurrentGuild() {
+        return jda.getGuildById(discordProperty.getServerId());
+    }
+
+    public TextChannel getAdminChannel() {
+        return jda.getTextChannelById(discordProperty.getAdminChannelId());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
@@ -6,6 +6,7 @@ import com.gdschongik.gdsc.global.property.DiscordProperty;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 
@@ -27,5 +28,11 @@ public class DiscordUtil {
 
     public TextChannel getAdminChannel() {
         return jda.getTextChannelById(discordProperty.getAdminChannelId());
+    }
+
+    public Member getMemberByUsername(String username) {
+        return getCurrentGuild().getMembersByName(username, true).stream()
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.DISCORD_MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/resources/application-discord.yml
+++ b/src/main/resources/application-discord.yml
@@ -2,3 +2,4 @@ discord:
   token: ${DISCORD_BOT_TOKEN:}
   server-id: ${DISCORD_SERVER_ID:}
   command-channel-id: ${DISCORD_COMMAND_CHANNEL_ID:}
+  admin-channel-id: ${DISCORD_ADMIN_CHANNEL_ID:}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #303

## 📌 작업 내용 및 특이사항
(분량 조절에 실패했습니다 죄송합니다 흑흑ㅠ)

- 이번 작업의 핵심은 유저가 직접 `/가입하기` 명령어를 입력하는 대신, 어드민에서 승인하면 자동으로 디스코드 역할을 부여하게 만드는 것입니다.
- `어드민에서 가입승인하기` 와 `디스코드에서 역할부여하기` 라는 두 로직이 하나의 서비스 메서드에 위치하게 되는 경우, 아래와 같은 문제가 있습니다.
    1) 서로 관련없는 서비스 간 결합도가 증가합니다.
    2) 디스코드에서 예외가 발생했을 때 트랜잭션이 롤백되어 가입승인이 취소되는 문제가 발생합니다.
- 이를 해결하기 위해 '멤버 가입승인 이벤트'를 발행하고 -> 이벤트 리스너에서 디스코드 역할부여를 수행하는 식으로 두 로직이 느슨하게 결합될 수 있도록 만들었습니다.
- 먼저 Spring Data JPA에서 제공하는`AbstractAggregateRoot` 를 사용하여 멤버 가입승인 이벤트를 발행하도록 했습니다.
    - ApplicationEventPublisher를 사용하여 서비스 레이어에서 이벤트를 발행해도 되지만, 멤버 도메인 객체가 승인될 때 승인 이벤트에 대한 발행 책임까지 가지는 편이 도메인 일관성 측면에서 적합하다 판단했습니다.
    - 단 AbstractAggregateRoot에서 등록한 이벤트를 처리하기 위해서는 명시적으로 `repository.save()` 를 호출해줘야 합니다.
 
---

- 디스코드 패키지의 이벤트 리스너 - 핸들러 구조는 JDA 이벤트에 한정되어 있었고, 때문에 JDA의 `GenericEvent` 를 인자로 받고 있었습니다.
- 하지만 이번 요구사항으로 스프링 이벤트 역시 처리할 수 있어야 하게 되었고, 디스코드 이벤트 <-> 스프링 이벤트 둘을 구분할 필요성이 생겼습니다.
- 리스너의 경우 별다른 방법이 없어서 `@Listener` 어노테이션이 달린 것과 `@TransactionEventListener` 가 달린 메서드를 가진 것 둘로 구분하여 이해하면 되고, 핸들러의 경우 디스코드 핸들러가 `GenericEvent` 를 인자로 받기 때문에 스프링 이벤트 핸들러를 별도로 만들어줘야 합니다. (리스너의 경우 핸들러처럼 명확하게 구분되지 않는 점이 마음에 안들긴 하지만... 추후 개선해보도록 하겠습니다)
- 따라서 `DiscordEventHandler` 와 구분되는 `SpringEventHandler` 인터페이스를 만들고 이를 구현하도록 했습니다.
- 한편 디스코드 이벤트 핸들러에서 발생하는 예외를 AOP로 캐치하여 처리하는 `DiscordEventHandlerAspect` 에 대응되는 `SpringEventHandlerAspect` 도 만들어주었습니다. 스프링 이벤트 역시 디스코드 이벤트처럼 예외를 json 응답으로 내려줄 수 없기 때문에 별도의 처리기가 필요하고, 이 경우 디스코드 어드민 채널로 예외를 발송하도록 구현했습니다.

## 📝 참고사항 
- `/가입하기` 기능에 해당하는 `JoinCommandListener` 와 `JoinCommandHandler` 는 당장 제거하지 않고 deprecated 처리해두었습니다.

## 📚 기타
-
