### PR TITLE
refactor : 멤버 도메인 준회원 승급 조건 추가 - 기본 정보 작성

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/DiscordIdBatchCommandHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/DiscordIdBatchCommandHandler.java
@@ -28,8 +28,5 @@ public class DiscordIdBatchCommandHandler implements DiscordEventHandler {
                 .sendMessage(REPLY_MESSAGE_BATCH_DISCORD_ID)
                 .setEphemeral(true)
                 .queue();
-
-        // 뷰 로직.
-        // @Trasactional DB
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/DiscordIdBatchCommandHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/DiscordIdBatchCommandHandler.java
@@ -28,5 +28,8 @@ public class DiscordIdBatchCommandHandler implements DiscordEventHandler {
                 .sendMessage(REPLY_MESSAGE_BATCH_DISCORD_ID)
                 .setEphemeral(true)
                 .queue();
+
+        // 뷰 로직.
+        // @Trasactional DB
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/handler/MemberAssociateEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/handler/MemberAssociateEventHandler.java
@@ -1,0 +1,40 @@
+package com.gdschongik.gdsc.domain.member.application.handler;
+
+import static com.gdschongik.gdsc.domain.member.domain.MemberRole.*;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberAssociateEvent;
+import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberAssociateEventHandler {
+    public void handle(Object context) {
+        MemberAssociateEvent event = (MemberAssociateEvent) context;
+        if (validateAdvanceAvailable(event.member())) {
+            advanceToAssociate(event.member());
+        }
+    }
+
+    private void advanceToAssociate(Member member) {
+        member.advanceToAssociate();
+    }
+
+    private boolean validateAdvanceAvailable(Member member) {
+        if (isAtLeastAssociate(member.getRole())) {
+            return false;
+        }
+
+        if (member.isAllVerified()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean isAtLeastAssociate(MemberRole role) {
+        return role.equals(ASSOCIATE) || role.equals(ADMIN) || role.equals(REGULAR);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/handler/MemberAssociateEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/handler/MemberAssociateEventHandler.java
@@ -6,8 +6,10 @@ import com.gdschongik.gdsc.domain.member.domain.MemberAssociateEvent;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class MemberAssociateEventHandler {
@@ -17,20 +19,10 @@ public class MemberAssociateEventHandler {
         Member member = memberRepository
                 .findById(memberAssociateEvent.memberId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-        if (validateAdvanceAvailable(member)) {
+        try {
             member.advanceToAssociate();
+        } catch (CustomException e) {
+            log.info("{}", e.getErrorCode());
         }
-    }
-
-    private boolean validateAdvanceAvailable(Member member) {
-        if (member.isAtLeastAssociate()) {
-            return false;
-        }
-
-        if (member.getRequirement().isAllVerified()) {
-            return true;
-        }
-
-        return false;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/handler/MemberAssociateEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/handler/MemberAssociateEventHandler.java
@@ -1,7 +1,5 @@
 package com.gdschongik.gdsc.domain.member.application.handler;
 
-import static com.gdschongik.gdsc.domain.member.domain.MemberRole.*;
-
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberAssociateEvent;
@@ -30,7 +28,7 @@ public class MemberAssociateEventHandler {
             return false;
         }
 
-        if (member.isAllVerified()) {
+        if (member.getRequirement().isAllVerified()) {
             return true;
         }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/handler/MemberAssociateEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/handler/MemberAssociateEventHandler.java
@@ -11,8 +11,8 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class MemberAssociateEventHandler {
-    public void handle(Object context) {
-        MemberAssociateEvent event = (MemberAssociateEvent) context;
+    public void handle(MemberAssociateEvent context) {
+        MemberAssociateEvent event = context;
         if (validateAdvanceAvailable(event.member())) {
             advanceToAssociate(event.member());
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/handler/MemberAssociateEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/handler/MemberAssociateEventHandler.java
@@ -14,9 +14,8 @@ public class MemberAssociateEventHandler {
     private final MemberRepository memberRepository;
 
     public void advanceToAssociate(MemberAssociateEvent memberAssociateEvent) {
-        MemberAssociateEvent event = memberAssociateEvent;
         Member member = memberRepository
-                .findById(event.memberId())
+                .findById(memberAssociateEvent.memberId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
         if (validateAdvanceAvailable(member)) {
             member.advanceToAssociate();
@@ -24,7 +23,7 @@ public class MemberAssociateEventHandler {
     }
 
     private boolean validateAdvanceAvailable(Member member) {
-        if (member.isAtLeastAssociate(member.getRole())) {
+        if (member.isAtLeastAssociate()) {
             return false;
         }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/listener/MemberAssociateEventListener.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/listener/MemberAssociateEventListener.java
@@ -1,51 +1,21 @@
 package com.gdschongik.gdsc.domain.member.application.listener;
 
-import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.application.handler.MemberAssociateEventHandler;
 import com.gdschongik.gdsc.domain.member.domain.MemberAssociateEvent;
-import com.gdschongik.gdsc.domain.member.domain.MemberRole;
-import com.gdschongik.gdsc.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
-
-import static com.gdschongik.gdsc.domain.member.domain.MemberRole.*;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class MemberAssociateEventListener {
 
-    private final MemberUtil memberUtil;
+    private final MemberAssociateEventHandler memberAssociateEventHandler;
 
     @TransactionalEventListener(MemberAssociateEvent.class)
     public void handleMemberAssociateEvent(MemberAssociateEvent event) {
-        Member member = memberUtil.getCurrentMember();
-        if(validateAdvanceAvailable(member)) {
-            advanceToAssociate(member);
-        }
+        memberAssociateEventHandler.handle(event);
     }
-
-
-    public void advanceToAssociate(Member member) {
-        member.advanceToAssociate();
-    }
-
-    private boolean validateAdvanceAvailable(Member member) {
-        if (isAtLeastAssociate(member.getRole())) {
-            return false;
-        }
-
-        if (member.isAllVerified()) {
-            return true;
-        }
-
-        return false;
-    }
-
-    private boolean isAtLeastAssociate(MemberRole role) {
-        return role.equals(ASSOCIATE) || role.equals(ADMIN) || role.equals(REGULAR);
-    }
-
-
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/listener/MemberAssociateEventListener.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/listener/MemberAssociateEventListener.java
@@ -14,6 +14,6 @@ public class MemberAssociateEventListener {
 
     @TransactionalEventListener(MemberAssociateEvent.class)
     public void handleMemberAssociateEvent(MemberAssociateEvent event) {
-        memberAssociateEventHandler.handle(event);
+        memberAssociateEventHandler.advanceToAssociate(event);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/listener/MemberAssociateEventListener.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/listener/MemberAssociateEventListener.java
@@ -1,0 +1,51 @@
+package com.gdschongik.gdsc.domain.member.application.listener;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberAssociateEvent;
+import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.global.util.MemberUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static com.gdschongik.gdsc.domain.member.domain.MemberRole.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberAssociateEventListener {
+
+    private final MemberUtil memberUtil;
+
+    @TransactionalEventListener(MemberAssociateEvent.class)
+    public void handleMemberAssociateEvent(MemberAssociateEvent event) {
+        Member member = memberUtil.getCurrentMember();
+        if(validateAdvanceAvailable(member)) {
+            advanceToAssociate(member);
+        }
+    }
+
+
+    public void advanceToAssociate(Member member) {
+        member.advanceToAssociate();
+    }
+
+    private boolean validateAdvanceAvailable(Member member) {
+        if (isAtLeastAssociate(member.getRole())) {
+            return false;
+        }
+
+        if (member.isAllVerified()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean isAtLeastAssociate(MemberRole role) {
+        return role.equals(ASSOCIATE) || role.equals(ADMIN) || role.equals(REGULAR);
+    }
+
+
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/listener/MemberAssociateEventListener.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/listener/MemberAssociateEventListener.java
@@ -3,11 +3,9 @@ package com.gdschongik.gdsc.domain.member.application.listener;
 import com.gdschongik.gdsc.domain.member.application.handler.MemberAssociateEventHandler;
 import com.gdschongik.gdsc.domain.member.domain.MemberAssociateEvent;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class MemberAssociateEventListener {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -28,7 +28,7 @@ public class MemberCustomRepositoryImpl extends MemberQueryMethod implements Mem
     public Page<Member> findAllGrantable(MemberQueryOption queryOption, Pageable pageable) {
         List<Member> fetch = queryFactory
                 .selectFrom(member)
-                .where(matchesQueryOption(queryOption), eqRole(MemberRole.GUEST), isGrantAvailable())
+                .where(matchesQueryOption(queryOption), eqRole(MemberRole.GUEST), isAssociateAvailable())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(member.createdAt.desc())
@@ -37,7 +37,7 @@ public class MemberCustomRepositoryImpl extends MemberQueryMethod implements Mem
         JPAQuery<Long> countQuery = queryFactory
                 .select(member.count())
                 .from(member)
-                .where(matchesQueryOption(queryOption), eqRole(MemberRole.GUEST), isGrantAvailable());
+                .where(matchesQueryOption(queryOption), eqRole(MemberRole.GUEST), isAssociateAvailable());
 
         return PageableExecutionUtils.getPage(fetch, pageable, countQuery::fetchOne);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberQueryMethod.java
@@ -67,6 +67,14 @@ public class MemberQueryMethod {
                 .and(eqRequirementStatus(member.requirement.bevyStatus, VERIFIED));
     }
 
+    protected BooleanBuilder isAssociateAvailable() {
+        return new BooleanBuilder()
+                .and(eqRequirementStatus(member.requirement.discordStatus, VERIFIED))
+                .and(eqRequirementStatus(member.requirement.univStatus, VERIFIED))
+                .and(eqRequirementStatus(member.requirement.infoStatus, VERIFIED))
+                .and(eqRequirementStatus(member.requirement.bevyStatus, VERIFIED));
+    }
+
     protected BooleanBuilder matchesQueryOption(MemberQueryOption queryOption) {
         return new BooleanBuilder()
                 .and(eqStudentId(queryOption.studentId()))

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -255,7 +255,7 @@ public class Member extends BaseTimeEntity {
     private void verifyUnivEmail() {
         validateStatusUpdatable();
         requirement.updateUnivStatus(RequirementStatus.VERIFIED);
-        registerEvent(new MemberAssociateEvent(this));
+        registerEvent(new MemberAssociateEvent(this.id));
     }
 
     public boolean isAllVerified() {
@@ -281,13 +281,17 @@ public class Member extends BaseTimeEntity {
         return true;
     }
 
+    public boolean isAtLeastAssociate(MemberRole role) {
+        return role.equals(ASSOCIATE) || role.equals(ADMIN) || role.equals(REGULAR);
+    }
+
     public void verifyDiscord(String discordUsername, String nickname) {
         validateStatusUpdatable();
         this.requirement.verifyDiscord();
         this.discordUsername = discordUsername;
         this.nickname = nickname;
 
-        registerEvent(new MemberAssociateEvent(this));
+        registerEvent(new MemberAssociateEvent(this.id));
     }
 
     /**
@@ -302,14 +306,14 @@ public class Member extends BaseTimeEntity {
         validateStatusUpdatable();
 
         this.requirement.verifyBevy();
-        registerEvent(new MemberAssociateEvent(this));
+        registerEvent(new MemberAssociateEvent(this.id));
     }
 
     public void verifyInfo() {
         validateStatusUpdatable();
         this.requirement.verifyInfoStatus();
 
-        registerEvent(new MemberAssociateEvent(this));
+        registerEvent(new MemberAssociateEvent(this.id));
     }
 
     // 데이터 전달 로직

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -176,6 +176,7 @@ public class Member extends BaseTimeEntity {
     public void updateBasicMemberInfo(
             String studentId, String name, String phone, Department department, String email) {
         validateStatusUpdatable();
+        verifyInfoStatus();
 
         this.studentId = studentId;
         this.name = name;
@@ -187,9 +188,10 @@ public class Member extends BaseTimeEntity {
     /**
      * GUEST -> 준회원으로 승급됩니다.
      * 모든 조건을 충족하면 서버에서 각각의 인증과정에서 자동으로 advanceToAssociate()호출된다
-     * 조건 1 : 재학생 인증
-     * 조건 2 : 디스코드 인증
-     * 조건 3 : Bevy 인증
+     * 조건 1 : 기본 회원정보 작성
+     * 조건 2 : 재학생 인증
+     * 조건 3 : 디스코드 인증
+     * 조건 4 : Bevy 인증
      */
     public void advanceToAssociate() {
         validateStatusUpdatable();
@@ -256,6 +258,9 @@ public class Member extends BaseTimeEntity {
         if (isAtLeastAssociate()) {
             return false;
         }
+        if (!this.requirement.isInfoVerified()) {
+            return false;
+        }
 
         if (!this.requirement.isDiscordVerified() || this.discordUsername == null || this.nickname == null) {
             return false;
@@ -274,6 +279,10 @@ public class Member extends BaseTimeEntity {
     private void validateAssociateAvailable() {
         if (isAtLeastAssociate()) {
             throw new CustomException(MEMBER_ALREADY_GRANTED);
+        }
+
+        if (!this.requirement.isInfoVerified()) {
+            throw new CustomException(BASIC_INFO_NOT_VERIFIED);
         }
 
         if (!this.requirement.isDiscordVerified() || this.discordUsername == null || this.nickname == null) {
@@ -316,6 +325,13 @@ public class Member extends BaseTimeEntity {
     public void verifyBevy() {
         validateStatusUpdatable();
         this.requirement.verifyBevy();
+        if (isAssociateAvailable()) {
+            advanceToAssociate();
+        }
+    }
+
+    public void verifyInfoStatus() {
+        this.requirement.verifyInfoStatus();
         if (isAssociateAvailable()) {
             advanceToAssociate();
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -132,14 +132,15 @@ public class Member extends BaseTimeEntity {
 
     /**
      * 회원 승인 가능 여부를 검증합니다.
+     * TODO validateAdvanceAvailable로 수정해야 함
      */
     private void validateGrantAvailable() {
         if (isGranted()) {
             throw new CustomException(MEMBER_ALREADY_GRANTED);
         }
 
-        if (!this.requirement.isPaymentVerified()) {
-            throw new CustomException(PAYMENT_NOT_VERIFIED);
+        if (!this.requirement.isInfoVerified()) {
+            throw new CustomException(BASIC_INFO_NOT_VERIFIED);
         }
 
         if (!this.requirement.isDiscordVerified() || this.discordUsername == null || this.nickname == null) {
@@ -184,7 +185,7 @@ public class Member extends BaseTimeEntity {
         this.department = department;
         this.email = email;
 
-        registerEvent(new MemberAssociateEvent());
+        registerEvent(new MemberAssociateEvent(this));
     }
 
     /**
@@ -197,6 +198,7 @@ public class Member extends BaseTimeEntity {
      */
     public void advanceToAssociate() {
         validateStatusUpdatable();
+        validateGrantAvailable();
 
         this.role = ASSOCIATE;
         registerEvent(new MemberGrantEvent(discordUsername, nickname));
@@ -250,8 +252,9 @@ public class Member extends BaseTimeEntity {
     public void completeUnivEmailVerification(String univEmail) {
         this.univEmail = univEmail;
         requirement.updateUnivStatus(RequirementStatus.VERIFIED);
-        registerEvent(new MemberAssociateEvent());
+        registerEvent(new MemberAssociateEvent(this));
     }
+
     public boolean isAllVerified() {
         if (validateAssociateAvailable()) {
             return true;
@@ -284,7 +287,7 @@ public class Member extends BaseTimeEntity {
         this.discordUsername = discordUsername;
         this.nickname = nickname;
 
-        registerEvent(new MemberAssociateEvent());
+        registerEvent(new MemberAssociateEvent(this));
     }
 
     /**
@@ -299,12 +302,12 @@ public class Member extends BaseTimeEntity {
         validateStatusUpdatable();
 
         this.requirement.verifyBevy();
-        registerEvent(new MemberAssociateEvent());
+        registerEvent(new MemberAssociateEvent(this));
     }
 
     public void verifyInfoStatus() {
         this.requirement.verifyInfoStatus();
-        registerEvent(new MemberAssociateEvent());
+        registerEvent(new MemberAssociateEvent(this));
     }
 
     // 데이터 전달 로직

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -135,7 +135,7 @@ public class Member extends BaseTimeEntity {
      * TODO validateAdvanceAvailable로 수정해야 함
      */
     private void validateGrantAvailable() {
-        if (isGranted()) {
+        if (isAtLeastAssociate()) {
             throw new CustomException(MEMBER_ALREADY_GRANTED);
         }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -256,13 +256,13 @@ public class Member extends BaseTimeEntity {
     }
 
     public boolean isAllVerified() {
-        if (validateAssociateAvailable()) {
+        if (isAssociateAvailable()) {
             return true;
         }
         return false;
     }
 
-    private boolean validateAssociateAvailable() {
+    private boolean isAssociateAvailable() {
         if (!this.requirement.isInfoVerified()) {
             return false;
         }
@@ -307,7 +307,6 @@ public class Member extends BaseTimeEntity {
 
     public void verifyInfoStatus() {
         this.requirement.verifyInfoStatus();
-        registerEvent(new MemberAssociateEvent(this));
     }
 
     // 데이터 전달 로직

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -184,8 +184,6 @@ public class Member extends BaseTimeEntity {
         this.phone = phone;
         this.department = department;
         this.email = email;
-
-        registerEvent(new MemberAssociateEvent(this));
     }
 
     /**
@@ -307,6 +305,8 @@ public class Member extends BaseTimeEntity {
 
     public void verifyInfoStatus() {
         this.requirement.verifyInfoStatus();
+
+        registerEvent(new MemberAssociateEvent(this));
     }
 
     // 데이터 전달 로직

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -258,29 +258,6 @@ public class Member extends BaseTimeEntity {
         registerEvent(new MemberAssociateEvent(this.id));
     }
 
-    public boolean isAllVerified() {
-        return isAssociateAvailable();
-    }
-
-    private boolean isAssociateAvailable() {
-        if (!this.requirement.isInfoVerified()) {
-            return false;
-        }
-
-        if (!this.requirement.isDiscordVerified() || this.discordUsername == null || this.nickname == null) {
-            return false;
-        }
-
-        if (!this.requirement.isBevyVerified()) {
-            return false;
-        }
-
-        if (!this.requirement.isUnivVerified() || this.univEmail == null) {
-            return false;
-        }
-        return true;
-    }
-
     public boolean isAtLeastAssociate(MemberRole role) {
         return role.equals(ASSOCIATE) || role.equals(ADMIN) || role.equals(REGULAR);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -258,8 +258,8 @@ public class Member extends BaseTimeEntity {
         registerEvent(new MemberAssociateEvent(this.id));
     }
 
-    public boolean isAtLeastAssociate(MemberRole role) {
-        return role.equals(ASSOCIATE) || role.equals(ADMIN) || role.equals(REGULAR);
+    public boolean isAtLeastAssociate() {
+        return this.role.equals(ASSOCIATE) || this.role.equals(ADMIN) || this.role.equals(REGULAR);
     }
 
     public void verifyDiscord(String discordUsername, String nickname) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -177,7 +177,7 @@ public class Member extends BaseTimeEntity {
     public void updateBasicMemberInfo(
             String studentId, String name, String phone, Department department, String email) {
         validateStatusUpdatable();
-        verifyInfoStatus();
+        verifyInfo();
 
         this.studentId = studentId;
         this.name = name;
@@ -249,15 +249,17 @@ public class Member extends BaseTimeEntity {
 
     public void completeUnivEmailVerification(String univEmail) {
         this.univEmail = univEmail;
+        verifyUnivEmail();
+    }
+
+    private void verifyUnivEmail() {
+        validateStatusUpdatable();
         requirement.updateUnivStatus(RequirementStatus.VERIFIED);
         registerEvent(new MemberAssociateEvent(this));
     }
 
     public boolean isAllVerified() {
-        if (isAssociateAvailable()) {
-            return true;
-        }
-        return false;
+        return isAssociateAvailable();
     }
 
     private boolean isAssociateAvailable() {
@@ -303,7 +305,8 @@ public class Member extends BaseTimeEntity {
         registerEvent(new MemberAssociateEvent(this));
     }
 
-    public void verifyInfoStatus() {
+    public void verifyInfo() {
+        validateStatusUpdatable();
         this.requirement.verifyInfoStatus();
 
         registerEvent(new MemberAssociateEvent(this));

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -258,7 +258,7 @@ public class Member extends BaseTimeEntity {
         registerEvent(new MemberAssociateEvent(this.id));
     }
 
-    public boolean isAtLeastAssociate() {
+    private boolean isAtLeastAssociate() {
         return this.role.equals(ASSOCIATE) || this.role.equals(ADMIN) || this.role.equals(REGULAR);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberAssociateEvent.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberAssociateEvent.java
@@ -1,3 +1,3 @@
 package com.gdschongik.gdsc.domain.member.domain;
 
-public record MemberAssociateEvent(Member member) {}
+public record MemberAssociateEvent(Long memberId) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberAssociateEvent.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberAssociateEvent.java
@@ -1,4 +1,3 @@
 package com.gdschongik.gdsc.domain.member.domain;
 
-public record MemberAssociateEvent() {
-}
+public record MemberAssociateEvent(Member member) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberAssociateEvent.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberAssociateEvent.java
@@ -1,0 +1,4 @@
+package com.gdschongik.gdsc.domain.member.domain;
+
+public record MemberAssociateEvent() {
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Requirement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Requirement.java
@@ -27,16 +27,21 @@ public class Requirement {
     @Enumerated(EnumType.STRING)
     private RequirementStatus bevyStatus;
 
+    @Enumerated(EnumType.STRING)
+    private RequirementStatus infoStatus;
+
     @Builder(access = AccessLevel.PRIVATE)
     private Requirement(
             RequirementStatus univStatus,
             RequirementStatus discordStatus,
             RequirementStatus paymentStatus,
-            RequirementStatus bevyStatus) {
+            RequirementStatus bevyStatus,
+            RequirementStatus infoStatus) {
         this.univStatus = univStatus;
         this.discordStatus = discordStatus;
         this.paymentStatus = paymentStatus;
         this.bevyStatus = bevyStatus;
+        this.infoStatus = infoStatus;
     }
 
     public static Requirement createRequirement() {
@@ -45,6 +50,7 @@ public class Requirement {
                 .discordStatus(PENDING)
                 .paymentStatus(PENDING)
                 .bevyStatus(PENDING)
+                .infoStatus(PENDING)
                 .build();
     }
 
@@ -64,6 +70,10 @@ public class Requirement {
         this.bevyStatus = VERIFIED;
     }
 
+    public void verifyInfoStatus() {
+        this.infoStatus = VERIFIED;
+    }
+
     public boolean isUnivVerified() {
         return this.univStatus == VERIFIED;
     }
@@ -78,5 +88,9 @@ public class Requirement {
 
     public boolean isBevyVerified() {
         return this.bevyStatus == VERIFIED;
+    }
+
+    public boolean isInfoVerified() {
+        return this.infoStatus == VERIFIED;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Requirement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Requirement.java
@@ -99,9 +99,6 @@ public class Requirement {
     }
 
     private boolean isAssociateAvailable() {
-        if (!this.isInfoVerified() || !this.isDiscordVerified() || !this.isBevyVerified() || !this.isUnivVerified()) {
-            return false;
-        }
-        return true;
+        return this.isInfoVerified() && this.isDiscordVerified() && this.isBevyVerified() && this.isUnivVerified();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Requirement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Requirement.java
@@ -93,4 +93,27 @@ public class Requirement {
     public boolean isInfoVerified() {
         return this.infoStatus == VERIFIED;
     }
+
+    public boolean isAllVerified() {
+        return isAssociateAvailable();
+    }
+
+    private boolean isAssociateAvailable() {
+        if (!this.isInfoVerified()) {
+            return false;
+        }
+
+        if (!this.isDiscordVerified()) {
+            return false;
+        }
+
+        if (!this.isBevyVerified()) {
+            return false;
+        }
+
+        if (!this.isUnivVerified()) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Requirement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Requirement.java
@@ -1,7 +1,10 @@
 package com.gdschongik.gdsc.domain.member.domain;
 
 import static com.gdschongik.gdsc.domain.member.domain.RequirementStatus.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.UNIV_NOT_VERIFIED;
 
+import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Requirement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Requirement.java
@@ -99,19 +99,7 @@ public class Requirement {
     }
 
     private boolean isAssociateAvailable() {
-        if (!this.isInfoVerified()) {
-            return false;
-        }
-
-        if (!this.isDiscordVerified()) {
-            return false;
-        }
-
-        if (!this.isBevyVerified()) {
-            return false;
-        }
-
-        if (!this.isUnivVerified()) {
+        if (!this.isInfoVerified() || !this.isDiscordVerified() || !this.isBevyVerified() || !this.isUnivVerified()) {
             return false;
         }
         return true;

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Requirement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Requirement.java
@@ -1,10 +1,7 @@
 package com.gdschongik.gdsc.domain.member.domain;
 
 import static com.gdschongik.gdsc.domain.member.domain.RequirementStatus.*;
-import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
-import static com.gdschongik.gdsc.global.exception.ErrorCode.UNIV_NOT_VERIFIED;
 
-import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -66,7 +66,8 @@ public enum ErrorCode {
     // Recruitment
     DATE_PRECEDENCE_INVALID(HttpStatus.BAD_REQUEST, "종료일이 시작일과 같거나 앞설 수 없습니다."),
     RECRUITMENT_NOT_OPEN(HttpStatus.CONFLICT, "리크루트먼트 모집기간이 아닙니다."),
-    RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "열려있는 리크루트먼트가 없습니다.");
+    RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "열려있는 리크루트먼트가 없습니다."),
+    BASIC_INFO_NOT_VERIFIED(HttpStatus.CONFLICT, "기본 회원정보 작성이 완료되지 않았습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -40,7 +40,7 @@ public enum ErrorCode {
     UNIV_NOT_VERIFIED(HttpStatus.CONFLICT, "재학생 인증이 완료되지 않았습니다."),
     DISCORD_NOT_VERIFIED(HttpStatus.CONFLICT, "디스코드 인증이 완료되지 않았습니다."),
     BEVY_NOT_VERIFIED(HttpStatus.CONFLICT, "GDSC Bevy 가입이 완료되지 않았습니다."),
-    BASIC_INFO_NOT_VERIFIED(HttpStatus.CONFLICT, "기본 회원정보 작성이 완료되지 않았습니다.");
+    BASIC_INFO_NOT_VERIFIED(HttpStatus.CONFLICT, "기본 회원정보 작성이 완료되지 않았습니다."),
 
     // Univ Email Verification
     UNIV_EMAIL_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 가입된 재학생 메일입니다."),

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/MemberIntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/MemberIntegrationTest.java
@@ -7,6 +7,7 @@ import static com.gdschongik.gdsc.global.common.constant.MemberConstant.NICKNAME
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.gdschongik.gdsc.domain.member.application.handler.MemberAssociateEventHandler;
+import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberAssociateEvent;
 import com.gdschongik.gdsc.integration.IntegrationTest;
@@ -19,15 +20,22 @@ public class MemberIntegrationTest extends IntegrationTest {
     @Autowired
     private MemberAssociateEventHandler memberAssociateEventHandler;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
     @Test
     void 준회원_승급조건_만족됐으면_MemberRole은_ASSOCIATE이다() {
-        // when
+        // given
         Member member = Member.createGuestMember(OAUTH_ID);
+        memberRepository.save(member);
         member.completeUnivEmailVerification(UNIV_EMAIL);
         member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
         member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
         member.verifyBevy();
-        memberAssociateEventHandler.handle(new MemberAssociateEvent(member));
+
+        // when
+        memberAssociateEventHandler.advanceToAssociate(new MemberAssociateEvent(member.getId()));
+        member = memberRepository.save(member);
 
         // then
         assertThat(member.getRole()).isEqualTo(ASSOCIATE);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/MemberIntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/MemberIntegrationTest.java
@@ -1,0 +1,35 @@
+package com.gdschongik.gdsc.domain.member.application;
+
+import static com.gdschongik.gdsc.domain.member.domain.Department.D022;
+import static com.gdschongik.gdsc.domain.member.domain.MemberRole.ASSOCIATE;
+import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.MemberConstant.NICKNAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gdschongik.gdsc.domain.member.application.handler.MemberAssociateEventHandler;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberAssociateEvent;
+import com.gdschongik.gdsc.integration.IntegrationTest;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Slf4j
+public class MemberIntegrationTest extends IntegrationTest {
+    @Autowired
+    private MemberAssociateEventHandler memberAssociateEventHandler;
+
+    @Test
+    void 준회원_승급조건_만족됐으면_MemberRole은_ASSOCIATE이다() {
+        // when
+        Member member = Member.createGuestMember(OAUTH_ID);
+        member.completeUnivEmailVerification(UNIV_EMAIL);
+        member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
+        member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
+        member.verifyBevy();
+        memberAssociateEventHandler.handle(new MemberAssociateEvent(member));
+
+        // then
+        assertThat(member.getRole()).isEqualTo(ASSOCIATE);
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -41,9 +41,9 @@ class MemberRepositoryTest extends RepositoryTest {
         void 준회원_승급조건_모두_충족했다면_조회_성공한다() {
             // given
             Member member = getMember();
+            member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
             member.getRequirement().updateUnivStatus(VERIFIED);
             member.getRequirement().verifyDiscord();
-            member.getRequirement().updatePaymentStatus(VERIFIED);
             member.getRequirement().verifyBevy();
 
             // when
@@ -169,6 +169,7 @@ class MemberRepositoryTest extends RepositoryTest {
             member.completeUnivEmailVerification(UNIV_EMAIL);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
             member.verifyBevy();
+            member.advanceToAssociate();
 
             flushAndClearBeforeExecute();
 
@@ -188,6 +189,7 @@ class MemberRepositoryTest extends RepositoryTest {
             member.completeUnivEmailVerification(UNIV_EMAIL);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
             member.verifyBevy();
+            member.advanceToAssociate();
 
             flushAndClearBeforeExecute();
 

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -49,6 +49,7 @@ class MemberTest {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
+            member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
             member.completeUnivEmailVerification(UNIV_EMAIL);
             member.verifyBevy();
 
@@ -65,6 +66,7 @@ class MemberTest {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
+            member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
             member.completeUnivEmailVerification(UNIV_EMAIL);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
 
@@ -77,10 +79,11 @@ class MemberTest {
         }
 
         @Test
-        void 디스코드인증_Bevy인증_재학생인증하면_성공한다() {
+        void 기본_회원정보_작성_디스코드인증_Bevy인증_재학생인증하면_성공한다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
+            member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
             member.completeUnivEmailVerification(UNIV_EMAIL);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
             member.verifyBevy();
@@ -93,7 +96,7 @@ class MemberTest {
         void 이미_준회원으로_승급_돼있으면_실패한다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
-
+            member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
             member.completeUnivEmailVerification(UNIV_EMAIL);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
             member.verifyBevy();
@@ -231,6 +234,7 @@ class MemberTest {
         void 준회원_승급조건이_모두_만족됐으면_MemberRole은_ASSOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
+            member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
             member.verifyBevy();
 
@@ -260,6 +264,7 @@ class MemberTest {
         void 준회원_승급조건이_모두_만족됐으면_MemberRole은_ASSOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
+            member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
             member.completeUnivEmailVerification(UNIV_EMAIL);
             member.verifyBevy();
 
@@ -289,6 +294,7 @@ class MemberTest {
         void 준회원_승급조건이_모두_만족됐으면_MemberRole은_ASSOCIATE이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
+            member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
             member.completeUnivEmailVerification(UNIV_EMAIL);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -53,7 +53,7 @@ class MemberTest {
             member.verifyBevy();
 
             // when & then
-            assertThat(member.isAllVerified()).isFalse();
+            assertThat(member.getRequirement().isAllVerified()).isFalse();
         }
 
         @Test
@@ -66,7 +66,7 @@ class MemberTest {
             member.verifyBevy();
 
             // when & then
-            assertThat(member.isAllVerified()).isFalse();
+            assertThat(member.getRequirement().isAllVerified()).isFalse();
         }
 
         @Test
@@ -79,7 +79,7 @@ class MemberTest {
             member.verifyBevy();
 
             // when & then
-            assertThat(member.isAllVerified()).isFalse();
+            assertThat(member.getRequirement().isAllVerified()).isFalse();
         }
 
         @Test
@@ -92,7 +92,7 @@ class MemberTest {
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
 
             // when & then
-            assertThat(member.isAllVerified()).isFalse();
+            assertThat(member.getRequirement().isAllVerified()).isFalse();
         }
 
         @Test
@@ -106,7 +106,7 @@ class MemberTest {
             member.verifyBevy();
 
             // when & then
-            assertThat(member.isAllVerified()).isTrue();
+            assertThat(member.getRequirement().isAllVerified()).isTrue();
         }
     }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -105,7 +105,7 @@ class MemberTest {
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
             member.verifyBevy();
 
-            // then
+            // when & then
             assertThat(member.isAllVerified()).isTrue();
         }
     }
@@ -155,7 +155,6 @@ class MemberTest {
             member.completeUnivEmailVerification(UNIV_EMAIL);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
 
-            System.out.println(member.getRequirement().isInfoVerified());
             // when & then
             assertThatThrownBy(() -> {
                         member.advanceToAssociate();
@@ -165,7 +164,7 @@ class MemberTest {
         }
 
         @Test
-        void 디스코드인증_Bevy인증_재학생인증하면_성공한다() {
+        void 기본_회원정보_작성_디스코드인증_Bevy인증_재학생인증하면_성공한다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 
@@ -173,6 +172,8 @@ class MemberTest {
             member.completeUnivEmailVerification(UNIV_EMAIL);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
             member.verifyBevy();
+
+            // when
             member.advanceToAssociate();
 
             // then

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -96,7 +96,7 @@ class MemberTest {
         }
 
         @Test
-        void 기본_회원정보_작성_디스코드인증_Bevy인증_재학생인증하면_isAllVerified는_true이다() {
+        void 준회원_가입조건을_모두_충족했다면_isAllVerified는_true이다() {
             // given
             Member member = Member.createGuestMember(OAUTH_ID);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -2,7 +2,6 @@ package com.gdschongik.gdsc.domain.membership.application;
 
 import static com.gdschongik.gdsc.domain.member.domain.Department.D022;
 import static com.gdschongik.gdsc.domain.member.domain.MemberRole.*;
-import static com.gdschongik.gdsc.domain.member.domain.RequirementStatus.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
@@ -34,12 +33,12 @@ public class MembershipServiceTest extends IntegrationTest {
     @Autowired
     private RecruitmentRepository recruitmentRepository;
 
-    private Member createMember() {
+    public Member createMember() {
         Member member = Member.createGuestMember(OAUTH_ID);
+        memberRepository.save(member);
 
         member.completeUnivEmailVerification(UNIV_EMAIL);
         member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
-        member.updatePaymentStatus(VERIFIED);
         member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
         member.verifyBevy();
 

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.domain.membership.application;
 
+import static com.gdschongik.gdsc.domain.member.domain.Department.D022;
 import static com.gdschongik.gdsc.domain.member.domain.MemberRole.*;
 import static com.gdschongik.gdsc.domain.member.domain.RequirementStatus.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
@@ -37,6 +38,7 @@ public class MembershipServiceTest extends IntegrationTest {
         Member member = Member.createGuestMember(OAUTH_ID);
 
         member.completeUnivEmailVerification(UNIV_EMAIL);
+        member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
         member.updatePaymentStatus(VERIFIED);
         member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
         member.verifyBevy();


### PR DESCRIPTION
## 🌱 관련 이슈
- close #348 

## 📌 작업 내용 및 특이사항
- event handling 꽤 ..어렵네영ㅋ..
- 준회원 승급 조건 추가하면서 event 처리로 멤버 도메인 ASSOCIATE 승급 로직을 구현했습니다
- 일단 제가 결론 부터 말씀드리자면 Event 레코드 안에 멤버를 넣어서 전파하는 방식을 택하니까! 굳이 login안해도 테스트 다 정상적으로 작동하고  event handling에 더 적합하다 싶어서 현재 코드 방식으로 짜놓았습니다 ㅎㅎ
- 제가 저번에 integration test에 이제 준회원 승급 조건을 넣어서 로직 검증을 짜놓아야 된다고 말씀드렸는데, isAllVerified라는 중간 검증이 생겨버리니 굳이 통합 테스트에서 승급할 필요없이 isAllverified를 만족시키는지만 확인하면 돼서 Member 도메인 테스트에 수정/추가 해두었습니다!
- isAllverified라는 도메인 로직 검증 메서드가 생긴 이유는 event handler에서 코드를 개선시킬 수 있을 것 같아서 추가했습니다.. 그리고 굳이 Requirement에 isAllVerified 필드를 추가 하지 않고 그냥 메소드 호출할때 저 멤버가 현재 다 verified인지 검증만 해주면 될 것 같아서 코드를 짯습니다!
- eventListener에 대한 검증 테스트는 안했는데 적절하다고 생각하시나요? 의견 궁금하네요!
- + 짜고 보니까 isAllVerified부분 테스트 메서드 이름이 조금 어색하네영...좀만 더 생각해볼게요 저 이름은! 

## 📝 참고사항
- @DomainEvents라는 어노테이션을 사용해서 requirement가 디비에 수정되는 순간 원하는 이벤트 처리할 수 있게 리팩토링 하고 싶은데 이건 백로그에 남기려고 합니다!
- register event하고 나서 repository.save()하는 것이 안티 패턴이라고 하더라고요 그래서 다른 분들 레퍼런스 찾아보면 그냥 publish아니면 조금 더 고수이신 분들은 aop 커스터마이징해서 하고 막 그러던데 이것도 리팩토링 할 부분인 것 같네요
- https://ramka-devstory.tistory.com/m/7
- https://msolo021015.medium.com/abstractaggregateroot%EC%99%80-jparepository-save-%EC%95%88%ED%8B%B0-%ED%8C%A8%ED%84%B4%EC%97%90-%EB%8C%80%ED%95%B4-ca81a8f2ce22

## 📚 기타
-
