### PR TITLE
feat: 멤버 기본 회원 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
@@ -4,6 +4,7 @@ import com.gdschongik.gdsc.domain.member.application.OnboardingMemberService;
 import com.gdschongik.gdsc.domain.member.dto.request.BasicMemberInfoRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberSignupRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.OnboardingMemberUpdateRequest;
+import com.gdschongik.gdsc.domain.member.dto.response.MemberBasicInfoResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberInfoResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberUnivStatusResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -62,10 +63,17 @@ public class OnboardingMemberController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "기본 회원정보 작성", description = "기본 회원정보를 작성합니다")
+    @Operation(summary = "기본 회원정보 작성", description = "기본 회원정보를 작성합니다.")
     @PostMapping("/me/basic-info")
     public ResponseEntity<Void> updateBasicMemberInfo(@Valid @RequestBody BasicMemberInfoRequest request) {
         onboardingMemberService.updateBasicMemberInfo(request);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "기본 회원정보 조회", description = "기본 회원정보를 조회합니다.")
+    @GetMapping("/me/basic-info")
+    public ResponseEntity<MemberBasicInfoResponse> getMemberBasicInfo() {
+        MemberBasicInfoResponse response = onboardingMemberService.getMemberBasicInfo();
+        return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
@@ -7,6 +7,7 @@ import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.dto.request.BasicMemberInfoRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberSignupRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.OnboardingMemberUpdateRequest;
+import com.gdschongik.gdsc.domain.member.dto.response.MemberBasicInfoResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberInfoResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberUnivStatusResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
@@ -68,5 +69,10 @@ public class OnboardingMemberService {
         Member currentMember = memberUtil.getCurrentMember();
         currentMember.updateBasicMemberInfo(
                 request.studentId(), request.name(), request.phone(), request.department(), request.email());
+    }
+
+    public MemberBasicInfoResponse getMemberBasicInfo() {
+        Member currentMember = memberUtil.getCurrentMember();
+        return MemberBasicInfoResponse.from(currentMember);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberBasicInfoResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberBasicInfoResponse.java
@@ -1,0 +1,35 @@
+package com.gdschongik.gdsc.domain.member.dto.response;
+
+import com.gdschongik.gdsc.domain.member.domain.Department;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import java.util.Optional;
+
+public record MemberBasicInfoResponse(
+        Long memberId,
+        MemberRole memberRole,
+        String studentId,
+        String name,
+        String phone,
+        String department,
+        String email,
+        String discordUsername,
+        String nickname) {
+    public static MemberBasicInfoResponse from(Member member) {
+        return new MemberBasicInfoResponse(
+                member.getId(),
+                member.getRole(),
+                member.getStudentId(),
+                member.getName(),
+                Optional.ofNullable(member.getPhone())
+                        .map(phone -> String.format(
+                                "%s-%s-%s", phone.substring(0, 3), phone.substring(3, 7), phone.substring(7)))
+                        .orElse(null),
+                Optional.ofNullable(member.getDepartment())
+                        .map(Department::getDepartmentName)
+                        .orElse(null),
+                member.getEmail(),
+                member.getDiscordUsername(),
+                member.getNickname());
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberBasicInfoResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberBasicInfoResponse.java
@@ -2,12 +2,10 @@ package com.gdschongik.gdsc.domain.member.dto.response;
 
 import com.gdschongik.gdsc.domain.member.domain.Department;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import java.util.Optional;
 
 public record MemberBasicInfoResponse(
         Long memberId,
-        MemberRole memberRole,
         String studentId,
         String name,
         String phone,
@@ -18,7 +16,6 @@ public record MemberBasicInfoResponse(
     public static MemberBasicInfoResponse from(Member member) {
         return new MemberBasicInfoResponse(
                 member.getId(),
-                member.getRole(),
                 member.getStudentId(),
                 member.getName(),
                 Optional.ofNullable(member.getPhone())


### PR DESCRIPTION
## 🌱 관련 이슈
- close #324

## 📌 작업 내용 및 특이사항
- 대시보드에서 호출할 `멤버 기본 회원정보` api를 구현했습니다.
- 단순 조회이고 특별한 요구사항이 없어서 test는 생략했습니다.

## 📝 참고사항
-

## 📚 기타
-
