### PR TITLE
refactor: 멤버 엔티티 승인 함수 준회원 승급으로 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
@@ -65,14 +65,14 @@ public class AdminMemberController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "회원 승인", description = "회원의 가입을 승인합니다.")
+    @Operation(summary = "회원 승인", description = "회원의 가입을 승인합니다.", deprecated = true)
     @PutMapping("/grant")
     public ResponseEntity<MemberGrantResponse> grantMember(@Valid @RequestBody MemberGrantRequest request) {
         MemberGrantResponse response = adminMemberService.grantMember(request);
         return ResponseEntity.ok().body(response);
     }
 
-    @Operation(summary = "승인 가능 회원 전체 조회", description = "승인 가능한 회원 전체를 조회합니다.")
+    @Operation(summary = "승인 가능 회원 전체 조회", description = "승인 가능한 회원 전체를 조회합니다.", deprecated = true)
     @GetMapping("/grantable")
     public ResponseEntity<Page<AdminMemberResponse>> getGrantableMembers(
             MemberQueryOption queryOption, Pageable pageable) {
@@ -80,7 +80,7 @@ public class AdminMemberController {
         return ResponseEntity.ok().body(response);
     }
 
-    @Operation(summary = "회비 납부 상태에 따른 회원 전체 조회", description = "회비 납부 상태에 따라 회원 목록을 조회합니다.")
+    @Operation(summary = "회비 납부 상태에 따른 회원 전체 조회", description = "회비 납부 상태에 따라 회원 목록을 조회합니다.", deprecated = true)
     @GetMapping("/payment")
     public ResponseEntity<Page<AdminMemberResponse>> getMembersByPaymentStatus(
             MemberQueryOption queryOption,
@@ -91,7 +91,7 @@ public class AdminMemberController {
         return ResponseEntity.ok().body(response);
     }
 
-    @Operation(summary = "회비 납부 상태 변경", description = "회비 납부 상태를 변경합니다.")
+    @Operation(summary = "회비 납부 상태 변경", description = "회비 납부 상태를 변경합니다.", deprecated = true)
     @PutMapping("/payment/{memberId}")
     public ResponseEntity<Void> updatePayment(
             @PathVariable Long memberId, @Valid @RequestBody MemberPaymentRequest request) {
@@ -99,7 +99,7 @@ public class AdminMemberController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "승인된 회원 전체 조회", description = "승인된 회원 전체를 조회합니다.")
+    @Operation(summary = "승인된 회원 전체 조회", description = "승인된 회원 전체를 조회합니다.", deprecated = true)
     @GetMapping("/granted")
     public ResponseEntity<Page<AdminMemberResponse>> getGrantedMembers(
             MemberQueryOption queryOption, Pageable pageable) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
@@ -63,7 +63,7 @@ public class OnboardingMemberController {
     }
 
     @Operation(summary = "기본 회원정보 작성", description = "기본 회원정보를 작성합니다")
-    @PostMapping("/basic-info")
+    @PostMapping("/me/basic-info")
     public ResponseEntity<Void> updateBasicMemberInfo(@Valid @RequestBody BasicMemberInfoRequest request) {
         onboardingMemberService.updateBasicMemberInfo(request);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
@@ -62,7 +62,7 @@ public class OnboardingMemberController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "기본 회원정보 작성", description = "회원정보를 작성합니다")
+    @Operation(summary = "기본 회원정보 작성", description = "기본 회원정보를 작성합니다")
     @PostMapping("/update-basic-info")
     public ResponseEntity<Void> updateBasicMemberInfo(@Valid @RequestBody BasicMemberInfoRequest request) {
         onboardingMemberService.updateBasicMemberInfo(request);

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.member.api;
 
 import com.gdschongik.gdsc.domain.member.application.OnboardingMemberService;
+import com.gdschongik.gdsc.domain.member.dto.request.MemberRegisterRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberSignupRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.OnboardingMemberUpdateRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberInfoResponse;
@@ -63,7 +64,7 @@ public class OnboardingMemberController {
 
     @Operation(summary = "가입 신청", description = "가입을 신청합니다.")
     @PostMapping("/register")
-    public ResponseEntity<Void> registerAssociateMember(@Valid @RequestBody MemberSignupRequest request) {
+    public ResponseEntity<Void> registerAssociateMember(@Valid @RequestBody MemberRegisterRequest request) {
         onboardingMemberService.registerAssociateMember(request);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.member.api;
 
 import com.gdschongik.gdsc.domain.member.application.OnboardingMemberService;
-import com.gdschongik.gdsc.domain.member.dto.request.MemberRegisterRequest;
+import com.gdschongik.gdsc.domain.member.dto.request.BasicMemberInfoRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberSignupRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.OnboardingMemberUpdateRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberInfoResponse;
@@ -62,10 +62,10 @@ public class OnboardingMemberController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "가입 신청", description = "가입을 신청합니다.")
-    @PostMapping("/register")
-    public ResponseEntity<Void> registerAssociateMember(@Valid @RequestBody MemberRegisterRequest request) {
-        onboardingMemberService.registerAssociateMember(request);
+    @Operation(summary = "기본 회원정보 작성", description = "회원정보를 작성합니다")
+    @PostMapping("/update-basic-info")
+    public ResponseEntity<Void> updateBasicMemberInfo(@Valid @RequestBody BasicMemberInfoRequest request) {
+        onboardingMemberService.updateBasicMemberInfo(request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
@@ -25,10 +25,17 @@ public class OnboardingMemberController {
 
     private final OnboardingMemberService onboardingMemberService;
 
-    @Operation(summary = "회원 가입 신청", description = "회원 가입을 신청합니다.")
+    @Operation(summary = "회원 가입 신청", description = "회원 가입을 신청합니다.", deprecated = true)
     @PostMapping
     public ResponseEntity<Void> signupMember(@Valid @RequestBody MemberSignupRequest request) {
         onboardingMemberService.signupMember(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "가입 신청", description = "회원 가입을 신청합니다.", deprecated = true)
+    @PostMapping
+    public ResponseEntity<Void> registerMember(@Valid @RequestBody MemberSignupRequest request) {
+        onboardingMemberService.registerAssociateMember(request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
@@ -32,13 +32,6 @@ public class OnboardingMemberController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "가입 신청", description = "회원 가입을 신청합니다.", deprecated = true)
-    @PostMapping
-    public ResponseEntity<Void> registerMember(@Valid @RequestBody MemberSignupRequest request) {
-        onboardingMemberService.registerAssociateMember(request);
-        return ResponseEntity.ok().build();
-    }
-
     @Deprecated
     @Operation(summary = "디스코드 회원 정보 수정", description = "디스코드 회원 정보를 수정합니다.")
     @PutMapping("/me/discord")
@@ -69,7 +62,7 @@ public class OnboardingMemberController {
     }
 
     @Operation(summary = "가입 신청", description = "가입을 신청합니다.")
-    @PostMapping
+    @PostMapping("/register")
     public ResponseEntity<Void> registerAssociateMember(@Valid @RequestBody MemberSignupRequest request) {
         onboardingMemberService.registerAssociateMember(request);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
@@ -60,4 +60,11 @@ public class OnboardingMemberController {
         onboardingMemberService.verifyBevyStatus();
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "가입 신청", description = "가입을 신청합니다.")
+    @PostMapping
+    public ResponseEntity<Void> registerAssociateMember(@Valid @RequestBody MemberSignupRequest request) {
+        onboardingMemberService.registerAssociateMember(request);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
@@ -63,7 +63,7 @@ public class OnboardingMemberController {
     }
 
     @Operation(summary = "기본 회원정보 작성", description = "기본 회원정보를 작성합니다")
-    @PostMapping("/update-basic-info")
+    @PostMapping("/basic-info")
     public ResponseEntity<Void> updateBasicMemberInfo(@Valid @RequestBody BasicMemberInfoRequest request) {
         onboardingMemberService.updateBasicMemberInfo(request);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
@@ -4,6 +4,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.dto.request.MemberRegisterRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberSignupRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.OnboardingMemberUpdateRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberInfoResponse;
@@ -63,7 +64,7 @@ public class OnboardingMemberService {
     }
 
     @Transactional
-    public void registerAssociateMember(MemberSignupRequest request) {
+    public void registerAssociateMember(MemberRegisterRequest request) {
         Member currentMember = memberUtil.getCurrentMember();
         currentMember.register(
                 request.studentId(), request.name(), request.phone(), request.department(), request.email());

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
@@ -4,7 +4,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.member.dto.request.MemberRegisterRequest;
+import com.gdschongik.gdsc.domain.member.dto.request.BasicMemberInfoRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberSignupRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.OnboardingMemberUpdateRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberInfoResponse;
@@ -64,9 +64,9 @@ public class OnboardingMemberService {
     }
 
     @Transactional
-    public void registerAssociateMember(MemberRegisterRequest request) {
+    public void updateBasicMemberInfo(BasicMemberInfoRequest request) {
         Member currentMember = memberUtil.getCurrentMember();
-        currentMember.register(
+        currentMember.updateBasicMemberInfo(
                 request.studentId(), request.name(), request.phone(), request.department(), request.email());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
@@ -61,4 +61,11 @@ public class OnboardingMemberService {
         Member currentMember = memberUtil.getCurrentMember();
         currentMember.verifyBevy();
     }
+
+    @Transactional
+    public void registerAssociateMember(MemberSignupRequest request) {
+        Member currentMember = memberUtil.getCurrentMember();
+        currentMember.register(
+                request.studentId(), request.name(), request.phone(), request.department(), request.email());
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -173,7 +173,8 @@ public class Member extends BaseTimeEntity {
     /**
      * 가입 신청 시 작성한 정보를 저장한다.
      */
-    public void register(String studentId, String name, String phone, Department department, String email) {
+    public void updateBasicMemberInfo(
+            String studentId, String name, String phone, Department department, String email) {
         validateStatusUpdatable();
 
         this.studentId = studentId;

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -253,7 +253,7 @@ public class Member extends BaseTimeEntity {
     }
 
     private boolean isAssociateAvailable() {
-        if (isAssociate()) {
+        if (checkIfAssociateOrHigher()) {
             return false;
         }
 
@@ -272,7 +272,7 @@ public class Member extends BaseTimeEntity {
     }
 
     private void validateAssociateAvailable() {
-        if (isAssociate()) {
+        if (checkIfAssociateOrHigher()) {
             throw new CustomException(MEMBER_ALREADY_GRANTED);
         }
 
@@ -289,7 +289,7 @@ public class Member extends BaseTimeEntity {
         }
     }
 
-    private boolean isAssociate() {
+    private boolean checkIfAssociateOrHigher() {
         return role.equals(ASSOCIATE) || role.equals(ADMIN) || role.equals(REGULAR);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -253,7 +253,7 @@ public class Member extends BaseTimeEntity {
     }
 
     private boolean isAssociateAvailable() {
-        if (checkIfAssociateOrHigher()) {
+        if (isAtLeastAssociate()) {
             return false;
         }
 
@@ -272,7 +272,7 @@ public class Member extends BaseTimeEntity {
     }
 
     private void validateAssociateAvailable() {
-        if (checkIfAssociateOrHigher()) {
+        if (isAtLeastAssociate()) {
             throw new CustomException(MEMBER_ALREADY_GRANTED);
         }
 
@@ -289,7 +289,7 @@ public class Member extends BaseTimeEntity {
         }
     }
 
-    private boolean checkIfAssociateOrHigher() {
+    private boolean isAtLeastAssociate() {
         return role.equals(ASSOCIATE) || role.equals(ADMIN) || role.equals(REGULAR);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -138,10 +138,6 @@ public class Member extends BaseTimeEntity {
             throw new CustomException(MEMBER_ALREADY_GRANTED);
         }
 
-        if (!this.requirement.isPaymentVerified()) {
-            throw new CustomException(PAYMENT_NOT_VERIFIED);
-        }
-
         if (!this.requirement.isDiscordVerified() || this.discordUsername == null || this.nickname == null) {
             throw new CustomException(DISCORD_NOT_VERIFIED);
         }
@@ -177,7 +173,7 @@ public class Member extends BaseTimeEntity {
         validateStatusUpdatable();
         validateGrantAvailable();
 
-        this.role = USER;
+        this.role = ASSOCIATE;
         registerEvent(new MemberGrantEvent(discordUsername, nickname));
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -171,7 +171,7 @@ public class Member extends BaseTimeEntity {
     }
 
     /**
-     * 가입 신청 시 작성한 정보를 저장한다.
+     * 기본 회원 정보 작성한다.
      */
     public void updateBasicMemberInfo(
             String studentId, String name, String phone, Department department, String email) {
@@ -191,9 +191,9 @@ public class Member extends BaseTimeEntity {
      * 조건 2 : 디스코드 인증
      * 조건 3 : Bevy 인증
      */
-    public void signup() {
+    public void advanceToAssociate() {
         validateStatusUpdatable();
-        validateSignupAvailable();
+        validateAssociateAvailable();
 
         this.role = ASSOCIATE;
         registerEvent(new MemberGrantEvent(discordUsername, nickname));
@@ -247,13 +247,13 @@ public class Member extends BaseTimeEntity {
     public void completeUnivEmailVerification(String univEmail) {
         this.univEmail = univEmail;
         requirement.updateUnivStatus(RequirementStatus.VERIFIED);
-        if (isSignupAvailable()) {
-            signup();
+        if (isAssociateAvailable()) {
+            advanceToAssociate();
         }
     }
 
-    private boolean isSignupAvailable() {
-        if (isSignedUp()) {
+    private boolean isAssociateAvailable() {
+        if (isAssociate()) {
             return false;
         }
 
@@ -271,8 +271,8 @@ public class Member extends BaseTimeEntity {
         return true;
     }
 
-    private void validateSignupAvailable() {
-        if (isSignedUp()) {
+    private void validateAssociateAvailable() {
+        if (isAssociate()) {
             throw new CustomException(MEMBER_ALREADY_GRANTED);
         }
 
@@ -289,7 +289,7 @@ public class Member extends BaseTimeEntity {
         }
     }
 
-    private boolean isSignedUp() {
+    private boolean isAssociate() {
         return role.equals(ASSOCIATE) || role.equals(ADMIN) || role.equals(REGULAR);
     }
 
@@ -300,8 +300,8 @@ public class Member extends BaseTimeEntity {
         this.discordUsername = discordUsername;
         this.nickname = nickname;
 
-        if (isSignupAvailable()) {
-            signup();
+        if (isAssociateAvailable()) {
+            advanceToAssociate();
         }
     }
 
@@ -316,8 +316,8 @@ public class Member extends BaseTimeEntity {
     public void verifyBevy() {
         validateStatusUpdatable();
         this.requirement.verifyBevy();
-        if (isSignupAvailable()) {
-            signup();
+        if (isAssociateAvailable()) {
+            advanceToAssociate();
         }
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -239,8 +239,9 @@ public class Member extends BaseTimeEntity {
 
     // 데이터 전달 로직
 
+    //TODO 한꺼번에 USER관련 기능을 삭제 할때 함께 USER부분을 삭제하기
     public boolean isGranted() {
-        return role.equals(ASSOCIATE) || role.equals(MemberRole.ADMIN);
+        return role.equals(USER) || role.equals(ASSOCIATE) || role.equals(MemberRole.ADMIN);
     }
 
     /**

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -244,7 +244,6 @@ public class Member extends BaseTimeEntity {
         this.nickname = nickname;
     }
 
-    // TODO deprecated방식
     public void completeUnivEmailVerification(String univEmail) {
         this.univEmail = univEmail;
         requirement.updateUnivStatus(RequirementStatus.VERIFIED);
@@ -291,7 +290,7 @@ public class Member extends BaseTimeEntity {
     }
 
     private boolean isSignedUp() {
-        return role.equals(ASSOCIATE) || role.equals(MemberRole.ADMIN);
+        return role.equals(ASSOCIATE) || role.equals(MemberRole.ADMIN) || role.equals(REGULAR);
     }
 
     // 가입조건 인증 로직

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -138,6 +138,10 @@ public class Member extends BaseTimeEntity {
             throw new CustomException(MEMBER_ALREADY_GRANTED);
         }
 
+        if (!this.requirement.isPaymentVerified()) {
+            throw new CustomException(PAYMENT_NOT_VERIFIED);
+        }
+
         if (!this.requirement.isDiscordVerified() || this.discordUsername == null || this.nickname == null) {
             throw new CustomException(DISCORD_NOT_VERIFIED);
         }
@@ -236,7 +240,7 @@ public class Member extends BaseTimeEntity {
     // 데이터 전달 로직
 
     public boolean isGranted() {
-        return role.equals(USER) || role.equals(MemberRole.ADMIN);
+        return role.equals(ASSOCIATE) || role.equals(MemberRole.ADMIN);
     }
 
     /**

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -172,7 +172,6 @@ public class Member extends BaseTimeEntity {
 
     /**
      * 가입 신청 시 작성한 정보를 저장한다.
-     *
      */
     public void register(String studentId, String name, String phone, Department department, String email) {
         validateStatusUpdatable();
@@ -290,7 +289,7 @@ public class Member extends BaseTimeEntity {
     }
 
     private boolean isSignedUp() {
-        return role.equals(ASSOCIATE) || role.equals(MemberRole.ADMIN) || role.equals(REGULAR);
+        return role.equals(ASSOCIATE) || role.equals(ADMIN) || role.equals(REGULAR);
     }
 
     // 가입조건 인증 로직

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -239,7 +239,7 @@ public class Member extends BaseTimeEntity {
 
     // 데이터 전달 로직
 
-    //TODO 한꺼번에 USER관련 기능을 삭제 할때 함께 USER부분을 삭제하기
+    // TODO 한꺼번에 USER관련 기능을 삭제 할때 함께 USER부분을 삭제하기
     public boolean isGranted() {
         return role.equals(USER) || role.equals(ASSOCIATE) || role.equals(MemberRole.ADMIN);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -171,7 +171,7 @@ public class Member extends BaseTimeEntity {
     }
 
     /**
-     * 기본 회원 정보 작성한다.
+     * 기본 회원 정보를 작성한다.
      */
     public void updateBasicMemberInfo(
             String studentId, String name, String phone, Department department, String email) {
@@ -185,7 +185,7 @@ public class Member extends BaseTimeEntity {
     }
 
     /**
-     * 회원가입합니다
+     * GUEST -> 준회원으로 승급됩니다.
      * 모든 조건을 충족하면 서버에서 각각의 인증과정에서 자동으로 signUp()호출된다
      * 조건 1 : 재학생 인증
      * 조건 2 : 디스코드 인증

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -186,7 +186,7 @@ public class Member extends BaseTimeEntity {
 
     /**
      * GUEST -> 준회원으로 승급됩니다.
-     * 모든 조건을 충족하면 서버에서 각각의 인증과정에서 자동으로 signUp()호출된다
+     * 모든 조건을 충족하면 서버에서 각각의 인증과정에서 자동으로 advanceToAssociate()호출된다
      * 조건 1 : 재학생 인증
      * 조건 2 : 디스코드 인증
      * 조건 3 : Bevy 인증

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -190,7 +190,7 @@ public class Member extends BaseTimeEntity {
      * 조건 2 : 디스코드 인증
      * 조건 3 : Bevy 인증
      */
-    public void signUp() {
+    public void signup() {
         validateStatusUpdatable();
         validateSignupAvailable();
 
@@ -247,7 +247,7 @@ public class Member extends BaseTimeEntity {
         this.univEmail = univEmail;
         requirement.updateUnivStatus(RequirementStatus.VERIFIED);
         if (isSignupAvailable()) {
-            signUp();
+            signup();
         }
     }
 
@@ -300,7 +300,7 @@ public class Member extends BaseTimeEntity {
         this.nickname = nickname;
 
         if (isSignupAvailable()) {
-            signUp();
+            signup();
         }
     }
 
@@ -316,7 +316,7 @@ public class Member extends BaseTimeEntity {
         validateStatusUpdatable();
         this.requirement.verifyBevy();
         if (isSignupAvailable()) {
-            signUp();
+            signup();
         }
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/BasicMemberInfoRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/BasicMemberInfoRequest.java
@@ -10,7 +10,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
-public record MemberRegisterRequest(
+public record BasicMemberInfoRequest(
         @NotBlank
                 @Pattern(regexp = STUDENT_ID, message = "학번은 " + STUDENT_ID + " 형식이어야 합니다.")
                 @Schema(description = "학번", pattern = STUDENT_ID)

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberRegisterRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberRegisterRequest.java
@@ -1,0 +1,24 @@
+package com.gdschongik.gdsc.domain.member.dto.request;
+
+import static com.gdschongik.gdsc.global.common.constant.RegexConstant.PHONE_WITHOUT_HYPHEN;
+import static com.gdschongik.gdsc.global.common.constant.RegexConstant.STUDENT_ID;
+
+import com.gdschongik.gdsc.domain.member.domain.Department;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record MemberRegisterRequest(
+        @NotBlank
+                @Pattern(regexp = STUDENT_ID, message = "학번은 " + STUDENT_ID + " 형식이어야 합니다.")
+                @Schema(description = "학번", pattern = STUDENT_ID)
+                String studentId,
+        @NotBlank @Schema(description = "이름") String name,
+        @NotBlank
+                @Pattern(regexp = PHONE_WITHOUT_HYPHEN, message = "전화번호는 " + PHONE_WITHOUT_HYPHEN + " 형식이어야 합니다.")
+                @Schema(description = "전화번호", pattern = PHONE_WITHOUT_HYPHEN)
+                String phone,
+        @NotNull @Schema(description = "학과") Department department,
+        @NotBlank @Email @Schema(description = "이메일") String email) {}

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
@@ -57,7 +57,7 @@ class OnboardingMemberServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 회워정보_작성을_완료하지_않았다면_실패한다() {
+        void 회원정보_작성을_완료하지_않았다면_실패한다() {
             // given
             setFixture();
             logoutAndReloginAs(1L, MemberRole.GUEST);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
@@ -39,37 +39,6 @@ class OnboardingMemberServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class 가입신청_수행시 {
-
-        @Test
-        void 재학생_인증을_완료했다면_성공한다() {
-            // given
-            setFixture();
-            logoutAndReloginAs(1L, MemberRole.GUEST);
-            verifyEmail();
-
-            // when
-            onboardingMemberService.signupMember(SIGNUP_REQUEST);
-
-            // then
-            Member signupMember = memberRepository.findById(1L).get();
-            assertThat(signupMember.isApplied()).isTrue();
-        }
-
-        @Test
-        void 재학생_인증을_미완료했다면_실패한다() {
-            // given
-            setFixture();
-            logoutAndReloginAs(1L, MemberRole.GUEST);
-
-            // when & then
-            assertThatThrownBy(() -> onboardingMemberService.signupMember(SIGNUP_REQUEST))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(ErrorCode.UNIV_NOT_VERIFIED.getMessage());
-        }
-    }
-
-    @Nested
     class 회원정보_조회시 {
 
         @Test
@@ -78,7 +47,7 @@ class OnboardingMemberServiceTest extends IntegrationTest {
             setFixture();
             logoutAndReloginAs(1L, MemberRole.GUEST);
             verifyEmail();
-            onboardingMemberService.signupMember(SIGNUP_REQUEST);
+            onboardingMemberService.registerAssociateMember(SIGNUP_REQUEST);
 
             // when
             MemberInfoResponse response = onboardingMemberService.getMemberInfo();

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
@@ -42,7 +42,7 @@ class OnboardingMemberServiceTest extends IntegrationTest {
     class 회원정보_조회시 {
 
         @Test
-        void 기본회원정보_작성을_완료헀다면_성공한다() {
+        void 기본_회원정보_작성을_완료헀다면_성공한다() {
             // given
             setFixture();
             logoutAndReloginAs(1L, MemberRole.GUEST);
@@ -57,7 +57,7 @@ class OnboardingMemberServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 기본회원정보_작성을_완료하지_않았다면_실패한다() {
+        void 기본_회원정보_작성을_완료하지_않았다면_실패한다() {
             // given
             setFixture();
             logoutAndReloginAs(1L, MemberRole.GUEST);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
@@ -7,7 +7,7 @@ import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Department;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
-import com.gdschongik.gdsc.domain.member.dto.request.MemberSignupRequest;
+import com.gdschongik.gdsc.domain.member.dto.request.MemberRegisterRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberInfoResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
@@ -18,8 +18,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 class OnboardingMemberServiceTest extends IntegrationTest {
 
-    public static final MemberSignupRequest SIGNUP_REQUEST =
-            new MemberSignupRequest(STUDENT_ID, NAME, PHONE_NUMBER, Department.D015, EMAIL);
+    public static final MemberRegisterRequest REGISTER_REQUEST =
+            new MemberRegisterRequest(STUDENT_ID, NAME, PHONE_NUMBER, Department.D015, EMAIL);
 
     @Autowired
     private OnboardingMemberService onboardingMemberService;
@@ -47,7 +47,7 @@ class OnboardingMemberServiceTest extends IntegrationTest {
             setFixture();
             logoutAndReloginAs(1L, MemberRole.GUEST);
             verifyEmail();
-            onboardingMemberService.registerAssociateMember(SIGNUP_REQUEST);
+            onboardingMemberService.registerAssociateMember(REGISTER_REQUEST);
 
             // when
             MemberInfoResponse response = onboardingMemberService.getMemberInfo();

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
@@ -7,7 +7,7 @@ import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Department;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
-import com.gdschongik.gdsc.domain.member.dto.request.MemberRegisterRequest;
+import com.gdschongik.gdsc.domain.member.dto.request.BasicMemberInfoRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberInfoResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
@@ -18,8 +18,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 class OnboardingMemberServiceTest extends IntegrationTest {
 
-    public static final MemberRegisterRequest REGISTER_REQUEST =
-            new MemberRegisterRequest(STUDENT_ID, NAME, PHONE_NUMBER, Department.D015, EMAIL);
+    public static final BasicMemberInfoRequest BASIC_MEMBER_INFO_REQUEST =
+            new BasicMemberInfoRequest(STUDENT_ID, NAME, PHONE_NUMBER, Department.D015, EMAIL);
 
     @Autowired
     private OnboardingMemberService onboardingMemberService;
@@ -42,12 +42,12 @@ class OnboardingMemberServiceTest extends IntegrationTest {
     class 회원정보_조회시 {
 
         @Test
-        void 가입신청을_완료헀다면_성공한다() {
+        void 회원정보_작성을_완료헀다면_성공한다() {
             // given
             setFixture();
             logoutAndReloginAs(1L, MemberRole.GUEST);
             verifyEmail();
-            onboardingMemberService.registerAssociateMember(REGISTER_REQUEST);
+            onboardingMemberService.updateBasicMemberInfo(BASIC_MEMBER_INFO_REQUEST);
 
             // when
             MemberInfoResponse response = onboardingMemberService.getMemberInfo();
@@ -57,7 +57,7 @@ class OnboardingMemberServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 가입신청을_완료하지_않았다면_실패한다() {
+        void 회워정보_작성을_완료하지_않았다면_실패한다() {
             // given
             setFixture();
             logoutAndReloginAs(1L, MemberRole.GUEST);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
@@ -42,7 +42,7 @@ class OnboardingMemberServiceTest extends IntegrationTest {
     class 회원정보_조회시 {
 
         @Test
-        void 회원정보_작성을_완료헀다면_성공한다() {
+        void 기본회원정보_작성을_완료헀다면_성공한다() {
             // given
             setFixture();
             logoutAndReloginAs(1L, MemberRole.GUEST);
@@ -57,7 +57,7 @@ class OnboardingMemberServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 회원정보_작성을_완료하지_않았다면_실패한다() {
+        void 기본회원정보_작성을_완료하지_않았다면_실패한다() {
             // given
             setFixture();
             logoutAndReloginAs(1L, MemberRole.GUEST);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -146,10 +146,10 @@ class MemberRepositoryTest extends RepositoryTest {
     class 역할로_조회할때 {
 
         @Test
-        void 가입신청후_회원가입전_이라면_GUEST로_조회된다() {
+        void 회원정보_작성후_회원가입전_이라면_GUEST로_조회된다() {
             // given
             Member member = getMember();
-            member.register(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
+            member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
 
             flushAndClearBeforeExecute();
 
@@ -165,7 +165,7 @@ class MemberRepositoryTest extends RepositoryTest {
         void 회원가입후라면_ASSOCIATE로_조회된다() {
             // given
             Member member = getMember();
-            member.register(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
+            member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
             member.completeUnivEmailVerification(UNIV_EMAIL);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
             member.verifyBevy();
@@ -184,7 +184,7 @@ class MemberRepositoryTest extends RepositoryTest {
         void 회원가입후라면_GUEST로_조회되지_않는다() {
             // given
             Member member = getMember();
-            member.register(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
+            member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
             member.completeUnivEmailVerification(UNIV_EMAIL);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
             member.verifyBevy();

--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -146,11 +146,10 @@ class MemberRepositoryTest extends RepositoryTest {
     class 역할로_조회할때 {
 
         @Test
-        void 승인전이라면_GUEST로_조회된다() {
+        void 가입신청후_회원가입전_이라면_GUEST로_조회된다() {
             // given
             Member member = getMember();
-            member.completeUnivEmailVerification(UNIV_EMAIL);
-            member.signup(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
+            member.register(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
 
             flushAndClearBeforeExecute();
 
@@ -163,29 +162,11 @@ class MemberRepositoryTest extends RepositoryTest {
         }
 
         @Test
-        void 승인전이라면_USER로_조회되지_않는다() {
+        void 회원가입후라면_ASSOCIATE로_조회된다() {
             // given
             Member member = getMember();
+            member.register(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
             member.completeUnivEmailVerification(UNIV_EMAIL);
-            member.signup(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
-
-            flushAndClearBeforeExecute();
-
-            // when
-            Page<Member> members = memberRepository.findAllByRole(EMPTY_QUERY_OPTION, PageRequest.of(0, 10), USER);
-
-            // then
-            Member guest = memberRepository.findById(1L).get();
-            assertThat(members).doesNotContain(guest);
-        }
-
-        @Test
-        void 승인후라면_USER로_조회된다() {
-            // given
-            Member member = getMember();
-            member.completeUnivEmailVerification(UNIV_EMAIL);
-            member.signup(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
-            member.updatePaymentStatus(VERIFIED);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
             member.verifyBevy();
 
@@ -200,12 +181,11 @@ class MemberRepositoryTest extends RepositoryTest {
         }
 
         @Test
-        void 승인후라면_GUEST로_조회되지_않는다() {
+        void 회원가입후라면_GUEST로_조회되지_않는다() {
             // given
             Member member = getMember();
+            member.register(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
             member.completeUnivEmailVerification(UNIV_EMAIL);
-            member.signup(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
-            member.updatePaymentStatus(VERIFIED);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
             member.verifyBevy();
 

--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -162,7 +162,7 @@ class MemberRepositoryTest extends RepositoryTest {
         }
 
         @Test
-        void 회원가입후라면_ASSOCIATE로_조회된다() {
+        void 회원정보_작성후_회원가입후라면_ASSOCIATE로_조회된다() {
             // given
             Member member = getMember();
             member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -162,7 +162,7 @@ class MemberRepositoryTest extends RepositoryTest {
         }
 
         @Test
-        void 기본_회원정보_작성후_준회원_승급후_이라면_ASSOCIATE로_조회된다() {
+        void 기본_회원정보_작성후_준회원_승급후라면_ASSOCIATE로_조회된다() {
             // given
             Member member = getMember();
             member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -35,10 +35,10 @@ class MemberRepositoryTest extends RepositoryTest {
     }
 
     @Nested
-    class 승인_가능_멤버를_조회할때 {
+    class 준회원_승급가능_멤버를_조회할때 {
 
         @Test
-        void 가입조건_모두_충족했다면_조회_성공한다() {
+        void 준회원_승급조건_모두_충족했다면_조회_성공한다() {
             // given
             Member member = getMember();
             member.getRequirement().updateUnivStatus(VERIFIED);
@@ -146,7 +146,7 @@ class MemberRepositoryTest extends RepositoryTest {
     class 역할로_조회할때 {
 
         @Test
-        void 회원정보_작성후_회원가입전_이라면_GUEST로_조회된다() {
+        void 기본회원정보_작성후_준회원_승급전_이라면_GUEST로_조회된다() {
             // given
             Member member = getMember();
             member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
@@ -162,7 +162,7 @@ class MemberRepositoryTest extends RepositoryTest {
         }
 
         @Test
-        void 회원정보_작성후_회원가입후라면_ASSOCIATE로_조회된다() {
+        void 기본회원정보_작성후_준회원_승급후_이라면_ASSOCIATE로_조회된다() {
             // given
             Member member = getMember();
             member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
@@ -181,7 +181,7 @@ class MemberRepositoryTest extends RepositoryTest {
         }
 
         @Test
-        void 회원가입후라면_GUEST로_조회되지_않는다() {
+        void 기본회원정보_작성후_준회원_승급후라면_GUEST로_조회되지_않는다() {
             // given
             Member member = getMember();
             member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -193,7 +193,7 @@ class MemberRepositoryTest extends RepositoryTest {
             flushAndClearBeforeExecute();
 
             // when
-            Page<Member> members = memberRepository.findAllByRole(EMPTY_QUERY_OPTION, PageRequest.of(0, 10), USER);
+            Page<Member> members = memberRepository.findAllByRole(EMPTY_QUERY_OPTION, PageRequest.of(0, 10), ASSOCIATE);
 
             // then
             Member user = memberRepository.findById(1L).get();

--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -146,7 +146,7 @@ class MemberRepositoryTest extends RepositoryTest {
     class 역할로_조회할때 {
 
         @Test
-        void 기본회원정보_작성후_준회원_승급전_이라면_GUEST로_조회된다() {
+        void 기본_회원정보_작성후_준회원_승급전_이라면_GUEST로_조회된다() {
             // given
             Member member = getMember();
             member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
@@ -162,7 +162,7 @@ class MemberRepositoryTest extends RepositoryTest {
         }
 
         @Test
-        void 기본회원정보_작성후_준회원_승급후_이라면_ASSOCIATE로_조회된다() {
+        void 기본_회원정보_작성후_준회원_승급후_이라면_ASSOCIATE로_조회된다() {
             // given
             Member member = getMember();
             member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
@@ -181,7 +181,7 @@ class MemberRepositoryTest extends RepositoryTest {
         }
 
         @Test
-        void 기본회원정보_작성후_준회원_승급후라면_GUEST로_조회되지_않는다() {
+        void 기본_회원정보_작성후_준회원_승급후라면_GUEST로_조회되지_않는다() {
             // given
             Member member = getMember();
             member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -188,7 +188,6 @@ class MemberRepositoryTest extends RepositoryTest {
             member.updatePaymentStatus(VERIFIED);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
             member.verifyBevy();
-            member.grant();
 
             flushAndClearBeforeExecute();
 
@@ -209,7 +208,6 @@ class MemberRepositoryTest extends RepositoryTest {
             member.updatePaymentStatus(VERIFIED);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
             member.verifyBevy();
-            member.grant();
 
             flushAndClearBeforeExecute();
 

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -45,7 +45,7 @@ class MemberTest {
     class 회원_가입시 {
 
         @Test
-        void 디스코드_인증하지_않았으면_실패() {
+        void 디스코드_인증하지_않았으면_실패한다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -61,7 +61,7 @@ class MemberTest {
         }
 
         @Test
-        void Bevy_연동하지_않았으면_실패() {
+        void Bevy_연동하지_않았으면_실패한다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -77,7 +77,7 @@ class MemberTest {
         }
 
         @Test
-        void 회비납부_디스코드인증_Bevy인증_재학생인증하면_성공() {
+        void 회비납부_디스코드인증_Bevy인증_재학생인증하면_성공한다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -90,7 +90,7 @@ class MemberTest {
         }
 
         @Test
-        void 이미_승인되어있으면_실패() {
+        void 이미_승인되어있으면_실패한다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -110,7 +110,7 @@ class MemberTest {
     @Nested
     class 회원탈퇴시 {
         @Test
-        void 이미_탈퇴한_유저면_실패() {
+        void 이미_탈퇴한_유저면_실패한다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -125,7 +125,7 @@ class MemberTest {
         }
 
         @Test
-        void 회원탈퇴시_이전에_탈퇴하지_않은_유저면_성공() {
+        void 회원탈퇴시_이전에_탈퇴하지_않은_유저면_성공한다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -140,7 +140,7 @@ class MemberTest {
     @Nested
     class 회원수정시 {
         @Test
-        void 탈퇴하지_않은_유저면_성공() {
+        void 탈퇴하지_않은_유저면_성공한다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -152,7 +152,7 @@ class MemberTest {
         }
 
         @Test
-        void 탈퇴한_유저면_실패() {
+        void 탈퇴한_유저면_실패한다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -169,7 +169,7 @@ class MemberTest {
     }
 
     @Test
-    void 디스코드인증시_탈퇴한_유저면_실패() {
+    void 디스코드인증시_탈퇴한_유저면_실패한다() {
         // given
         Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -184,7 +184,7 @@ class MemberTest {
     }
 
     @Test
-    void 회비납부시_탈퇴한_유저면_실패() {
+    void 회비납부시_탈퇴한_유저면_실패한다() {
         // given
         Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -199,7 +199,7 @@ class MemberTest {
     }
 
     @Test
-    void Bevy인증시_탈퇴한_유저면_실패() {
+    void Bevy인증시_탈퇴한_유저면_실패한다() {
         // given
         Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -216,7 +216,7 @@ class MemberTest {
     @Nested
     class 재학생_인증시 {
         @Test
-        void 회원가입_조건이_모두_만족안됐으면_MEMBER_ROLE은_GUEST이다() {
+        void 회원가입_조건이_모두_만족안됐으면_MemberRole은_GUEST이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -228,7 +228,7 @@ class MemberTest {
         }
 
         @Test
-        void 회원가입_조건이_모두_만족됐으면_MEMBER_ROLE은_ASOOCIATE이다() {
+        void 회원가입_조건이_모두_만족됐으면_MemberRole은_ASOOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
@@ -245,7 +245,7 @@ class MemberTest {
     @Nested
     class 디스코드_인증시 {
         @Test
-        void 회원가입_조건이_모두_만족안됐으면_MEMBER_ROLE은_GUEST이다() {
+        void 회원가입_조건이_모두_만족안됐으면_MemberRole은_GUEST이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -257,7 +257,7 @@ class MemberTest {
         }
 
         @Test
-        void 회원가입_조건이_모두_만족됐으면_MEMBER_ROLE은_ASOOCIATE이다() {
+        void 회원가입_조건이_모두_만족됐으면_MemberRole은_ASOOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.completeUnivEmailVerification(UNIV_EMAIL);
@@ -274,7 +274,7 @@ class MemberTest {
     @Nested
     class Bevy_인증시 {
         @Test
-        void 회원가입_조건이_모두_만족안됐으면_MEMBER_ROLE은_GUEST이다() {
+        void 회원가입_조건이_모두_만족안됐으면_MemberRole은_GUEST이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -286,7 +286,7 @@ class MemberTest {
         }
 
         @Test
-        void 회원가입_조건이_모두_만족됐으면_MEMBER_ROLE은_ASOOCIATE이다() {
+        void 회원가입_조건이_모두_만족됐으면_MemberRole은_ASOOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.completeUnivEmailVerification(UNIV_EMAIL);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -54,7 +54,7 @@ class MemberTest {
 
             // when & then
             assertThatThrownBy(() -> {
-                        member.signup();
+                        member.advanceToAssociate();
                     })
                     .isInstanceOf(CustomException.class)
                     .hasMessage(DISCORD_NOT_VERIFIED.getMessage());
@@ -70,7 +70,7 @@ class MemberTest {
 
             // when & then
             assertThatThrownBy(() -> {
-                        member.signup();
+                        member.advanceToAssociate();
                     })
                     .isInstanceOf(CustomException.class)
                     .hasMessage(BEVY_NOT_VERIFIED.getMessage());
@@ -100,7 +100,7 @@ class MemberTest {
 
             // when & then
             assertThatThrownBy(() -> {
-                        member.signup();
+                        member.advanceToAssociate();
                     })
                     .isInstanceOf(CustomException.class)
                     .hasMessage(MEMBER_ALREADY_GRANTED.getMessage());

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 class MemberTest {
 
     @Nested
-    class 기본회원정보_입력시 {
+    class 게스트_회원가입시 {
         @Test
         void MemberRole은_GUEST이다() {
             // given

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 class MemberTest {
 
     @Nested
-    class 회원가입시 {
+    class 가입_신청_시 {
         @Test
         void MemberRole은_GUEST이다() {
             // given
@@ -42,54 +42,7 @@ class MemberTest {
     }
 
     @Nested
-    class 가입신청시 {
-        @Test
-        void 재학생인증_되어있으면_성공() {
-            // given
-            Member member = Member.createGuestMember(OAUTH_ID);
-
-            // when
-            member.completeUnivEmailVerification(UNIV_EMAIL);
-            member.signup(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
-
-            // then
-            assertThat(member.getStudentId()).isEqualTo(STUDENT_ID);
-        }
-
-        @Test
-        void 재학생인증_안되어있으면_실패() {
-            // given
-            Member member = Member.createGuestMember(OAUTH_ID);
-
-            // when & then
-            assertThatThrownBy(() -> {
-                        member.signup(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
-                    })
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(UNIV_NOT_VERIFIED.getMessage());
-        }
-    }
-
-    @Nested
-    class 가입승인시 {
-        @Test
-        void 회비를_납부하지_않았으면_실패() {
-            // given
-            Member member = Member.createGuestMember(OAUTH_ID);
-
-            member.completeUnivEmailVerification(UNIV_EMAIL);
-            member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
-            member.verifyBevy();
-
-            member.signup(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
-
-            // when & then
-            assertThatThrownBy(() -> {
-                        member.grant();
-                    })
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(PAYMENT_NOT_VERIFIED.getMessage());
-        }
+    class 회원_가입시 {
 
         @Test
         void 디스코드_인증하지_않았으면_실패() {
@@ -97,14 +50,11 @@ class MemberTest {
             Member member = Member.createGuestMember(OAUTH_ID);
 
             member.completeUnivEmailVerification(UNIV_EMAIL);
-            member.updatePaymentStatus(VERIFIED);
             member.verifyBevy();
-
-            member.signup(STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL);
 
             // when & then
             assertThatThrownBy(() -> {
-                        member.grant();
+                        member.signUp();
                     })
                     .isInstanceOf(CustomException.class)
                     .hasMessage(DISCORD_NOT_VERIFIED.getMessage());
@@ -116,12 +66,11 @@ class MemberTest {
             Member member = Member.createGuestMember(OAUTH_ID);
 
             member.completeUnivEmailVerification(UNIV_EMAIL);
-            member.updatePaymentStatus(VERIFIED);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
 
             // when & then
             assertThatThrownBy(() -> {
-                        member.grant();
+                        member.signUp();
                     })
                     .isInstanceOf(CustomException.class)
                     .hasMessage(BEVY_NOT_VERIFIED.getMessage());
@@ -133,11 +82,8 @@ class MemberTest {
             Member member = Member.createGuestMember(OAUTH_ID);
 
             member.completeUnivEmailVerification(UNIV_EMAIL);
-            member.updatePaymentStatus(VERIFIED);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
             member.verifyBevy();
-
-            member.grant();
 
             // then
             assertThat(member.getRole()).isEqualTo(ASSOCIATE);
@@ -149,15 +95,12 @@ class MemberTest {
             Member member = Member.createGuestMember(OAUTH_ID);
 
             member.completeUnivEmailVerification(UNIV_EMAIL);
-            member.updatePaymentStatus(VERIFIED);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
             member.verifyBevy();
 
-            member.grant();
-
             // when & then
             assertThatThrownBy(() -> {
-                        member.grant();
+                        member.signUp();
                     })
                     .isInstanceOf(CustomException.class)
                     .hasMessage(MEMBER_ALREADY_GRANTED.getMessage());

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -216,7 +216,7 @@ class MemberTest {
     @Nested
     class 재학생_인증시 {
         @Test
-        void 회원가입_조건이_모두_만족안됐으면_MEMBER_ROLE이_GUEST이다() {
+        void 회원가입_조건이_모두_만족안됐으면_MEMBER_ROLE은_GUEST이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -228,7 +228,7 @@ class MemberTest {
         }
 
         @Test
-        void 회원가입_조건이_모두_만족됐으면_MEMBER_ROLE이_ASOOCIATE이다() {
+        void 회원가입_조건이_모두_만족됐으면_MEMBER_ROLE은_ASOOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
@@ -245,7 +245,7 @@ class MemberTest {
     @Nested
     class 디스코드_인증시 {
         @Test
-        void 회원가입_조건이_모두_만족안됐으면_MEMBER_ROLE이_GUEST이다() {
+        void 회원가입_조건이_모두_만족안됐으면_MEMBER_ROLE은_GUEST이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -257,7 +257,7 @@ class MemberTest {
         }
 
         @Test
-        void 회원가입_조건이_모두_만족됐으면_MEMBER_ROLE이_ASOOCIATE이다() {
+        void 회원가입_조건이_모두_만족됐으면_MEMBER_ROLE은_ASOOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.completeUnivEmailVerification(UNIV_EMAIL);
@@ -274,7 +274,7 @@ class MemberTest {
     @Nested
     class Bevy_인증시 {
         @Test
-        void 회원가입_조건이_모두_만족안됐으면_MEMBER_ROLE이_GUEST이다() {
+        void 회원가입_조건이_모두_만족안됐으면_MEMBER_ROLE은_GUEST이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -286,7 +286,7 @@ class MemberTest {
         }
 
         @Test
-        void 회원가입_조건이_모두_만족됐으면_MEMBER_ROLE이_ASOOCIATE이다() {
+        void 회원가입_조건이_모두_만족됐으면_MEMBER_ROLE은_ASOOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.completeUnivEmailVerification(UNIV_EMAIL);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -216,7 +216,7 @@ class MemberTest {
     @Nested
     class 재학생_인증시 {
         @Test
-        void 회원가입_조건이_모두_만족안됐으면_멤버ROLE이_GUEST이다() {
+        void 회원가입_조건이_모두_만족안됐으면_MEMBER_ROLE이_GUEST이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -228,7 +228,7 @@ class MemberTest {
         }
 
         @Test
-        void 회원가입_조건이_모두_만족됐으면_멤버_ROLE이_ASOOCIATE이다() {
+        void 회원가입_조건이_모두_만족됐으면_MEMBER_ROLE이_ASOOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
@@ -245,7 +245,7 @@ class MemberTest {
     @Nested
     class 디스코드_인증시 {
         @Test
-        void 회원가입_조건이_모두_만족안됐으면_멤버상태가_GUEST이다() {
+        void 회원가입_조건이_모두_만족안됐으면_MEMBER_ROLE이_GUEST이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -257,7 +257,7 @@ class MemberTest {
         }
 
         @Test
-        void 회원가입_조건이_모두_만족됐으면_멤버상태가_ASOOCIATE이다() {
+        void 회원가입_조건이_모두_만족됐으면_MEMBER_ROLE이_ASOOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.completeUnivEmailVerification(UNIV_EMAIL);
@@ -274,7 +274,7 @@ class MemberTest {
     @Nested
     class Bevy_인증시 {
         @Test
-        void 회원가입_조건이_모두_만족안됐으면_멤버상태가_GUEST이다() {
+        void 회원가입_조건이_모두_만족안됐으면_MEMBER_ROLE이_GUEST이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -286,7 +286,7 @@ class MemberTest {
         }
 
         @Test
-        void 회원가입_조건이_모두_만족됐으면_멤버상태가_ASOOCIATE이다() {
+        void 회원가입_조건이_모두_만족됐으면_MEMBER_ROLE이_ASOOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.completeUnivEmailVerification(UNIV_EMAIL);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 class MemberTest {
 
     @Nested
-    class 가입_신청_시 {
+    class 기본회원정보_입력시 {
         @Test
         void MemberRole은_GUEST이다() {
             // given
@@ -42,7 +42,7 @@ class MemberTest {
     }
 
     @Nested
-    class 회원_가입시 {
+    class 준회원으로_승급시 {
 
         @Test
         void 디스코드_인증하지_않았으면_실패한다() {
@@ -90,7 +90,7 @@ class MemberTest {
         }
 
         @Test
-        void 이미_승인되어있으면_실패한다() {
+        void 이미_준회원으로_승급_돼있으면_실패한다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -216,7 +216,7 @@ class MemberTest {
     @Nested
     class 재학생_인증시 {
         @Test
-        void 회원가입_조건이_모두_만족안됐으면_MemberRole은_GUEST이다() {
+        void 준회원_승급조건이_모두_만족안됐으면_MemberRole은_GUEST이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -228,7 +228,7 @@ class MemberTest {
         }
 
         @Test
-        void 회원가입_조건이_모두_만족됐으면_MemberRole은_ASOOCIATE이다() {
+        void 준회원_승급조건이_모두_만족됐으면_MemberRole은_ASOOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
@@ -245,7 +245,7 @@ class MemberTest {
     @Nested
     class 디스코드_인증시 {
         @Test
-        void 회원가입_조건이_모두_만족안됐으면_MemberRole은_GUEST이다() {
+        void 준회원_승급조건이_모두_만족안됐으면_MemberRole은_GUEST이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -257,7 +257,7 @@ class MemberTest {
         }
 
         @Test
-        void 회원가입_조건이_모두_만족됐으면_MemberRole은_ASOOCIATE이다() {
+        void 준회원_승급조건이_모두_만족됐으면_MemberRole은_ASOOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.completeUnivEmailVerification(UNIV_EMAIL);
@@ -274,7 +274,7 @@ class MemberTest {
     @Nested
     class Bevy_인증시 {
         @Test
-        void 회원가입_조건이_모두_만족안됐으면_MemberRole은_GUEST이다() {
+        void 준회원_승급조건이_모두_만족안됐으면_MemberRole은_GUEST이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -286,7 +286,7 @@ class MemberTest {
         }
 
         @Test
-        void 회원가입_조건이_모두_만족됐으면_MemberRole은_ASOOCIATE이다() {
+        void 준회원_승급조건이_모두_만족됐으면_MemberRole은_ASOOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.completeUnivEmailVerification(UNIV_EMAIL);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -228,7 +228,7 @@ class MemberTest {
         }
 
         @Test
-        void 준회원_승급조건이_모두_만족됐으면_MemberRole은_ASOOCIATE이다() {
+        void 준회원_승급조건이_모두_만족됐으면_MemberRole은_ASSOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
@@ -257,7 +257,7 @@ class MemberTest {
         }
 
         @Test
-        void 준회원_승급조건이_모두_만족됐으면_MemberRole은_ASOOCIATE이다() {
+        void 준회원_승급조건이_모두_만족됐으면_MemberRole은_ASSOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.completeUnivEmailVerification(UNIV_EMAIL);
@@ -286,7 +286,7 @@ class MemberTest {
         }
 
         @Test
-        void 준회원_승급조건이_모두_만족됐으면_MemberRole은_ASOOCIATE이다() {
+        void 준회원_승급조건이_모두_만족됐으면_MemberRole은_ASSOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.completeUnivEmailVerification(UNIV_EMAIL);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -269,4 +269,91 @@ class MemberTest {
                 .isInstanceOf(CustomException.class)
                 .hasMessage(MEMBER_DELETED.getMessage());
     }
+
+    @Nested
+    class 재학생_인증시 {
+        @Test
+        void 나머지_조건이_만족안됐으면_멤버상태가_GUEST이다() {
+            // given
+            Member member = Member.createGuestMember(OAUTH_ID);
+
+            // when
+            member.completeUnivEmailVerification(UNIV_EMAIL);
+
+            // then
+            assertThat(member.getRole()).isEqualTo(GUEST);
+        }
+
+        @Test
+        void 나머지_조건이_만족됐으면_멤버상태가_ASOOCIATE이다() {
+            // given
+            Member member = Member.createGuestMember(OAUTH_ID);
+            member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
+            member.verifyBevy();
+
+            // when
+            member.completeUnivEmailVerification(UNIV_EMAIL);
+
+            // then
+            assertThat(member.getRole()).isEqualTo(ASSOCIATE);
+        }
+    }
+
+    @Nested
+    class 디스코드_인증시 {
+        @Test
+        void 나머지_조건이_만족안됐으면_멤버상태가_GUEST이다() {
+            // given
+            Member member = Member.createGuestMember(OAUTH_ID);
+
+            // when
+            member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
+
+            // then
+            assertThat(member.getRole()).isEqualTo(GUEST);
+        }
+
+        @Test
+        void 나머지_조건이_만족됐으면_멤버상태가_ASOOCIATE이다() {
+            // given
+            Member member = Member.createGuestMember(OAUTH_ID);
+            member.completeUnivEmailVerification(UNIV_EMAIL);
+            member.verifyBevy();
+
+            // when
+            member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
+
+            // then
+            assertThat(member.getRole()).isEqualTo(ASSOCIATE);
+        }
+    }
+
+    @Nested
+    class Bevy_인증시 {
+        @Test
+        void 나머지_조건이_만족안됐으면_멤버상태가_GUEST이다() {
+            // given
+            Member member = Member.createGuestMember(OAUTH_ID);
+
+            // when
+            member.verifyBevy();
+
+            // then
+            assertThat(member.getRole()).isEqualTo(GUEST);
+        }
+
+        @Test
+        void 나머지_조건이_만족됐으면_멤버상태가_ASOOCIATE이다() {
+            // given
+            Member member = Member.createGuestMember(OAUTH_ID);
+            member.completeUnivEmailVerification(UNIV_EMAIL);
+            member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
+
+            // when
+            member.verifyBevy();
+
+            // then
+            assertThat(member.getRole()).isEqualTo(ASSOCIATE);
+        }
+    }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -140,7 +140,7 @@ class MemberTest {
             member.grant();
 
             // then
-            assertThat(member.getRole()).isEqualTo(USER);
+            assertThat(member.getRole()).isEqualTo(ASSOCIATE);
         }
 
         @Test

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -216,7 +216,7 @@ class MemberTest {
     @Nested
     class 재학생_인증시 {
         @Test
-        void 회원가입_조건이_모두_만족안됐으면_멤버상태가_GUEST이다() {
+        void 회원가입_조건이_모두_만족안됐으면_멤버ROLE이_GUEST이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -228,7 +228,7 @@ class MemberTest {
         }
 
         @Test
-        void 회원가입_조건이_모두_만족됐으면_멤버상태가_ASOOCIATE이다() {
+        void 회원가입_조건이_모두_만족됐으면_멤버_ROLE이_ASOOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -54,7 +54,7 @@ class MemberTest {
 
             // when & then
             assertThatThrownBy(() -> {
-                        member.signUp();
+                        member.signup();
                     })
                     .isInstanceOf(CustomException.class)
                     .hasMessage(DISCORD_NOT_VERIFIED.getMessage());
@@ -70,14 +70,14 @@ class MemberTest {
 
             // when & then
             assertThatThrownBy(() -> {
-                        member.signUp();
+                        member.signup();
                     })
                     .isInstanceOf(CustomException.class)
                     .hasMessage(BEVY_NOT_VERIFIED.getMessage());
         }
 
         @Test
-        void 회비납부_디스코드인증_Bevy인증_재학생인증하면_성공한다() {
+        void 디스코드인증_Bevy인증_재학생인증하면_성공한다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -100,7 +100,7 @@ class MemberTest {
 
             // when & then
             assertThatThrownBy(() -> {
-                        member.signUp();
+                        member.signup();
                     })
                     .isInstanceOf(CustomException.class)
                     .hasMessage(MEMBER_ALREADY_GRANTED.getMessage());

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -216,7 +216,7 @@ class MemberTest {
     @Nested
     class 재학생_인증시 {
         @Test
-        void 나머지_조건이_만족안됐으면_멤버상태가_GUEST이다() {
+        void 회원가입_조건이_모두_만족안됐으면_멤버상태가_GUEST이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -228,7 +228,7 @@ class MemberTest {
         }
 
         @Test
-        void 나머지_조건이_만족됐으면_멤버상태가_ASOOCIATE이다() {
+        void 회원가입_조건이_모두_만족됐으면_멤버상태가_ASOOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
@@ -245,7 +245,7 @@ class MemberTest {
     @Nested
     class 디스코드_인증시 {
         @Test
-        void 나머지_조건이_만족안됐으면_멤버상태가_GUEST이다() {
+        void 회원가입_조건이_모두_만족안됐으면_멤버상태가_GUEST이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -257,7 +257,7 @@ class MemberTest {
         }
 
         @Test
-        void 나머지_조건이_만족됐으면_멤버상태가_ASOOCIATE이다() {
+        void 회원가입_조건이_모두_만족됐으면_멤버상태가_ASOOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.completeUnivEmailVerification(UNIV_EMAIL);
@@ -274,7 +274,7 @@ class MemberTest {
     @Nested
     class Bevy_인증시 {
         @Test
-        void 나머지_조건이_만족안됐으면_멤버상태가_GUEST이다() {
+        void 회원가입_조건이_모두_만족안됐으면_멤버상태가_GUEST이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -286,7 +286,7 @@ class MemberTest {
         }
 
         @Test
-        void 나머지_조건이_만족됐으면_멤버상태가_ASOOCIATE이다() {
+        void 회원가입_조건이_모두_만족됐으면_멤버상태가_ASOOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
             member.completeUnivEmailVerification(UNIV_EMAIL);

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -41,7 +41,6 @@ public class MembershipServiceTest extends IntegrationTest {
         member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
         member.verifyBevy();
 
-        member.grant();
         return memberRepository.save(member);
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #339 

## 📌 작업 내용 및 특이사항
- 원래는 payment까지 없애려고 했는데 연결된 부분들이 많아서 grant()시 USER -> ASSOCIATE로 변경하는 부분만 바꾸고 테스트 코드도 변경하였습니당~
- 자세한 변경 사항
- 가입 신청 -> register함수
- 회원가입 signUp함수 (기존의 signup이 존재해서 singUp으로 명칭 정함)
- 기존의 재학생 인증, 디스코드 인증, Bevy인증 에 isSignUpAvailable 인증 로직 추가해서 변겅
- isSignUpAvailable은 boolean 리턴하고 기존의 isGrantAvailable과 비슷한 로직임. 이 boolean 함수를 사용한 이유는 인증할 때마다 signUp가능한지 validate함수를 바로 해버리면 예외처리를 해버리니, 일단 조건을 만족했다상태는 것은 저장이 되어야 하므로 boolean 리턴하게 함
- signUp(회원가입할 때) validateSignupAvailable을 따로 구현하여 exception 발생 시 예외처리 할 수 있게끔 구현하였습니다. 

## 📝 참고사항
-  !!정책 요구사항 관련!! 가입 신청(용어는 생각해보겠습니다..) , grant -> sign up (로직 변경)
- 이벤트 처리는 이슈 새로 파서 처리를 할 예정입니다.

## 📚 기타
- To do 코드 추가 : 디스코드 기능 중에 USER 쓰는 부분있어서 맨 마지막에 한꺼번에 수정 할때 USER 삭제하기
