### PR TITLE
feat: application 도메인 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/application/application/ApplicationService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/application/application/ApplicationService.java
@@ -1,0 +1,14 @@
+package com.gdschongik.gdsc.domain.application.application;
+
+import com.gdschongik.gdsc.domain.application.dao.ApplicationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ApplicationService {
+
+    private final ApplicationRepository applicationRepository;
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/application/dao/ApplicationRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/application/dao/ApplicationRepository.java
@@ -1,0 +1,6 @@
+package com.gdschongik.gdsc.domain.application.dao;
+
+import com.gdschongik.gdsc.domain.application.domain.Application;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicationRepository extends JpaRepository<Application, Long> {}

--- a/src/main/java/com/gdschongik/gdsc/domain/application/domain/Application.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/application/domain/Application.java
@@ -11,6 +11,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -28,6 +29,7 @@ public class Application extends BaseTermEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
     private Member member;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/gdschongik/gdsc/domain/application/domain/Application.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/application/domain/Application.java
@@ -38,4 +38,11 @@ public class Application extends BaseTermEntity {
         this.member = member;
         this.paymentStatus = paymentStatus;
     }
+
+    public static Application createApplication(Member member) {
+        return Application.builder()
+                .member(member)
+                .paymentStatus(RequirementStatus.PENDING)
+                .build();
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/application/domain/Application.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/application/domain/Application.java
@@ -1,0 +1,41 @@
+package com.gdschongik.gdsc.domain.application.domain;
+
+import com.gdschongik.gdsc.domain.common.model.BaseTermEntity;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.RequirementStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Application extends BaseTermEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "application_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    private RequirementStatus paymentStatus;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Application(Member member, RequirementStatus paymentStatus) {
+        this.member = member;
+        this.paymentStatus = paymentStatus;
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/common/model/BaseTermEntity.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/model/BaseTermEntity.java
@@ -5,7 +5,6 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @MappedSuperclass
@@ -17,12 +16,4 @@ public abstract class BaseTermEntity {
     @Column
     @Enumerated(EnumType.STRING)
     private Semester semester;
-
-    @RequiredArgsConstructor
-    public enum Semester {
-        FIRST("1학기"),
-        SECOND("2학기");
-
-        private final String value;
-    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/common/model/BaseTermEntity.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/model/BaseTermEntity.java
@@ -1,0 +1,25 @@
+package com.gdschongik.gdsc.domain.common.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseTermEntity {
+
+    @Column
+    private int year;
+
+    @Column
+    private int semester;
+
+    @RequiredArgsConstructor
+    enum Semester {
+        FIRST("1학기"),
+        SECOND("2학기");
+
+        private final String value;
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/common/model/BaseTermEntity.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/model/BaseTermEntity.java
@@ -1,6 +1,5 @@
 package com.gdschongik.gdsc.domain.common.model;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.MappedSuperclass;
@@ -10,10 +9,8 @@ import lombok.Getter;
 @MappedSuperclass
 public abstract class BaseTermEntity {
 
-    @Column
     private int year;
 
-    @Column
     @Enumerated(EnumType.STRING)
     private Semester semester;
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/common/model/BaseTermEntity.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/model/BaseTermEntity.java
@@ -1,6 +1,8 @@
 package com.gdschongik.gdsc.domain.common.model;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -13,10 +15,11 @@ public abstract class BaseTermEntity {
     private int year;
 
     @Column
-    private int semester;
+    @Enumerated(EnumType.STRING)
+    private Semester semester;
 
     @RequiredArgsConstructor
-    enum Semester {
+    public enum Semester {
         FIRST("1학기"),
         SECOND("2학기");
 

--- a/src/main/java/com/gdschongik/gdsc/domain/common/model/Semester.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/model/Semester.java
@@ -1,0 +1,13 @@
+package com.gdschongik.gdsc.domain.common.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Semester {
+    FIRST("1학기"),
+    SECOND("2학기");
+
+    private final String value;
+}

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -38,7 +38,6 @@ public enum ErrorCode {
     // Requirement
     UNIV_NOT_VERIFIED(HttpStatus.CONFLICT, "재학생 인증이 완료되지 않았습니다."),
     DISCORD_NOT_VERIFIED(HttpStatus.CONFLICT, "디스코드 인증이 완료되지 않았습니다."),
-    PAYMENT_NOT_VERIFIED(HttpStatus.CONFLICT, "회비 납부가 완료되지 않았습니다."),
     BEVY_NOT_VERIFIED(HttpStatus.CONFLICT, "GDSC Bevy 가입이 완료되지 않았습니다."),
 
     // Univ Email Verification
@@ -57,6 +56,9 @@ public enum ErrorCode {
     DISCORD_NOT_SIGNUP(HttpStatus.INTERNAL_SERVER_ERROR, "아직 가입신청서를 작성하지 않은 회원입니다."),
     DISCORD_NICKNAME_NOTNULL(HttpStatus.INTERNAL_SERVER_ERROR, "닉네임은 빈 값이 될 수 없습니다."),
     DISCORD_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "디스코드 멤버를 찾을 수 없습니다."),
+
+    // Application
+    PAYMENT_NOT_VERIFIED(HttpStatus.CONFLICT, "회비 납부가 완료되지 않았습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: "test"
 
   datasource:
-    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL;NON_KEYWORDS=YEAR
 
 discord:
   enabled: false


### PR DESCRIPTION
## 🌱 관련 이슈
- close #319

## 📌 작업 내용 및 특이사항
- application 엔티티, 서비스, 레포지토리를 생성했습니다.
   - 활동 기간을 나타내는 BaseTermEntity를  MappedSuperClass로 만들고 Application이 이를 상속하도록 했습니다.
   - BaseTermEntity의 Semester는 Enum 타입으로 만들어 넣었습니다.
- 테스트가 깨져서 원인을 파악해보니 h2에서 year가 예약이기 때문이었고, `application-test.yml`에서 year를 사용할 수 있도록 설정했습니다.

## 📝 참고사항
-

## 📚 기타
- service가 담기는 application 패키지와 이름이 같은게 좀 걸리네요.. 여전히 Application을 대체할 이름이 떠오르질 않는데 좋은 이름 생각나는게 있으신 분은 comment 남겨주세요!
