### PR TITLE
feat: Recruitment 생성 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/common/model/SemesterType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/model/SemesterType.java
@@ -18,10 +18,6 @@ public enum SemesterType {
     private final MonthDay startDate;
 
     public static SemesterType from(LocalDateTime dateTime) {
-        return getSemesterType(dateTime);
-    }
-
-    private static SemesterType getSemesterType(LocalDateTime dateTime) {
         int year = dateTime.getYear();
         LocalDateTime firstSemesterStartDate =
                 LocalDateTime.of(year, FIRST.startDate.getMonth(), FIRST.startDate.getDayOfMonth(), 0, 0);

--- a/src/main/java/com/gdschongik/gdsc/domain/common/model/SemesterType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/model/SemesterType.java
@@ -1,9 +1,10 @@
 package com.gdschongik.gdsc.domain.common.model;
 
+import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
+
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
 import java.time.LocalDateTime;
-import java.time.Month;
 import java.time.MonthDay;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -24,12 +25,11 @@ public enum SemesterType {
         LocalDateTime secondSemesterStartDate =
                 LocalDateTime.of(year, SECOND.startDate.getMonth(), SECOND.startDate.getDayOfMonth(), 0, 0);
 
-        if (dateTime.isAfter(firstSemesterStartDate.minusWeeks(2))
-                && dateTime.getMonthValue() < Month.JULY.getValue()) {
+        if (dateTime.isAfter(firstSemesterStartDate.minusWeeks(TWO_WEEKS)) && dateTime.getMonthValue() < JULY) {
             return FIRST;
         }
 
-        if (dateTime.isAfter(secondSemesterStartDate.minusWeeks(2))) {
+        if (dateTime.isAfter(secondSemesterStartDate.minusWeeks(TWO_WEEKS))) {
             return SECOND;
         }
         throw new CustomException(ErrorCode.SEMESTER_TYPE_INVALID_FOR_DATE);

--- a/src/main/java/com/gdschongik/gdsc/domain/common/model/SemesterType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/model/SemesterType.java
@@ -1,10 +1,5 @@
 package com.gdschongik.gdsc.domain.common.model;
 
-import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
-
-import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.global.exception.ErrorCode;
-import java.time.LocalDateTime;
 import java.time.MonthDay;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,21 +12,4 @@ public enum SemesterType {
 
     private final String value;
     private final MonthDay startDate;
-
-    public static SemesterType from(LocalDateTime dateTime) {
-        int year = dateTime.getYear();
-        LocalDateTime firstSemesterStartDate =
-                LocalDateTime.of(year, FIRST.startDate.getMonth(), FIRST.startDate.getDayOfMonth(), 0, 0);
-        LocalDateTime secondSemesterStartDate =
-                LocalDateTime.of(year, SECOND.startDate.getMonth(), SECOND.startDate.getDayOfMonth(), 0, 0);
-
-        if (dateTime.isAfter(firstSemesterStartDate.minusWeeks(TWO_WEEKS)) && dateTime.getMonthValue() < JULY) {
-            return FIRST;
-        }
-
-        if (dateTime.isAfter(secondSemesterStartDate.minusWeeks(TWO_WEEKS))) {
-            return SECOND;
-        }
-        throw new CustomException(ErrorCode.SEMESTER_TYPE_INVALID_FOR_DATE);
-    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/common/model/SemesterType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/model/SemesterType.java
@@ -1,6 +1,9 @@
 package com.gdschongik.gdsc.domain.common.model;
 
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.exception.ErrorCode;
 import java.time.LocalDateTime;
+import java.time.Month;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -13,9 +16,28 @@ public enum SemesterType {
     private final String value;
 
     public static SemesterType from(LocalDateTime dateTime) {
-        if (dateTime.getMonthValue() < 7) {
+        return getSemesterType(dateTime);
+    }
+
+    private static SemesterType getSemesterType(LocalDateTime dateTime) {
+        int year = dateTime.getYear();
+        LocalDateTime firstSemesterStartDate = LocalDateTime.of(year, 3, 1, 0, 0, 0);
+        LocalDateTime secondSemesterStartDate = LocalDateTime.of(year, 9, 1, 0, 0, 0);
+
+        if (dateTime.isAfter(firstSemesterStartDate.minusWeeks(2)) && dateTime.getMonthValue() < 7) {
             return FIRST;
         }
-        return SECOND;
+
+        if (dateTime.isAfter(secondSemesterStartDate.minusWeeks(2))) {
+            return SECOND;
+        }
+        throw new CustomException(ErrorCode.SEMESTER_TYPE_INVALID_FOR_DATE);
+    }
+
+    public static Month getStartMonth(SemesterType semesterType) {
+        if (semesterType == FIRST) {
+            return Month.MARCH;
+        }
+        return Month.SEPTEMBER;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/common/model/SemesterType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/model/SemesterType.java
@@ -4,16 +4,18 @@ import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.time.MonthDay;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public enum SemesterType {
-    FIRST("1학기"),
-    SECOND("2학기");
+    FIRST("1학기", MonthDay.of(3, 1)),
+    SECOND("2학기", MonthDay.of(9, 1));
 
     private final String value;
+    private final MonthDay startDate;
 
     public static SemesterType from(LocalDateTime dateTime) {
         return getSemesterType(dateTime);
@@ -21,10 +23,14 @@ public enum SemesterType {
 
     private static SemesterType getSemesterType(LocalDateTime dateTime) {
         int year = dateTime.getYear();
-        LocalDateTime firstSemesterStartDate = LocalDateTime.of(year, 3, 1, 0, 0, 0);
-        LocalDateTime secondSemesterStartDate = LocalDateTime.of(year, 9, 1, 0, 0, 0);
 
-        if (dateTime.isAfter(firstSemesterStartDate.minusWeeks(2)) && dateTime.getMonthValue() < 7) {
+        LocalDateTime firstSemesterStartDate =
+                LocalDateTime.of(year, FIRST.startDate.getMonth(), FIRST.startDate.getDayOfMonth(), 0, 0);
+        LocalDateTime secondSemesterStartDate =
+                LocalDateTime.of(year, SECOND.startDate.getMonth(), SECOND.startDate.getDayOfMonth(), 0, 0);
+
+        if (dateTime.isAfter(firstSemesterStartDate.minusWeeks(2))
+                && dateTime.getMonthValue() < Month.JULY.getValue()) {
             return FIRST;
         }
 
@@ -32,12 +38,5 @@ public enum SemesterType {
             return SECOND;
         }
         throw new CustomException(ErrorCode.SEMESTER_TYPE_INVALID_FOR_DATE);
-    }
-
-    public static Month getStartMonth(SemesterType semesterType) {
-        if (semesterType == FIRST) {
-            return Month.MARCH;
-        }
-        return Month.SEPTEMBER;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/common/model/SemesterType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/model/SemesterType.java
@@ -23,7 +23,6 @@ public enum SemesterType {
 
     private static SemesterType getSemesterType(LocalDateTime dateTime) {
         int year = dateTime.getYear();
-
         LocalDateTime firstSemesterStartDate =
                 LocalDateTime.of(year, FIRST.startDate.getMonth(), FIRST.startDate.getDayOfMonth(), 0, 0);
         LocalDateTime secondSemesterStartDate =

--- a/src/main/java/com/gdschongik/gdsc/domain/common/model/SemesterType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/model/SemesterType.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.domain.common.model;
 
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,4 +11,11 @@ public enum SemesterType {
     SECOND("2학기");
 
     private final String value;
+
+    public static SemesterType from(LocalDateTime dateTime) {
+        if (dateTime.getMonthValue() < 7) {
+            return FIRST;
+        }
+        return SECOND;
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Admin Recruitment", description = "어드민 리쿠르팅 관리 API입니다.")
 @RestController
-@RequestMapping("/admin/recruitment")
+@RequestMapping("/admin/recruitments")
 @RequiredArgsConstructor
 public class AdminRecruitmentController {
 

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Admin Recruitment", description = "어드민 리쿠르트먼트 관리 API입니다.")
+@Tag(name = "Admin Recruitment", description = "어드민 리쿠르팅 관리 API입니다.")
 @RestController
 @RequestMapping("/admin/recruitment")
 @RequiredArgsConstructor
@@ -20,7 +20,7 @@ public class AdminRecruitmentController {
 
     private final AdminRecruitmentService adminRecruitmentService;
 
-    @Operation(summary = "리쿠르트먼트 생성", description = "새로운 리쿠르트먼트(모집 기간)를 생성합니다.")
+    @Operation(summary = "리쿠르팅 생성", description = "새로운 리쿠르팅(모집 기간)를 생성합니다.")
     @PostMapping
     public ResponseEntity<Void> createRecruitment(@Valid @RequestBody RecruitmentCreateRequest request) {
         adminRecruitmentService.createRecruitment(request);

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
@@ -1,0 +1,29 @@
+package com.gdschongik.gdsc.domain.recruitment.api;
+
+import com.gdschongik.gdsc.domain.recruitment.application.AdminRecruitmentService;
+import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Admin Recruitment", description = "어드민 리쿠르트먼트 관리 API입니다.")
+@RestController
+@RequestMapping("/admin/recruitment")
+@RequiredArgsConstructor
+public class AdminRecruitmentController {
+
+    private final AdminRecruitmentService adminRecruitmentService;
+
+    @Operation(summary = "리쿠르트먼트 생성", description = "새로운 리쿠르트먼트(모집 기간)를 생성합니다.")
+    @PostMapping
+    public ResponseEntity<Void> createRecruitment(@Valid @RequestBody RecruitmentCreateRequest request) {
+        adminRecruitmentService.createRecruitment(request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -1,9 +1,12 @@
 package com.gdschongik.gdsc.domain.recruitment.application;
 
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
+import com.gdschongik.gdsc.global.exception.CustomException;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -19,15 +22,51 @@ public class AdminRecruitmentService {
 
     @Transactional
     public void createRecruitment(RecruitmentCreateRequest request) {
-        LocalDateTime startDate = request.startDate();
-        int academicYear = startDate.getYear();
-        SemesterType semesterType = SemesterType.from(startDate);
-
-        validatePeriodOverlap(academicYear, semesterType, request.startDate(), request.endDate());
+        validatePeriodMatchesAcademicYear(request.startDate(), request.endDate(), request.academicYear());
+        validatePeriodMatchesSemesterType(request.startDate(), request.endDate(), request.semesterType());
+        validatePeriodWithinTwoWeeks(
+                request.startDate(), request.endDate(), request.academicYear(), request.semesterType());
+        validatePeriodOverlap(request.academicYear(), request.semesterType(), request.startDate(), request.endDate());
 
         Recruitment recruitment = Recruitment.createRecruitment(
-                request.name(), request.startDate(), request.endDate(), academicYear, semesterType);
+                request.name(), request.startDate(), request.endDate(), request.academicYear(), request.semesterType());
         recruitmentRepository.save(recruitment);
+        // todo: recruitment 모집 시작 직전에 멤버 역할 수정하는 로직 필요.
+    }
+
+    private void validatePeriodMatchesAcademicYear(
+            LocalDateTime startDate, LocalDateTime endDate, Integer academicYear) {
+        if (academicYear.equals(startDate.getYear()) && academicYear.equals(endDate.getYear())) {
+            return;
+        }
+
+        throw new CustomException(RECRUITMENT_PERIOD_MISMATCH_ACADEMIC_YEAR);
+    }
+
+    private void validatePeriodMatchesSemesterType(
+            LocalDateTime startDate, LocalDateTime endDate, SemesterType semesterType) {
+        if (SemesterType.from(startDate).equals(semesterType)
+                && SemesterType.from(endDate).equals(semesterType)) {
+            return;
+        }
+
+        throw new CustomException(RECRUITMENT_PERIOD_MISMATCH_SEMESTER_TYPE);
+    }
+
+    private void validatePeriodWithinTwoWeeks(
+            LocalDateTime startDate, LocalDateTime endDate, Integer academicYear, SemesterType semesterType) {
+        LocalDateTime semesterStartDate =
+                LocalDateTime.of(academicYear, SemesterType.getStartMonth(semesterType), 1, 0, 0);
+
+        if (semesterStartDate.minusWeeks(2).isAfter(startDate)
+                || semesterStartDate.plusWeeks(2).isBefore(startDate)) {
+            throw new CustomException(RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS);
+        }
+
+        if (semesterStartDate.minusWeeks(2).isAfter(endDate)
+                || semesterStartDate.plusWeeks(2).isBefore(endDate)) {
+            throw new CustomException(RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS);
+        }
     }
 
     private void validatePeriodOverlap(

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -1,0 +1,40 @@
+package com.gdschongik.gdsc.domain.recruitment.application;
+
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminRecruitmentService {
+
+    private final RecruitmentRepository recruitmentRepository;
+
+    @Transactional
+    public void createRecruitment(RecruitmentCreateRequest request) {
+        LocalDateTime startDate = request.startDate();
+        int academicYear = startDate.getYear();
+        SemesterType semesterType = SemesterType.from(startDate);
+
+        validatePeriodOverlap(academicYear, semesterType, request.startDate(), request.endDate());
+
+        Recruitment recruitment = Recruitment.createRecruitment(
+                request.name(), request.startDate(), request.endDate(), academicYear, semesterType);
+        recruitmentRepository.save(recruitment);
+    }
+
+    private void validatePeriodOverlap(
+            Integer academicYear, SemesterType semesterType, LocalDateTime startDate, LocalDateTime endDate) {
+        List<Recruitment> recruitments =
+                recruitmentRepository.findAllByAcademicYearAndSemesterType(academicYear, semesterType);
+
+        recruitments.forEach(recruitment -> recruitment.validatePeriodOverlap(startDate, endDate));
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -65,11 +65,11 @@ public class AdminRecruitmentService {
         /*
         개강일 기준으로 2주 전까지는 같은 학기로 간주한다.
          */
-        if (dateTime.isAfter(firstSemesterStartDate.minusWeeks(TWO_WEEKS)) && dateTime.getMonthValue() < JULY) {
+        if (dateTime.isAfter(firstSemesterStartDate.minusWeeks(PRE_SEMESTER_TERM)) && dateTime.getMonthValue() < JULY) {
             return FIRST;
         }
 
-        if (dateTime.isAfter(secondSemesterStartDate.minusWeeks(TWO_WEEKS))) {
+        if (dateTime.isAfter(secondSemesterStartDate.minusWeeks(PRE_SEMESTER_TERM))) {
             return SECOND;
         }
 
@@ -85,13 +85,13 @@ public class AdminRecruitmentService {
                 0,
                 0);
 
-        if (semesterStartDate.minusWeeks(TWO_WEEKS).isAfter(startDate)
-                || semesterStartDate.plusWeeks(TWO_WEEKS).isBefore(startDate)) {
+        if (semesterStartDate.minusWeeks(PRE_SEMESTER_TERM).isAfter(startDate)
+                || semesterStartDate.plusWeeks(PRE_SEMESTER_TERM).isBefore(startDate)) {
             throw new CustomException(RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS);
         }
 
-        if (semesterStartDate.minusWeeks(TWO_WEEKS).isAfter(endDate)
-                || semesterStartDate.plusWeeks(TWO_WEEKS).isBefore(endDate)) {
+        if (semesterStartDate.minusWeeks(PRE_SEMESTER_TERM).isAfter(endDate)
+                || semesterStartDate.plusWeeks(PRE_SEMESTER_TERM).isBefore(endDate)) {
             throw new CustomException(RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS);
         }
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -73,7 +73,7 @@ public class AdminRecruitmentService {
             return SECOND;
         }
 
-        throw new CustomException(SEMESTER_TYPE_INVALID_FOR_DATE);
+        throw new CustomException(RECRUITMENT_PERIOD_SEMESTER_TYPE_UNMAPPED);
     }
 
     private void validatePeriodWithinTwoWeeks(

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -10,6 +10,7 @@ import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -65,7 +66,8 @@ public class AdminRecruitmentService {
         /*
         개강일 기준으로 2주 전까지는 같은 학기로 간주한다.
          */
-        if (dateTime.isAfter(firstSemesterStartDate.minusWeeks(PRE_SEMESTER_TERM)) && dateTime.getMonthValue() < JULY) {
+        if (dateTime.isAfter(firstSemesterStartDate.minusWeeks(PRE_SEMESTER_TERM))
+                && dateTime.getMonthValue() < Month.JULY.getValue()) {
             return FIRST;
         }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.domain.recruitment.application;
 
+import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
@@ -62,13 +63,13 @@ public class AdminRecruitmentService {
                 0,
                 0);
 
-        if (semesterStartDate.minusWeeks(2).isAfter(startDate)
-                || semesterStartDate.plusWeeks(2).isBefore(startDate)) {
+        if (semesterStartDate.minusWeeks(TWO_WEEKS).isAfter(startDate)
+                || semesterStartDate.plusWeeks(TWO_WEEKS).isBefore(startDate)) {
             throw new CustomException(RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS);
         }
 
-        if (semesterStartDate.minusWeeks(2).isAfter(endDate)
-                || semesterStartDate.plusWeeks(2).isBefore(endDate)) {
+        if (semesterStartDate.minusWeeks(TWO_WEEKS).isAfter(endDate)
+                || semesterStartDate.plusWeeks(TWO_WEEKS).isBefore(endDate)) {
             throw new CustomException(RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS);
         }
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -55,8 +55,12 @@ public class AdminRecruitmentService {
 
     private void validatePeriodWithinTwoWeeks(
             LocalDateTime startDate, LocalDateTime endDate, Integer academicYear, SemesterType semesterType) {
-        LocalDateTime semesterStartDate =
-                LocalDateTime.of(academicYear, SemesterType.getStartMonth(semesterType), 1, 0, 0);
+        LocalDateTime semesterStartDate = LocalDateTime.of(
+                academicYear,
+                semesterType.getStartDate().getMonth(),
+                semesterType.getStartDate().getDayOfMonth(),
+                0,
+                0);
 
         if (semesterStartDate.minusWeeks(2).isAfter(startDate)
                 || semesterStartDate.plusWeeks(2).isBefore(startDate)) {

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRepository.java
@@ -1,6 +1,11 @@
 package com.gdschongik.gdsc.domain.recruitment.dao;
 
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RecruitmentRepository extends JpaRepository<Recruitment, Long>, RecruitmentCustomRepository {}
+public interface RecruitmentRepository extends JpaRepository<Recruitment, Long>, RecruitmentCustomRepository {
+
+    List<Recruitment> findAllByAcademicYearAndSemesterType(Integer academicYear, SemesterType semesterType);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
@@ -50,4 +50,8 @@ public class Recruitment extends BaseSemesterEntity {
     public boolean isOpen() {
         return this.period.isOpen();
     }
+
+    public void validatePeriodOverlap(LocalDateTime startDate, LocalDateTime endDate) {
+        this.period.validatePeriodOverlap(startDate, endDate);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/vo/Period.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/vo/Period.java
@@ -1,7 +1,8 @@
 package com.gdschongik.gdsc.domain.recruitment.domain.vo;
 
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
 import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.global.exception.ErrorCode;
 import jakarta.persistence.Embeddable;
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -31,7 +32,7 @@ public class Period {
 
     private static void validatePeriod(LocalDateTime startDate, LocalDateTime endDate) {
         if (startDate.isAfter(endDate) || startDate.isEqual(endDate)) {
-            throw new CustomException(ErrorCode.DATE_PRECEDENCE_INVALID);
+            throw new CustomException(DATE_PRECEDENCE_INVALID);
         }
     }
 
@@ -39,6 +40,13 @@ public class Period {
         LocalDateTime now = LocalDateTime.now();
         return (now.isAfter(this.startDate) || now.isEqual(startDate))
                 && (now.isBefore(this.endDate) || now.isEqual(startDate));
+    }
+
+    public void validatePeriodOverlap(LocalDateTime startDate, LocalDateTime endDate) {
+        if (this.endDate.isBefore(startDate) || this.startDate.isAfter(endDate)) {
+            return;
+        }
+        throw new CustomException(RECRUITMENT_PERIOD_OVERLAP);
     }
 
     @Override

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentCreateRequest.java
@@ -2,12 +2,17 @@ package com.gdschongik.gdsc.domain.recruitment.dto.request;
 
 import static com.gdschongik.gdsc.global.common.constant.RegexConstant.*;
 
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 public record RecruitmentCreateRequest(
         @NotBlank @Schema(description = "이름") String name,
         @Future @Schema(description = "모집기간 시작일", pattern = DATETIME) LocalDateTime startDate,
-        @Future @Schema(description = "모집기간 종료일", pattern = DATETIME) LocalDateTime endDate) {}
+        @Future @Schema(description = "모집기간 종료일", pattern = DATETIME) LocalDateTime endDate,
+        @NotNull(message = "학년도는 null이 될 수 없습니다.") @Schema(description = "학년도", pattern = ACADEMIC_YEAR)
+                Integer academicYear,
+        @NotNull(message = "학기는 null이 될 수 없습니다.") @Schema(description = "학기") SemesterType semesterType) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentCreateRequest.java
@@ -1,0 +1,13 @@
+package com.gdschongik.gdsc.domain.recruitment.dto.request;
+
+import static com.gdschongik.gdsc.global.common.constant.RegexConstant.*;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+
+public record RecruitmentCreateRequest(
+        @NotBlank @Schema(description = "이름") String name,
+        @Future @Schema(description = "모집기간 시작일", pattern = DATETIME) LocalDateTime startDate,
+        @Future @Schema(description = "모집기간 종료일", pattern = DATETIME) LocalDateTime endDate) {}

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/RegexConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/RegexConstant.java
@@ -9,6 +9,7 @@ public class RegexConstant {
     public static final String DEPARTMENT = "^D[0-9]{3}$";
     public static final String HONGIK_EMAIL = "^[^\\W&=+'-+,<>]+(\\.[^\\W&=+'-+,<>]+)*@g\\.hongik\\.ac\\.kr$";
     public static final String DATETIME = "yyyy-MM-dd'T'HH:mm:ss";
+    public static final String ACADEMIC_YEAR = "^[0-9]{4}$";
 
     private RegexConstant() {}
 }

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/RegexConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/RegexConstant.java
@@ -8,6 +8,7 @@ public class RegexConstant {
     public static final String NICKNAME = "[ㄱ-ㅣ가-힣]{1,6}$";
     public static final String DEPARTMENT = "^D[0-9]{3}$";
     public static final String HONGIK_EMAIL = "^[^\\W&=+'-+,<>]+(\\.[^\\W&=+'-+,<>]+)*@g\\.hongik\\.ac\\.kr$";
+    public static final String DATETIME = "yyyy-MM-dd'T'HH:mm:ss";
 
     private RegexConstant() {}
 }

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/TemporalConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/TemporalConstant.java
@@ -7,6 +7,6 @@ public class TemporalConstant {
     // 월 상수
     public static final int JULY = 7;
 
-    // 주 상수
-    public static final int TWO_WEEKS = 2;
+    // 학기 준비 기간
+    public static final int PRE_SEMESTER_TERM = 2;
 }

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/TemporalConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/TemporalConstant.java
@@ -4,9 +4,6 @@ public class TemporalConstant {
 
     private TemporalConstant() {}
 
-    // 월 상수
-    public static final int JULY = 7;
-
-    // 학기 준비 기간
+    // 학기 준비 기간(주 단위)
     public static final int PRE_SEMESTER_TERM = 2;
 }

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/TemporalConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/TemporalConstant.java
@@ -1,0 +1,12 @@
+package com.gdschongik.gdsc.global.common.constant;
+
+public class TemporalConstant {
+
+    private TemporalConstant() {}
+
+    // 월 상수
+    public static final int JULY = 7;
+
+    // 주 상수
+    public static final int TWO_WEEKS = 2;
+}

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -58,9 +58,6 @@ public enum ErrorCode {
     DISCORD_NICKNAME_NOTNULL(HttpStatus.INTERNAL_SERVER_ERROR, "닉네임은 빈 값이 될 수 없습니다."),
     DISCORD_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "디스코드 멤버를 찾을 수 없습니다."),
 
-    // SemesterType
-    SEMESTER_TYPE_INVALID_FOR_DATE(HttpStatus.CONFLICT, "해당 날짜가 포함되는 학기가 없습니다."),
-
     // Membership
     PAYMENT_NOT_VERIFIED(HttpStatus.CONFLICT, "회비 납부가 완료되지 않았습니다."),
     MEMBERSHIP_NOT_APPLICABLE(HttpStatus.CONFLICT, "멤버십 가입을 신청할 수 없는 회원입니다."),
@@ -73,6 +70,7 @@ public enum ErrorCode {
     RECRUITMENT_PERIOD_OVERLAP(HttpStatus.BAD_REQUEST, "모집 기간이 중복됩니다."),
     RECRUITMENT_PERIOD_MISMATCH_ACADEMIC_YEAR(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 연도가 학년도와 일치하지 않습니다."),
     RECRUITMENT_PERIOD_MISMATCH_SEMESTER_TYPE(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 입력된 학기가 일치하지 않습니다."),
+    RECRUITMENT_PERIOD_SEMESTER_TYPE_UNMAPPED(HttpStatus.CONFLICT, "모집 시작일과 종료일이 매핑되는 학기가 없습니다."),
     RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일이 학기 시작일로부터 2주 이내에 있지 않습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -65,8 +65,8 @@ public enum ErrorCode {
 
     // Recruitment
     DATE_PRECEDENCE_INVALID(HttpStatus.BAD_REQUEST, "종료일이 시작일과 같거나 앞설 수 없습니다."),
-    RECRUITMENT_NOT_OPEN(HttpStatus.CONFLICT, "리크루트먼트 모집기간이 아닙니다."),
-    RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "열려있는 리크루트먼트가 없습니다."),
+    RECRUITMENT_NOT_OPEN(HttpStatus.CONFLICT, "리크루팅 모집기간이 아닙니다."),
+    RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "열려있는 리크루팅이 없습니다."),
     RECRUITMENT_PERIOD_OVERLAP(HttpStatus.BAD_REQUEST, "모집 기간이 중복됩니다."),
     RECRUITMENT_PERIOD_MISMATCH_ACADEMIC_YEAR(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 연도가 학년도와 일치하지 않습니다."),
     RECRUITMENT_PERIOD_MISMATCH_SEMESTER_TYPE(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 입력된 학기가 일치하지 않습니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -62,7 +62,7 @@ public enum ErrorCode {
 
     // Recruitment
     DATE_PRECEDENCE_INVALID(HttpStatus.BAD_REQUEST, "종료일이 시작일과 같거나 앞설 수 없습니다."),
-    PERIOD_DUPLICATE(HttpStatus.BAD_REQUEST, "모집 기간이 중복됩니다.");
+    RECRUITMENT_PERIOD_OVERLAP(HttpStatus.BAD_REQUEST, "모집 기간이 중복됩니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -58,6 +58,9 @@ public enum ErrorCode {
     DISCORD_NICKNAME_NOTNULL(HttpStatus.INTERNAL_SERVER_ERROR, "닉네임은 빈 값이 될 수 없습니다."),
     DISCORD_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "디스코드 멤버를 찾을 수 없습니다."),
 
+    // SemesterType
+    SEMESTER_TYPE_INVALID_FOR_DATE(HttpStatus.CONFLICT, "해당 날짜가 포함되는 학기가 없습니다."),
+
     // Membership
     PAYMENT_NOT_VERIFIED(HttpStatus.CONFLICT, "회비 납부가 완료되지 않았습니다."),
     MEMBERSHIP_NOT_APPLICABLE(HttpStatus.CONFLICT, "멤버십 가입을 신청할 수 없는 회원입니다."),
@@ -67,7 +70,10 @@ public enum ErrorCode {
     DATE_PRECEDENCE_INVALID(HttpStatus.BAD_REQUEST, "종료일이 시작일과 같거나 앞설 수 없습니다."),
     RECRUITMENT_NOT_OPEN(HttpStatus.CONFLICT, "리크루트먼트 모집기간이 아닙니다."),
     RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "열려있는 리크루트먼트가 없습니다."),
-    RECRUITMENT_PERIOD_OVERLAP(HttpStatus.BAD_REQUEST, "모집 기간이 중복됩니다.");
+    RECRUITMENT_PERIOD_OVERLAP(HttpStatus.BAD_REQUEST, "모집 기간이 중복됩니다."),
+    RECRUITMENT_PERIOD_MISMATCH_ACADEMIC_YEAR(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 연도가 학년도와 일치하지 않습니다."),
+    RECRUITMENT_PERIOD_MISMATCH_SEMESTER_TYPE(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 입력된 학기가 일치하지 않습니다."),
+    RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일이 학기 시작일로부터 2주 이내에 있지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -67,7 +67,7 @@ public enum ErrorCode {
     DATE_PRECEDENCE_INVALID(HttpStatus.BAD_REQUEST, "종료일이 시작일과 같거나 앞설 수 없습니다."),
     RECRUITMENT_NOT_OPEN(HttpStatus.CONFLICT, "리크루트먼트 모집기간이 아닙니다."),
     RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "열려있는 리크루트먼트가 없습니다."),
-	RECRUITMENT_PERIOD_OVERLAP(HttpStatus.BAD_REQUEST, "모집 기간이 중복됩니다.");
+    RECRUITMENT_PERIOD_OVERLAP(HttpStatus.BAD_REQUEST, "모집 기간이 중복됩니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -61,7 +61,8 @@ public enum ErrorCode {
     PAYMENT_NOT_VERIFIED(HttpStatus.CONFLICT, "회비 납부가 완료되지 않았습니다."),
 
     // Recruitment
-    DATE_PRECEDENCE_INVALID(HttpStatus.BAD_REQUEST, "종료일이 시작일과 같거나 앞설 수 없습니다.");
+    DATE_PRECEDENCE_INVALID(HttpStatus.BAD_REQUEST, "종료일이 시작일과 같거나 앞설 수 없습니다."),
+    PERIOD_DUPLICATE(HttpStatus.BAD_REQUEST, "모집 기간이 중복됩니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -4,8 +4,7 @@ import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
-import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.integration.IntegrationTest;
 import org.junit.jupiter.api.Nested;
@@ -15,22 +14,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 class AdminRecruitmentServiceTest extends IntegrationTest {
 
     @Autowired
-    private RecruitmentRepository recruitmentRepository;
+    private AdminRecruitmentService adminRecruitmentService;
 
     @Nested
     class 모집기간_생성시 {
         @Test
         void 기간이_중복되는_Recruitment가_있다면_실패한다() {
             // given
-            Recruitment recruitment = Recruitment.createRecruitment(RECRUITMENT_NAME, START_DATE, END_DATE);
-            recruitmentRepository.save(recruitment);
+            RecruitmentCreateRequest request = new RecruitmentCreateRequest(RECRUITMENT_NAME, START_DATE, END_DATE);
+            adminRecruitmentService.createRecruitment(request);
 
             // when & then
-            assertThatThrownBy(() -> {
-                        Recruitment duplicatedRecruitment =
-                                Recruitment.createRecruitment(RECRUITMENT_NAME, START_DATE, END_DATE);
-                        recruitmentRepository.save(duplicatedRecruitment);
-                    })
+            assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(PERIOD_DUPLICATE.getMessage());
         }

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -33,7 +33,8 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         void 기간이_중복되는_Recruitment가_있다면_실패한다() {
             // given
             createRecruitment();
-            RecruitmentCreateRequest request = new RecruitmentCreateRequest(RECRUITMENT_NAME, START_DATE, END_DATE);
+            RecruitmentCreateRequest request =
+                    new RecruitmentCreateRequest(RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -4,11 +4,13 @@ import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.integration.IntegrationTest;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,6 +42,42 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(RECRUITMENT_PERIOD_OVERLAP.getMessage());
+        }
+
+        @Test
+        void 모집_시작일과_종료일의_연도가_입력된_학년도와_다르다면_실패한다() {
+            // given
+            RecruitmentCreateRequest request =
+                    new RecruitmentCreateRequest(RECRUITMENT_NAME, START_DATE, END_DATE, 2025, SEMESTER_TYPE);
+
+            // when & then
+            assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(RECRUITMENT_PERIOD_MISMATCH_ACADEMIC_YEAR.getMessage());
+        }
+
+        @Test
+        void 모집_시작일과_종료일의_학기가_입력된_학기와_다르다면_실패한다() {
+            // given
+            RecruitmentCreateRequest request = new RecruitmentCreateRequest(
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SemesterType.SECOND);
+
+            // when & then
+            assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(RECRUITMENT_PERIOD_MISMATCH_SEMESTER_TYPE.getMessage());
+        }
+
+        @Test
+        void 모집_시작일과_종료일이_학기_시작일로부터_2주_이내에_있지_않다면_실패한다() {
+            // given
+            RecruitmentCreateRequest request = new RecruitmentCreateRequest(
+                    RECRUITMENT_NAME, START_DATE, LocalDateTime.of(2024, 4, 10, 00, 00), ACADEMIC_YEAR, SEMESTER_TYPE);
+
+            // when & then
+            assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS.getMessage());
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -27,7 +27,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(PERIOD_DUPLICATE.getMessage());
+                    .hasMessage(RECRUITMENT_PERIOD_OVERLAP.getMessage());
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -4,6 +4,8 @@ import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.integration.IntegrationTest;
@@ -16,13 +18,22 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
     @Autowired
     private AdminRecruitmentService adminRecruitmentService;
 
+    @Autowired
+    private RecruitmentRepository recruitmentRepository;
+
+    private void createRecruitment() {
+        Recruitment recruitment =
+                Recruitment.createRecruitment(RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE);
+        recruitmentRepository.save(recruitment);
+    }
+
     @Nested
     class 모집기간_생성시 {
         @Test
         void 기간이_중복되는_Recruitment가_있다면_실패한다() {
             // given
+            createRecruitment();
             RecruitmentCreateRequest request = new RecruitmentCreateRequest(RECRUITMENT_NAME, START_DATE, END_DATE);
-            adminRecruitmentService.createRecruitment(request);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -1,0 +1,38 @@
+package com.gdschongik.gdsc.domain.recruitment.application;
+
+import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.integration.IntegrationTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class AdminRecruitmentServiceTest extends IntegrationTest {
+
+    @Autowired
+    private RecruitmentRepository recruitmentRepository;
+
+    @Nested
+    class 모집기간_생성시 {
+        @Test
+        void 기간이_중복되는_Recruitment가_있다면_실패한다() {
+            // given
+            Recruitment recruitment = Recruitment.createRecruitment(RECRUITMENT_NAME, START_DATE, END_DATE);
+            recruitmentRepository.save(recruitment);
+
+            // when & then
+            assertThatThrownBy(() -> {
+                        Recruitment duplicatedRecruitment =
+                                Recruitment.createRecruitment(RECRUITMENT_NAME, START_DATE, END_DATE);
+                        recruitmentRepository.save(duplicatedRecruitment);
+                    })
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PERIOD_DUPLICATE.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #333

## 📌 작업 내용 및 특이사항
- ~~`academicYear`와 `semesterType`을 dto로 받을지 고민이었는데 일단은 모집기간 시작일을 기준으로 서버에서 처리하도록 구현했습니다.~~
  - ~~dto로 입력 받는다면 모집기간 시작일과 어긋나지 않는지 (예를 들어, 모집 기간 시작일은 24년 2월인데 `academicYear`와 `semesterType`을 2023, `SECOND`로 입력한 경우) 검증이 필요해지므로,
  서버에서 직접 처리하는게 좋다고 판단했습니다.~~
  - ~~semesterType은 시작일의 Month를 기준으로 1 ~ 6월은 `FIRST`, 7 ~ 12월은 `SECOND`가 되도록 했습니다.~~
- 검증해야 할 사항은 아래와 같습니다. 
  1. 기간이_중복되는_Recruitment가_있다면_실패한다
  2. 신청 시작일과 종료일은 모두 미래의 시점이다.
  3. 신청 시작일과 종료일의 year가 dto의 academicYear와 일치하는가
  4. 신청 시작일과 종료일의 학기가 dto의 semesterType과 일치하는가
  5. 신청 시작일과 종료일이 학기 시작일(3/1 혹은 9/1)로부터 2주 이내에 있는가
  
ii의 경우 dto에서 어노테이션으로 검증되는 부분이라 test를 작성하지는 않았습니다.

## 📝 참고사항
- 1차 모집 기간의 직전일에 기존 REGULAR 회원들을 모두 ASSOCIATE로 강등시키는 로직이 빠져있습니다.
이 부분은 코드 몇 줄로 끝나지 않을 것 같고 별도 이슈로 만들어 처리하는게 pr 리뷰하시기에 편할 것 같아서 todo 주석만 남겨뒀습니다.

## 📚 기타
-
