### PR TITLE
feat: 쿠폰 도메인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+/src/main/generated/
 
 ### NetBeans ###
 /nbproject/private/

--- a/src/main/java/com/gdschongik/gdsc/domain/common/vo/Money.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/vo/Money.java
@@ -1,0 +1,80 @@
+package com.gdschongik.gdsc.domain.common.vo;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.global.exception.CustomException;
+import jakarta.persistence.Embeddable;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Money {
+
+    private BigDecimal amount;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Money(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public static Money from(BigDecimal amount) {
+        validateAmountNotNull(amount);
+
+        return Money.builder().amount(amount).build();
+    }
+
+    private static void validateAmountNotNull(BigDecimal amount) {
+        if (amount == null) {
+            throw new CustomException(MONEY_AMOUNT_NOT_NULL);
+        }
+    }
+
+    // 모든 로직은 BigDecimal에서 제공하는 메서드를 그대로 사용하여 구현
+
+    // 금액 사칙연산 로직
+
+    public Money add(@NonNull Money target) {
+        return Money.from(this.amount.add(target.amount));
+    }
+
+    public Money subtract(@NonNull Money target) {
+        return Money.from(this.amount.subtract(target.amount));
+    }
+
+    public Money multiply(@NonNull BigDecimal target) {
+        return Money.builder().amount(this.amount.multiply(target)).build();
+    }
+
+    public Money divide(@NonNull BigDecimal target) {
+        return Money.builder()
+                .amount(this.amount.divide(target, RoundingMode.HALF_UP))
+                .build();
+    }
+
+    // 금액 비교 로직
+
+    public boolean isGreaterThan(@NonNull Money target) {
+        return this.amount.compareTo(target.amount) > 0;
+    }
+
+    public boolean isGreaterThanOrEqual(@NonNull Money target) {
+        return this.amount.compareTo(target.amount) >= 0;
+    }
+
+    public boolean isLessThan(@NonNull Money target) {
+        return this.amount.compareTo(target.amount) < 0;
+    }
+
+    public boolean isLessThanOrEqual(@NonNull Money target) {
+        return this.amount.compareTo(target.amount) <= 0;
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
@@ -1,13 +1,17 @@
 package com.gdschongik.gdsc.domain.coupon.domain;
 
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
 import com.gdschongik.gdsc.domain.common.model.BaseTimeEntity;
 import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.math.BigDecimal;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,6 +39,13 @@ public class Coupon extends BaseTimeEntity {
     }
 
     public static Coupon createCoupon(String name, Money discountAmount) {
+        validateDiscountAmountPositive(discountAmount);
         return Coupon.builder().name(name).discountAmount(discountAmount).build();
+    }
+
+    private static void validateDiscountAmountPositive(Money discountAmount) {
+        if (!discountAmount.isGreaterThan(Money.from(BigDecimal.ZERO))) {
+            throw new CustomException(COUPON_DISCOUNT_AMOUNT_NOT_POSITIVE);
+        }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
@@ -43,9 +43,19 @@ public class Coupon extends BaseTimeEntity {
         return Coupon.builder().name(name).discountAmount(discountAmount).build();
     }
 
+    // 검증 로직
+
     private static void validateDiscountAmountPositive(Money discountAmount) {
         if (!discountAmount.isGreaterThan(Money.from(BigDecimal.ZERO))) {
             throw new CustomException(COUPON_DISCOUNT_AMOUNT_NOT_POSITIVE);
         }
+    }
+
+    // 상태 변경 로직
+
+    public void updateCoupon(String name, Money discountAmount) {
+        validateDiscountAmountPositive(discountAmount);
+        this.name = name;
+        this.discountAmount = discountAmount;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
@@ -1,0 +1,40 @@
+package com.gdschongik.gdsc.domain.coupon.domain;
+
+import com.gdschongik.gdsc.domain.common.model.BaseTimeEntity;
+import com.gdschongik.gdsc.domain.common.vo.Money;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coupon extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "coupon_id")
+    private Long id;
+
+    private String name;
+
+    @Embedded
+    private Money discountAmount;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public Coupon(String name, Money discountAmount) {
+        this.name = name;
+        this.discountAmount = discountAmount;
+    }
+
+    public static Coupon createCoupon(String name, Money discountAmount) {
+        return Coupon.builder().name(name).discountAmount(discountAmount).build();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
@@ -64,6 +64,12 @@ public class IssuedCoupon extends BaseTimeEntity {
         }
     }
 
+    private void validateRevokable() {
+        if (isUsed()) {
+            throw new CustomException(COUPON_ALREADY_USED);
+        }
+    }
+
     // 상태 변경 로직
 
     public void use() {
@@ -72,6 +78,7 @@ public class IssuedCoupon extends BaseTimeEntity {
     }
 
     public void revoke() {
+        validateRevokable();
         this.isRevoked = true;
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
@@ -71,6 +71,10 @@ public class IssuedCoupon extends BaseTimeEntity {
         this.usedAt = LocalDateTime.now();
     }
 
+    public void revoke() {
+        this.isRevoked = true;
+    }
+
     // 데이터 전달 로직
 
     public boolean isUsed() {

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
@@ -87,4 +87,8 @@ public class IssuedCoupon extends BaseTimeEntity {
     public boolean isUsed() {
         return this.usedAt != null;
     }
+
+    public boolean isRevoked() {
+        return this.isRevoked;
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
@@ -1,7 +1,11 @@
 package com.gdschongik.gdsc.domain.coupon.domain;
 
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static java.lang.Boolean.*;
+
 import com.gdschongik.gdsc.domain.common.model.BaseTimeEntity;
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.Column;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -10,6 +14,7 @@ import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
+import org.hibernate.annotations.Comment;
 import org.springframework.data.annotation.Id;
 
 public class IssuedCoupon extends BaseTimeEntity {
@@ -27,21 +32,39 @@ public class IssuedCoupon extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Comment("회수 여부")
+    private Boolean isRevoked;
+
     private LocalDateTime usedAt;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private IssuedCoupon(Coupon coupon, Member member, LocalDateTime usedAt) {
+    private IssuedCoupon(Coupon coupon, Member member, Boolean isRevoked) {
         this.coupon = coupon;
         this.member = member;
-        this.usedAt = usedAt;
+        this.isRevoked = isRevoked;
     }
 
     public static IssuedCoupon issue(Coupon coupon, Member member) {
-        return IssuedCoupon.builder().coupon(coupon).member(member).build();
+        return IssuedCoupon.builder()
+                .coupon(coupon)
+                .member(member)
+                .isRevoked(false)
+                .build();
     }
 
     public void useCoupon() {
+        validateUsable();
         this.usedAt = LocalDateTime.now();
+    }
+
+    private void validateUsable() {
+        if (this.isRevoked.equals(FALSE)) {
+            throw new CustomException(COUPON_NOT_USABLE);
+        }
+
+        if (isUsed()) {
+            throw new CustomException(COUPON_ALREADY_USED);
+        }
     }
 
     public boolean isUsed() {

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
@@ -60,13 +60,13 @@ public class IssuedCoupon extends BaseTimeEntity {
         }
 
         if (isUsed()) {
-            throw new CustomException(COUPON_ALREADY_USED);
+            throw new CustomException(COUPON_NOT_USABLE_ALREADY_USED);
         }
     }
 
     private void validateRevokable() {
         if (isUsed()) {
-            throw new CustomException(COUPON_ALREADY_USED);
+            throw new CustomException(COUPON_NOT_REVOKABLE_ALREADY_USED);
         }
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
@@ -55,7 +55,7 @@ public class IssuedCoupon extends BaseTimeEntity {
     // 검증 로직
 
     private void validateUsable() {
-        if (this.isRevoked.equals(FALSE)) {
+        if (this.isRevoked.equals(TRUE)) {
             throw new CustomException(COUPON_ALREADY_REVOKED);
         }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
@@ -52,10 +52,7 @@ public class IssuedCoupon extends BaseTimeEntity {
                 .build();
     }
 
-    public void useCoupon() {
-        validateUsable();
-        this.usedAt = LocalDateTime.now();
-    }
+    // 검증 로직
 
     private void validateUsable() {
         if (this.isRevoked.equals(FALSE)) {
@@ -66,6 +63,15 @@ public class IssuedCoupon extends BaseTimeEntity {
             throw new CustomException(COUPON_ALREADY_USED);
         }
     }
+
+    // 상태 변경 로직
+
+    public void useCoupon() {
+        validateUsable();
+        this.usedAt = LocalDateTime.now();
+    }
+
+    // 데이터 전달 로직
 
     public boolean isUsed() {
         return this.usedAt != null;

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
@@ -66,7 +66,7 @@ public class IssuedCoupon extends BaseTimeEntity {
 
     // 상태 변경 로직
 
-    public void useCoupon() {
+    public void use() {
         validateUsable();
         this.usedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
@@ -56,7 +56,7 @@ public class IssuedCoupon extends BaseTimeEntity {
 
     private void validateUsable() {
         if (this.isRevoked.equals(FALSE)) {
-            throw new CustomException(COUPON_NOT_USABLE);
+            throw new CustomException(COUPON_ALREADY_REVOKED);
         }
 
         if (isUsed()) {

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
@@ -1,0 +1,50 @@
+package com.gdschongik.gdsc.domain.coupon.domain;
+
+import com.gdschongik.gdsc.domain.common.model.BaseTimeEntity;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import org.springframework.data.annotation.Id;
+
+public class IssuedCoupon extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "issued_coupon_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_id")
+    private Coupon coupon;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private LocalDateTime usedAt;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private IssuedCoupon(Coupon coupon, Member member, LocalDateTime usedAt) {
+        this.coupon = coupon;
+        this.member = member;
+        this.usedAt = usedAt;
+    }
+
+    public static IssuedCoupon issue(Coupon coupon, Member member) {
+        return IssuedCoupon.builder().coupon(coupon).member(member).build();
+    }
+
+    public void useCoupon() {
+        this.usedAt = LocalDateTime.now();
+    }
+
+    public boolean isUsed() {
+        return this.usedAt != null;
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
@@ -56,7 +56,7 @@ public class IssuedCoupon extends BaseTimeEntity {
 
     private void validateUsable() {
         if (this.isRevoked.equals(TRUE)) {
-            throw new CustomException(COUPON_ALREADY_REVOKED);
+            throw new CustomException(COUPON_NOT_USABLE_REVOKED);
         }
 
         if (isUsed()) {

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -77,6 +77,7 @@ public enum ErrorCode {
     RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일이 학기 시작일로부터 2주 이내에 있지 않습니다."),
 
     // Coupon
+    COUPON_DISCOUNT_AMOUNT_NOT_POSITIVE(HttpStatus.CONFLICT, "쿠폰의 할인 금액은 0보다 커야 합니다."),
     COUPON_NOT_USABLE_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용한 쿠폰은 사용할 수 없습니다."),
     COUPON_NOT_USABLE_REVOKED(HttpStatus.CONFLICT, "회수된 쿠폰은 사용할 수 없습니다."),
     COUPON_NOT_REVOKABLE_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용한 쿠폰은 회수할 수 없습니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -78,7 +78,7 @@ public enum ErrorCode {
 
     // Coupon
     COUPON_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용된 쿠폰입니다."),
-    COUPON_ALREADY_REVOKED(HttpStatus.CONFLICT, "이미 회수된 쿠폰입니다"),
+    COUPON_NOT_USABLE_REVOKED(HttpStatus.CONFLICT, "회수된 쿠폰은 사용할 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -74,7 +74,12 @@ public enum ErrorCode {
     RECRUITMENT_PERIOD_MISMATCH_ACADEMIC_YEAR(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 연도가 학년도와 일치하지 않습니다."),
     RECRUITMENT_PERIOD_MISMATCH_SEMESTER_TYPE(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 입력된 학기가 일치하지 않습니다."),
     RECRUITMENT_PERIOD_SEMESTER_TYPE_UNMAPPED(HttpStatus.CONFLICT, "모집 시작일과 종료일이 매핑되는 학기가 없습니다."),
-    RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일이 학기 시작일로부터 2주 이내에 있지 않습니다.");
+    RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일이 학기 시작일로부터 2주 이내에 있지 않습니다."),
+
+    // Coupon
+    COUPON_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용된 쿠폰입니다."),
+    COUPON_NOT_USABLE(HttpStatus.CONFLICT, "사용할 수 없는 쿠폰입니다."),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -25,6 +25,9 @@ public enum ErrorCode {
     // Parameter
     INVALID_QUERY_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 쿼리 파라미터입니다."),
 
+    // Money
+    MONEY_AMOUNT_NOT_NULL(HttpStatus.INTERNAL_SERVER_ERROR, "금액은 null이 될 수 없습니다."),
+
     // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 커뮤니티 멤버입니다."),
     MEMBER_DELETED(HttpStatus.CONFLICT, "탈퇴한 회원입니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -77,8 +77,9 @@ public enum ErrorCode {
     RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일이 학기 시작일로부터 2주 이내에 있지 않습니다."),
 
     // Coupon
-    COUPON_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용된 쿠폰입니다."),
+    COUPON_NOT_USABLE_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용한 쿠폰은 사용할 수 없습니다."),
     COUPON_NOT_USABLE_REVOKED(HttpStatus.CONFLICT, "회수된 쿠폰은 사용할 수 없습니다."),
+    COUPON_NOT_REVOKABLE_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용한 쿠폰은 회수할 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -78,7 +78,7 @@ public enum ErrorCode {
 
     // Coupon
     COUPON_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용된 쿠폰입니다."),
-    COUPON_NOT_USABLE(HttpStatus.CONFLICT, "사용할 수 없는 쿠폰입니다."),
+    COUPON_ALREADY_REVOKED(HttpStatus.CONFLICT, "이미 회수된 쿠폰입니다"),
     ;
 
     private final HttpStatus status;

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/CouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/CouponTest.java
@@ -17,11 +17,8 @@ class CouponTest {
 
         @Test
         void 성공한다() {
-            // given
-            Money discountAmount = Money.from(ONE);
-
             // when
-            Coupon coupon = Coupon.createCoupon(COUPON_NAME, discountAmount);
+            Coupon coupon = Coupon.createCoupon(COUPON_NAME, Money.from(ONE));
 
             // then
             assertThat(coupon).isNotNull();

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/CouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/CouponTest.java
@@ -38,4 +38,32 @@ class CouponTest {
                     .hasMessageContaining(COUPON_DISCOUNT_AMOUNT_NOT_POSITIVE.getMessage());
         }
     }
+
+    @Nested
+    class 쿠폰_수정할때 {
+
+        @Test
+        void 성공한다() {
+            // given
+            Coupon coupon = Coupon.createCoupon(COUPON_NAME, Money.from(ONE));
+
+            // when
+            coupon.updateCoupon(COUPON_NAME, Money.from(TEN));
+
+            // then
+            assertThat(coupon.getDiscountAmount()).isEqualTo(Money.from(TEN));
+        }
+
+        @Test
+        void 할인금액이_양수가_아니라면_실패한다() {
+            // given
+            Coupon coupon = Coupon.createCoupon(COUPON_NAME, Money.from(ONE));
+            Money changedDiscountAmount = Money.from(ZERO);
+
+            // when & then
+            assertThatThrownBy(() -> coupon.updateCoupon(COUPON_NAME, changedDiscountAmount))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(COUPON_DISCOUNT_AMOUNT_NOT_POSITIVE.getMessage());
+        }
+    }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/CouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/CouponTest.java
@@ -1,0 +1,41 @@
+package com.gdschongik.gdsc.domain.coupon.domain;
+
+import static com.gdschongik.gdsc.global.common.constant.CouponConstant.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static java.math.BigDecimal.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class CouponTest {
+
+    @Nested
+    class 쿠폰_생성할때 {
+
+        @Test
+        void 성공한다() {
+            // given
+            Money discountAmount = Money.from(ONE);
+
+            // when
+            Coupon coupon = Coupon.createCoupon(COUPON_NAME, discountAmount);
+
+            // then
+            assertThat(coupon).isNotNull();
+        }
+
+        @Test
+        void 할인금액이_양수가_아니라면_실패한다() {
+            // given
+            Money discountAmount = Money.from(ZERO);
+
+            // when & then
+            assertThatThrownBy(() -> Coupon.createCoupon(COUPON_NAME, discountAmount))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(COUPON_DISCOUNT_AMOUNT_NOT_POSITIVE.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
@@ -88,7 +88,7 @@ class IssuedCouponTest {
             // when & then
             assertThatThrownBy(issuedCoupon::revoke)
                     .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(COUPON_NOT_USABLE_ALREADY_USED.getMessage());
+                    .hasMessageContaining(COUPON_NOT_REVOKABLE_ALREADY_USED.getMessage());
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
@@ -18,7 +18,7 @@ class IssuedCouponTest {
         IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
 
         // when
-        issuedCoupon.useCoupon();
+        issuedCoupon.use();
 
         // then
         assertThat(issuedCoupon.isUsed()).isTrue();

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
@@ -41,7 +41,7 @@ class IssuedCouponTest {
             // when, then
             assertThatThrownBy(issuedCoupon::use)
                     .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(COUPON_ALREADY_USED.getMessage());
+                    .hasMessageContaining(COUPON_NOT_USABLE_ALREADY_USED.getMessage());
         }
 
         @Test
@@ -87,7 +87,7 @@ class IssuedCouponTest {
             // when, then
             assertThatThrownBy(issuedCoupon::revoke)
                     .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(COUPON_ALREADY_USED.getMessage());
+                    .hasMessageContaining(COUPON_NOT_USABLE_ALREADY_USED.getMessage());
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
@@ -1,0 +1,26 @@
+package com.gdschongik.gdsc.domain.coupon.domain;
+
+import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+class IssuedCouponTest {
+
+    @Test
+    void 발급쿠폰_사용하면_사용여부는_true이다() {
+        // given
+        Coupon coupon = Coupon.createCoupon("쿠폰이름", Money.from(BigDecimal.ONE));
+        Member member = Member.createGuestMember(OAUTH_ID);
+        IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
+
+        // when
+        issuedCoupon.useCoupon();
+
+        // then
+        assertThat(issuedCoupon.isUsed()).isTrue();
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
@@ -39,7 +39,7 @@ class IssuedCouponTest {
             IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
             issuedCoupon.use();
 
-            // when, then
+            // when & then
             assertThatThrownBy(issuedCoupon::use)
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(COUPON_NOT_USABLE_ALREADY_USED.getMessage());
@@ -53,7 +53,7 @@ class IssuedCouponTest {
             IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
             issuedCoupon.revoke();
 
-            // when, then
+            // when & then
             assertThatThrownBy(issuedCoupon::use)
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(COUPON_NOT_USABLE_REVOKED.getMessage());
@@ -85,7 +85,7 @@ class IssuedCouponTest {
             IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
             issuedCoupon.use();
 
-            // when, then
+            // when & then
             assertThatThrownBy(issuedCoupon::revoke)
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(COUPON_NOT_USABLE_ALREADY_USED.getMessage());

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
@@ -1,26 +1,61 @@
 package com.gdschongik.gdsc.domain.coupon.domain;
 
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static java.math.BigDecimal.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import java.math.BigDecimal;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class IssuedCouponTest {
 
-    @Test
-    void 발급쿠폰_사용하면_사용여부는_true이다() {
-        // given
-        Coupon coupon = Coupon.createCoupon("쿠폰이름", Money.from(BigDecimal.ONE));
-        Member member = Member.createGuestMember(OAUTH_ID);
-        IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
+    @Nested
+    class 발급쿠폰_사용할때 {
 
-        // when
-        issuedCoupon.use();
+        @Test
+        void 성공하면_사용여부는_true이다() {
+            // given
+            Coupon coupon = Coupon.createCoupon("쿠폰이름", Money.from(ONE));
+            Member member = Member.createGuestMember(OAUTH_ID);
+            IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
 
-        // then
-        assertThat(issuedCoupon.isUsed()).isTrue();
+            // when
+            issuedCoupon.use();
+
+            // then
+            assertThat(issuedCoupon.isUsed()).isTrue();
+        }
+
+        @Test
+        void 이미_사용한_쿠폰이면_실패한다() {
+            // given
+            Coupon coupon = Coupon.createCoupon("쿠폰이름", Money.from(ONE));
+            Member member = Member.createGuestMember(OAUTH_ID);
+            IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
+            issuedCoupon.use();
+
+            // when, then
+            assertThatThrownBy(issuedCoupon::use)
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(COUPON_ALREADY_USED.getMessage());
+        }
+
+        @Test
+        void 이미_회수한_쿠폰이면_실패한다() {
+            // given
+            Coupon coupon = Coupon.createCoupon("쿠폰이름", Money.from(ONE));
+            Member member = Member.createGuestMember(OAUTH_ID);
+            IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
+            issuedCoupon.revoke();
+
+            // when, then
+            assertThatThrownBy(issuedCoupon::use)
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(COUPON_ALREADY_REVOKED.getMessage());
+        }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
@@ -58,4 +58,36 @@ class IssuedCouponTest {
                     .hasMessageContaining(COUPON_ALREADY_REVOKED.getMessage());
         }
     }
+
+    @Nested
+    class 발급쿠폰_회수할때 {
+
+        @Test
+        void 성공하면_회수여부는_true이다() {
+            // given
+            Coupon coupon = Coupon.createCoupon("쿠폰이름", Money.from(ONE));
+            Member member = Member.createGuestMember(OAUTH_ID);
+            IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
+
+            // when
+            issuedCoupon.revoke();
+
+            // then
+            assertThat(issuedCoupon.isRevoked()).isTrue();
+        }
+
+        @Test
+        void 이미_사용한_쿠폰이면_실패한다() {
+            // given
+            Coupon coupon = Coupon.createCoupon("쿠폰이름", Money.from(ONE));
+            Member member = Member.createGuestMember(OAUTH_ID);
+            IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
+            issuedCoupon.use();
+
+            // when, then
+            assertThatThrownBy(issuedCoupon::revoke)
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(COUPON_ALREADY_USED.getMessage());
+        }
+    }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
@@ -55,7 +55,7 @@ class IssuedCouponTest {
             // when, then
             assertThatThrownBy(issuedCoupon::use)
                     .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(COUPON_ALREADY_REVOKED.getMessage());
+                    .hasMessageContaining(COUPON_NOT_USABLE_REVOKED.getMessage());
         }
     }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.domain.coupon.domain;
 
+import static com.gdschongik.gdsc.global.common.constant.CouponConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static java.math.BigDecimal.*;
@@ -19,7 +20,7 @@ class IssuedCouponTest {
         @Test
         void 성공하면_사용여부는_true이다() {
             // given
-            Coupon coupon = Coupon.createCoupon("쿠폰이름", Money.from(ONE));
+            Coupon coupon = Coupon.createCoupon(COUPON_NAME, Money.from(ONE));
             Member member = Member.createGuestMember(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
 
@@ -33,7 +34,7 @@ class IssuedCouponTest {
         @Test
         void 이미_사용한_쿠폰이면_실패한다() {
             // given
-            Coupon coupon = Coupon.createCoupon("쿠폰이름", Money.from(ONE));
+            Coupon coupon = Coupon.createCoupon(COUPON_NAME, Money.from(ONE));
             Member member = Member.createGuestMember(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
             issuedCoupon.use();
@@ -47,7 +48,7 @@ class IssuedCouponTest {
         @Test
         void 이미_회수한_쿠폰이면_실패한다() {
             // given
-            Coupon coupon = Coupon.createCoupon("쿠폰이름", Money.from(ONE));
+            Coupon coupon = Coupon.createCoupon(COUPON_NAME, Money.from(ONE));
             Member member = Member.createGuestMember(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
             issuedCoupon.revoke();
@@ -65,7 +66,7 @@ class IssuedCouponTest {
         @Test
         void 성공하면_회수여부는_true이다() {
             // given
-            Coupon coupon = Coupon.createCoupon("쿠폰이름", Money.from(ONE));
+            Coupon coupon = Coupon.createCoupon(COUPON_NAME, Money.from(ONE));
             Member member = Member.createGuestMember(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
 
@@ -79,7 +80,7 @@ class IssuedCouponTest {
         @Test
         void 이미_사용한_쿠폰이면_실패한다() {
             // given
-            Coupon coupon = Coupon.createCoupon("쿠폰이름", Money.from(ONE));
+            Coupon coupon = Coupon.createCoupon(COUPON_NAME, Money.from(ONE));
             Member member = Member.createGuestMember(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
             issuedCoupon.use();

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/CouponConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/CouponConstant.java
@@ -1,0 +1,7 @@
+package com.gdschongik.gdsc.global.common.constant;
+
+public class CouponConstant {
+    public static final String COUPON_NAME = "테스트 쿠폰 이름";
+
+    private CouponConstant() {}
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #342

## 📌 작업 내용 및 특이사항

### 쿠폰 도메인 관련
- 쿠폰 도메인을 구현했습니다.
    - 쿠폰 도메인은 쿠폰 엔티티와 발급쿠폰 엔티티로 구성됩니다.
    - 쿠폰 기능의 경우 어드민이 쿠폰을 생성하고 -> 생성된 쿠폰을 멤버에게 발급하는 절차로 진행됩니다.
    - 즉 쿠폰의 경우 할인금액 등 쿠폰에 대한 정보를, 발급쿠폰의 경우 발급대상 및 사용여부 등 쿠폰 히스토리에 대한 정보를 관리합니다.
    - 발급쿠폰의 경우 사용여부가 존재하는데, 이는 내부적으로 필드를 두지 않고, 대신 사용일시의 존재여부로 판단합니다. (테스트 코드 참고)
    - 발급쿠폰 엔티티에서는 다음 행위가 가능합니다.
        - 발급쿠폰 사용하기
            - 이미 사용하거나, 회수된 쿠폰인 경우 사용 불가
        - 발급쿠폰 회수하기
            - 이미 사용한 쿠폰인 경우 회수 불가
- 그리고 도메인 로직의 경우, 굳이 메서드 이름에 도메인 이름을 중복시킬 필요가 없다고 판단하여 제외했습니다.
    - 즉 `coupon.useCoupon` 대신 `coupon.use` 가 더 적절하다 생각하여 변경했습니다. 
    - 마찬가지로 정적 팩토리 생성자도 `IssueCoupon.issue` 로 변경했습니다.


### 에러코드 관련
- 에러코드 컨벤션이 조금 다른데요, 같은 상태로 인해 발생하는 예외더라도 사용 상황이 다르면 다른 에러코드로 출력하기 위해 이렇게 했습니다.
    - 가령 '이미 사용된 쿠폰'인 경우 '재사용 케이스'와 '회수 케이스' 라는 맥락이 다르기 때문에, 분리했습니다.
    - 즉 `대상도메인_불가능한행위_불가능한이유` 와 같이 네이밍 컨벤션을 가져가려고 합니다. (ex: `COUPON_NOT_USABLE_ALREAY_USED`)   

### 금액 VO 관련
- 금액에 해당하는 Embedded VO 클래스인 `Money` 를 추가했습니다.
    - `Money`는 내부적으로 실제 금액 값에 해당하는 amount 필드를 갖습니다.
    - 해당 필드는 금융권 등에서 금액을 관리할 때 자주 사용되는 `BigDecimal` 타입을 사용합니다. ([레퍼런스](https://dev.gmarket.com/75))
    - `Money` 클래스는 사칙연산 및 대소비교 메서드를 지원합니다. 
        - 이때, 추가적인 로직 없이 `BigDecimal` 타입에서 지원하는 사칙연산 / 대소비교 메서드를 그대로 wrapping하여 제공합니다.
        - 단 나눗셈의 경우 무한소수 등 문제로 반올림 정책에 해당하는 RoundingMode를 지정해야 합니다. 여기서는 반올림 정책인 `HALF_UP` 을 지정했습니다.
        - 별도 로직을 넣지 않고 `BigDecimal` 메서드들을 그대로 래핑한 이유는, 에측가능성을 확보하기 위함입니다. `Money` 클래스에 대한 러닝커브를 발생시키는 것보다는, `BigDecimal` 이해도를 기반으로 `Money` 클래스를 그대로 사용하게 만들고자 했습니다. 대신 모든 메서드를 래핑하지 않고, 필요한 메서드만을 래핑했습니다.

### 추가 (24.06.09 오후 4시)

- 쿠폰의 경우 생성시 다음 검증정책이 존재합니다.
    - 할인금액은 0을 초과하는 양수이다. 
- 쿠폰의 이름 및 할인금액을 수정할 수 있습니다.

## 📝 참고사항
-

## 📚 기타
-
