### PR TITLE
feat: 멤버 엔티티에 디스코드 ID 추가 및 기존 멤버 Batch

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/CommonDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/CommonDiscordService.java
@@ -11,6 +11,7 @@ import com.gdschongik.gdsc.global.util.DiscordUtil;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +27,7 @@ public class CommonDiscordService {
                 .orElse(null);
     }
 
+    @Transactional
     public void batchDiscordId(RequirementStatus discordStatus) {
         List<Member> discordVerifiedMembers = memberRepository.findAllByDiscordStatus(discordStatus);
 
@@ -34,8 +36,6 @@ public class CommonDiscordService {
             String discordId = discordUtil.getMemberIdByUsername(discordUsername);
             member.updateDiscordId(discordId);
         });
-
-        memberRepository.saveAll(discordVerifiedMembers);
     }
 
     public void checkPermissionForCommand(String discordUsername) {

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/CommonDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/CommonDiscordService.java
@@ -1,7 +1,14 @@
 package com.gdschongik.gdsc.domain.discord.application;
 
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.domain.member.domain.RequirementStatus;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.util.DiscordUtil;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,11 +17,34 @@ import org.springframework.stereotype.Service;
 public class CommonDiscordService {
 
     private final MemberRepository memberRepository;
+    private final DiscordUtil discordUtil;
 
     public String getNicknameByDiscordUsername(String discordUsername) {
         return memberRepository
                 .findByDiscordUsername(discordUsername)
                 .map(Member::getNickname)
                 .orElse(null);
+    }
+
+    public void batchDiscordId(RequirementStatus discordStatus) {
+        List<Member> discordVerifiedMembers = memberRepository.findAllByDiscordStatus(discordStatus);
+
+        discordVerifiedMembers.forEach(member -> {
+            String discordUsername = member.getDiscordUsername();
+            String discordId = discordUtil.getMemberIdByUsername(discordUsername);
+            member.updateDiscordId(discordId);
+        });
+
+        memberRepository.saveAll(discordVerifiedMembers);
+    }
+
+    public void checkPermissionForCommand(String discordUsername) {
+        Member member = memberRepository
+                .findByDiscordUsername(discordUsername)
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+        if (member.getRole() != MemberRole.ADMIN) {
+            throw new CustomException(INVALID_ROLE);
+        }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
@@ -11,6 +11,7 @@ import com.gdschongik.gdsc.domain.discord.dto.response.DiscordVerificationCodeRe
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.util.DiscordUtil;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.security.SecureRandom;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ public class OnboardingDiscordService {
 
     private final DiscordVerificationCodeRepository discordVerificationCodeRepository;
     private final MemberUtil memberUtil;
+    private final DiscordUtil discordUtil;
     private final MemberRepository memberRepository;
 
     @Transactional
@@ -63,6 +65,9 @@ public class OnboardingDiscordService {
 
         final Member currentMember = memberUtil.getCurrentMember();
         currentMember.verifyDiscord(request.discordUsername(), request.nickname());
+
+        String discordId = discordUtil.getMemberIdByUsername(request.discordUsername());
+        currentMember.updateDiscordId(discordId);
     }
 
     private void validateDiscordUsernameDuplicate(String discordUsername) {

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/DiscordIdBatchHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/DiscordIdBatchHandler.java
@@ -1,0 +1,30 @@
+package com.gdschongik.gdsc.domain.discord.application.handler;
+
+import static com.gdschongik.gdsc.domain.member.domain.RequirementStatus.*;
+import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.*;
+
+import com.gdschongik.gdsc.domain.discord.application.CommonDiscordService;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.events.GenericEvent;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DiscordIdBatchHandler implements DiscordEventHandler {
+
+    private final CommonDiscordService commonDiscordService;
+
+    @Override
+    public void delegate(GenericEvent genericEvent) {
+        SlashCommandInteractionEvent event = (SlashCommandInteractionEvent) genericEvent;
+        event.deferReply(true).setContent(DEFER_MESSAGE_BATCH_DISCORD_ID).queue();
+
+        commonDiscordService.batchDiscordId(VERIFIED);
+
+        event.getHook()
+                .sendMessage(REPLY_MESSAGE_BATCH_DISCORD_ID)
+                .setEphemeral(true)
+                .queue();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/DiscordIdBatchHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/DiscordIdBatchHandler.java
@@ -20,6 +20,8 @@ public class DiscordIdBatchHandler implements DiscordEventHandler {
         SlashCommandInteractionEvent event = (SlashCommandInteractionEvent) genericEvent;
         event.deferReply(true).setContent(DEFER_MESSAGE_BATCH_DISCORD_ID).queue();
 
+        String discordUsername = event.getUser().getName();
+        commonDiscordService.checkPermissionForCommand(discordUsername);
         commonDiscordService.batchDiscordId(VERIFIED);
 
         event.getHook()

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/DiscordIdBatchListener.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/DiscordIdBatchListener.java
@@ -1,0 +1,22 @@
+package com.gdschongik.gdsc.domain.discord.application.listener;
+
+import com.gdschongik.gdsc.domain.discord.application.handler.DiscordIdBatchHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Listener
+@RequiredArgsConstructor
+public class DiscordIdBatchListener extends ListenerAdapter {
+
+    private final DiscordIdBatchHandler discordIdBatchHandler;
+
+    public void onSlashCommandInteraction(@NotNull SlashCommandInteractionEvent event) {
+        discordIdBatchHandler.delegate(event);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
@@ -21,4 +21,6 @@ public interface MemberCustomRepository {
     Map<Boolean, List<Member>> groupByVerified(List<Long> memberIdList);
 
     List<Member> findAllByRole(@Nullable MemberRole role);
+
+    List<Member> findAllByDiscordStatus(RequirementStatus discordStatus);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -111,4 +111,12 @@ public class MemberCustomRepositoryImpl extends MemberQueryMethod implements Mem
                 .orderBy(member.studentId.asc(), member.name.asc())
                 .fetch();
     }
+
+    @Override
+    public List<Member> findAllByDiscordStatus(RequirementStatus discordStatus) {
+        return queryFactory
+                .selectFrom(member)
+                .where(eqRequirementStatus(member.requirement.discordStatus, discordStatus))
+                .fetch();
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -51,6 +51,7 @@ public class Member extends BaseTimeEntity {
     private String discordUsername;
 
     private String nickname;
+    private String discordId;
 
     @Column(nullable = false)
     private String oauthId;

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -268,4 +268,8 @@ public class Member extends BaseTimeEntity {
     public void updateLastLoginAt() {
         this.lastLoginAt = LocalDateTime.now();
     }
+
+    public void updateDiscordId(String discordId) {
+        this.discordId = discordId;
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/DiscordConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/DiscordConstant.java
@@ -20,4 +20,10 @@ public class DiscordConstant {
     public static final String COMMAND_DESCRIPTION_JOIN = "가입 신청이 승인된 멤버에게 역할을 부여합니다.";
     public static final String DEFER_MESSAGE_JOIN = "가입 신청을 처리하는 중입니다...";
     public static final String REPLY_MESSAGE_JOIN = "가입 신청이 승인되었습니다. GDSC Hongik에 합류하신 것을 환영합니다!";
+
+    // 디스코드 ID 저장 커맨드
+    public static final String COMMAND_NAME_BATCH_DISCORD_ID = "디스코드id-배치실행";
+    public static final String COMMAND_DESCRIPTION_BATCH_DISCORD_ID = "디스코드 ID 배치를 진행합니다.";
+    public static final String DEFER_MESSAGE_BATCH_DISCORD_ID = "디스코드 ID 배치를 진행하는 중입니다...";
+    public static final String REPLY_MESSAGE_BATCH_DISCORD_ID = "디스코드 ID 배치가 완료되었습니다.";
 }

--- a/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
@@ -43,6 +43,7 @@ public class DiscordConfig {
                 .updateCommands()
                 .addCommands(Commands.slash(COMMAND_NAME_ISSUING_CODE, COMMAND_DESCRIPTION_ISSUING_CODE))
                 .addCommands(Commands.slash(COMMAND_NAME_JOIN, COMMAND_DESCRIPTION_JOIN))
+                .addCommands(Commands.slash(COMMAND_NAME_BATCH_DISCORD_ID, COMMAND_DESCRIPTION_BATCH_DISCORD_ID))
                 .queue();
 
         return jda;

--- a/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
@@ -35,4 +35,9 @@ public class DiscordUtil {
                 .findFirst()
                 .orElseThrow(() -> new CustomException(ErrorCode.DISCORD_MEMBER_NOT_FOUND));
     }
+    public String getMemberIdByUsername(String username) {
+        return getCurrentGuild().getMembersByName(username, true).stream()
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.DISCORD_MEMBER_NOT_FOUND)).getId();
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
@@ -35,9 +35,11 @@ public class DiscordUtil {
                 .findFirst()
                 .orElseThrow(() -> new CustomException(ErrorCode.DISCORD_MEMBER_NOT_FOUND));
     }
+
     public String getMemberIdByUsername(String username) {
         return getCurrentGuild().getMembersByName(username, true).stream()
                 .findFirst()
-                .orElseThrow(() -> new CustomException(ErrorCode.DISCORD_MEMBER_NOT_FOUND)).getId();
+                .orElseThrow(() -> new CustomException(ErrorCode.DISCORD_MEMBER_NOT_FOUND))
+                .getId();
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #318

## 📌 작업 내용 및 특이사항
- 멤버에 `discordId`라는 필드를 추가했습니다.
- batch 작업은 Discord 인증 상태가 `VERIFIED`인 멤버를 대상으로 했습니다. 신규 가입자를 비롯한 아직 인증이 되지 않은 멤버는 Discord 인증 과정 중 `OnboardingDiscordService.verifyDiscordCode`에서 ID가 저장되도록 했습니다.

## 📝 참고사항
-

## 📚 기타
-
