### PR TITLE
feat: 디스코드 서버 합류 여부 조회 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/api/OnboardingDiscordController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/api/OnboardingDiscordController.java
@@ -2,11 +2,13 @@ package com.gdschongik.gdsc.domain.discord.api;
 
 import com.gdschongik.gdsc.domain.discord.application.OnboardingDiscordService;
 import com.gdschongik.gdsc.domain.discord.dto.request.DiscordLinkRequest;
+import com.gdschongik.gdsc.domain.discord.dto.response.DiscordJoinStatusResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,5 +27,12 @@ public class OnboardingDiscordController {
     public ResponseEntity<Void> linkDiscord(@Valid @RequestBody DiscordLinkRequest request) {
         onboardingDiscordService.verifyDiscordCode(request);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "디스코드 서버 합류 여부 조회하기", description = "디스코드 서버에 합류했는지 조회합니다.")
+    @GetMapping("/me/discord/join-status")
+    public ResponseEntity<DiscordJoinStatusResponse> checkDiscordJoinStatus() {
+        DiscordJoinStatusResponse response = onboardingDiscordService.checkDiscordJoinStatus();
+        return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
@@ -6,6 +6,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.discord.dao.DiscordVerificationCodeRepository;
 import com.gdschongik.gdsc.domain.discord.domain.DiscordVerificationCode;
 import com.gdschongik.gdsc.domain.discord.dto.request.DiscordLinkRequest;
+import com.gdschongik.gdsc.domain.discord.dto.response.DiscordJoinStatusResponse;
 import com.gdschongik.gdsc.domain.discord.dto.response.DiscordNicknameResponse;
 import com.gdschongik.gdsc.domain.discord.dto.response.DiscordVerificationCodeResponse;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
@@ -103,5 +104,11 @@ public class OnboardingDiscordService {
         }
 
         return DiscordNicknameResponse.of(member.getNickname());
+    }
+
+    public DiscordJoinStatusResponse checkDiscordJoinStatus() {
+        Member currentMember = memberUtil.getCurrentMember();
+        boolean memberJoinStatus = discordUtil.existsByDiscordUsername(currentMember.getDiscordUsername());
+        return DiscordJoinStatusResponse.from(memberJoinStatus);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/dto/response/DiscordJoinStatusResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/dto/response/DiscordJoinStatusResponse.java
@@ -1,0 +1,7 @@
+package com.gdschongik.gdsc.domain.discord.dto.response;
+
+public record DiscordJoinStatusResponse(boolean joinStatus) {
+    public static DiscordJoinStatusResponse from(boolean joinStatus) {
+        return new DiscordJoinStatusResponse(joinStatus);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
@@ -42,4 +42,10 @@ public class DiscordUtil {
                 .orElseThrow(() -> new CustomException(ErrorCode.DISCORD_MEMBER_NOT_FOUND))
                 .getId();
     }
+
+    public boolean existsByDiscordUsername(String username) {
+        return getCurrentGuild().getMembersByName(username, true).stream()
+                .findFirst()
+                .isPresent();
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #358

## 📌 작업 내용 및 특이사항
- 멤버의 디스코드 유저네임을 이용해 디스코드 서버에 존재하는지 확인하는 api를 구현했습니다.

## 📝 참고사항
-

## 📚 기타
-
