### PR TITLE
feat: 리쿠르팅에 회비와 차수 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -39,8 +39,8 @@ public class AdminRecruitmentService {
                 request.endDate(),
                 request.academicYear(),
                 request.semesterType(),
-                request.fee(),
-                request.roundType());
+                request.roundType(),
+                request.fee());
         recruitmentRepository.save(recruitment);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -31,6 +31,7 @@ public class AdminRecruitmentService {
         validatePeriodWithinTwoWeeks(
                 request.startDate(), request.endDate(), request.academicYear(), request.semesterType());
         validatePeriodOverlap(request.academicYear(), request.semesterType(), request.startDate(), request.endDate());
+        validateRoundOverlap(request.academicYear(), request.semesterType(), request.round());
 
         Recruitment recruitment = Recruitment.createRecruitment(
                 request.name(),
@@ -41,7 +42,6 @@ public class AdminRecruitmentService {
                 request.fee(),
                 request.round());
         recruitmentRepository.save(recruitment);
-        // todo: recruitment 모집 시작 직전에 멤버 역할 수정하는 로직 필요.
     }
 
     private void validatePeriodMatchesAcademicYear(
@@ -111,5 +111,11 @@ public class AdminRecruitmentService {
                 recruitmentRepository.findAllByAcademicYearAndSemesterType(academicYear, semesterType);
 
         recruitments.forEach(recruitment -> recruitment.validatePeriodOverlap(startDate, endDate));
+    }
+
+    private void validateRoundOverlap(Integer academicYear, SemesterType semesterType, Round round) {
+        if (recruitmentRepository.existsByAcademicYearAndSemesterTypeAndRound(academicYear, semesterType, round)) {
+            throw new CustomException(RECRUITMENT_ROUND_OVERLAP);
+        }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -5,6 +5,7 @@ import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
@@ -40,7 +41,7 @@ public class AdminRecruitmentService {
                 request.academicYear(),
                 request.semesterType(),
                 request.roundType(),
-                request.fee());
+                Money.from(request.fee()));
         recruitmentRepository.save(recruitment);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -7,6 +7,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.Round;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import java.time.LocalDateTime;
@@ -32,7 +33,13 @@ public class AdminRecruitmentService {
         validatePeriodOverlap(request.academicYear(), request.semesterType(), request.startDate(), request.endDate());
 
         Recruitment recruitment = Recruitment.createRecruitment(
-                request.name(), request.startDate(), request.endDate(), request.academicYear(), request.semesterType());
+                request.name(),
+                request.startDate(),
+                request.endDate(),
+                request.academicYear(),
+                request.semesterType(),
+                request.fee(),
+                request.round());
         recruitmentRepository.save(recruitment);
         // todo: recruitment 모집 시작 직전에 멤버 역할 수정하는 로직 필요.
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -7,7 +7,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
-import com.gdschongik.gdsc.domain.recruitment.domain.Round;
+import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import java.time.LocalDateTime;
@@ -31,7 +31,7 @@ public class AdminRecruitmentService {
         validatePeriodWithinTwoWeeks(
                 request.startDate(), request.endDate(), request.academicYear(), request.semesterType());
         validatePeriodOverlap(request.academicYear(), request.semesterType(), request.startDate(), request.endDate());
-        validateRoundOverlap(request.academicYear(), request.semesterType(), request.round());
+        validateRoundOverlap(request.academicYear(), request.semesterType(), request.roundType());
 
         Recruitment recruitment = Recruitment.createRecruitment(
                 request.name(),
@@ -40,7 +40,7 @@ public class AdminRecruitmentService {
                 request.academicYear(),
                 request.semesterType(),
                 request.fee(),
-                request.round());
+                request.roundType());
         recruitmentRepository.save(recruitment);
     }
 
@@ -113,9 +113,10 @@ public class AdminRecruitmentService {
         recruitments.forEach(recruitment -> recruitment.validatePeriodOverlap(startDate, endDate));
     }
 
-    private void validateRoundOverlap(Integer academicYear, SemesterType semesterType, Round round) {
-        if (recruitmentRepository.existsByAcademicYearAndSemesterTypeAndRound(academicYear, semesterType, round)) {
-            throw new CustomException(RECRUITMENT_ROUND_OVERLAP);
+    private void validateRoundOverlap(Integer academicYear, SemesterType semesterType, RoundType roundType) {
+        if (recruitmentRepository.existsByAcademicYearAndSemesterTypeAndRoundType(
+                academicYear, semesterType, roundType)) {
+            throw new CustomException(RECRUITMENT_ROUND_TYPE_OVERLAP);
         }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRepository.java
@@ -2,7 +2,7 @@ package com.gdschongik.gdsc.domain.recruitment.dao;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
-import com.gdschongik.gdsc.domain.recruitment.domain.Round;
+import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,5 +10,6 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long>,
 
     List<Recruitment> findAllByAcademicYearAndSemesterType(Integer academicYear, SemesterType semesterType);
 
-    boolean existsByAcademicYearAndSemesterTypeAndRound(Integer academicYear, SemesterType semesterType, Round round);
+    boolean existsByAcademicYearAndSemesterTypeAndRoundType(
+            Integer academicYear, SemesterType semesterType, RoundType roundType);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRepository.java
@@ -2,10 +2,13 @@ package com.gdschongik.gdsc.domain.recruitment.dao;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.Round;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long>, RecruitmentCustomRepository {
 
     List<Recruitment> findAllByAcademicYearAndSemesterType(Integer academicYear, SemesterType semesterType);
+
+    boolean existsByAcademicYearAndSemesterTypeAndRound(Integer academicYear, SemesterType semesterType, Round round);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
@@ -29,16 +29,21 @@ public class Recruitment extends BaseSemesterEntity {
     private Money fee;
 
     @Enumerated(EnumType.STRING)
-    private Round round;
+    private RoundType roundType;
 
     @Builder(access = AccessLevel.PRIVATE)
     private Recruitment(
-            String name, final Period period, Integer academicYear, SemesterType semesterType, Money fee, Round round) {
+            String name,
+            final Period period,
+            Integer academicYear,
+            SemesterType semesterType,
+            Money fee,
+            RoundType roundType) {
         super(academicYear, semesterType);
         this.name = name;
         this.period = period;
         this.fee = fee;
-        this.round = round;
+        this.roundType = roundType;
     }
 
     public static Recruitment createRecruitment(
@@ -48,7 +53,7 @@ public class Recruitment extends BaseSemesterEntity {
             Integer academicYear,
             SemesterType semesterType,
             Money fee,
-            Round round) {
+            RoundType roundType) {
         Period period = Period.createPeriod(startDate, endDate);
         return Recruitment.builder()
                 .name(name)
@@ -56,7 +61,7 @@ public class Recruitment extends BaseSemesterEntity {
                 .academicYear(academicYear)
                 .semesterType(semesterType)
                 .fee(fee)
-                .round(round)
+                .roundType(roundType)
                 .build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
@@ -26,6 +26,7 @@ public class Recruitment extends BaseSemesterEntity {
     @Embedded
     private Period period;
 
+    @Embedded
     private Money fee;
 
     @Enumerated(EnumType.STRING)
@@ -52,16 +53,16 @@ public class Recruitment extends BaseSemesterEntity {
             LocalDateTime endDate,
             Integer academicYear,
             SemesterType semesterType,
-            Money fee,
-            RoundType roundType) {
+            RoundType roundType,
+            Money fee) {
         Period period = Period.createPeriod(startDate, endDate);
         return Recruitment.builder()
                 .name(name)
                 .period(period)
                 .academicYear(academicYear)
                 .semesterType(semesterType)
-                .fee(fee)
                 .roundType(roundType)
+                .fee(fee)
                 .build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.domain.recruitment.domain;
 
 import com.gdschongik.gdsc.domain.common.model.BaseSemesterEntity;
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
@@ -25,11 +26,19 @@ public class Recruitment extends BaseSemesterEntity {
     @Embedded
     private Period period;
 
+    private Money fee;
+
+    @Enumerated(EnumType.STRING)
+    private Round round;
+
     @Builder(access = AccessLevel.PRIVATE)
-    private Recruitment(String name, final Period period, Integer academicYear, SemesterType semesterType) {
+    private Recruitment(
+            String name, final Period period, Integer academicYear, SemesterType semesterType, Money fee, Round round) {
         super(academicYear, semesterType);
         this.name = name;
         this.period = period;
+        this.fee = fee;
+        this.round = round;
     }
 
     public static Recruitment createRecruitment(
@@ -37,13 +46,17 @@ public class Recruitment extends BaseSemesterEntity {
             LocalDateTime startDate,
             LocalDateTime endDate,
             Integer academicYear,
-            SemesterType semesterType) {
+            SemesterType semesterType,
+            Money fee,
+            Round round) {
         Period period = Period.createPeriod(startDate, endDate);
         return Recruitment.builder()
                 .name(name)
                 .period(period)
                 .academicYear(academicYear)
                 .semesterType(semesterType)
+                .fee(fee)
+                .round(round)
                 .build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Round.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Round.java
@@ -1,0 +1,13 @@
+package com.gdschongik.gdsc.domain.recruitment.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Round {
+    FIRST("1차"),
+    SECOND("2차");
+
+    private final String value;
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RoundType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RoundType.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum Round {
+public enum RoundType {
     FIRST("1차"),
     SECOND("2차");
 

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentCreateRequest.java
@@ -3,6 +3,8 @@ package com.gdschongik.gdsc.domain.recruitment.dto.request;
 import static com.gdschongik.gdsc.global.common.constant.RegexConstant.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.recruitment.domain.Round;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
@@ -15,4 +17,6 @@ public record RecruitmentCreateRequest(
         @Future @Schema(description = "모집기간 종료일", pattern = DATETIME) LocalDateTime endDate,
         @NotNull(message = "학년도는 null이 될 수 없습니다.") @Schema(description = "학년도", pattern = ACADEMIC_YEAR)
                 Integer academicYear,
-        @NotNull(message = "학기는 null이 될 수 없습니다.") @Schema(description = "학기") SemesterType semesterType) {}
+        @NotNull(message = "학기는 null이 될 수 없습니다.") @Schema(description = "학기") SemesterType semesterType,
+        @NotNull(message = "회비는 null이 될 수 없습니다.") @Schema(description = "회비") Money fee,
+        @NotNull(message = "모집 차수는 null이 될 수 없습니다.") @Schema(description = "모집 차수") Round round) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentCreateRequest.java
@@ -4,7 +4,7 @@ import static com.gdschongik.gdsc.global.common.constant.RegexConstant.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
-import com.gdschongik.gdsc.domain.recruitment.domain.Round;
+import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
@@ -19,4 +19,4 @@ public record RecruitmentCreateRequest(
                 Integer academicYear,
         @NotNull(message = "학기는 null이 될 수 없습니다.") @Schema(description = "학기") SemesterType semesterType,
         @NotNull(message = "회비는 null이 될 수 없습니다.") @Schema(description = "회비") Money fee,
-        @NotNull(message = "모집 차수는 null이 될 수 없습니다.") @Schema(description = "모집 차수") Round round) {}
+        @NotNull(message = "모집 차수는 null이 될 수 없습니다.") @Schema(description = "모집 차수") RoundType roundType) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentCreateRequest.java
@@ -3,12 +3,12 @@ package com.gdschongik.gdsc.domain.recruitment.dto.request;
 import static com.gdschongik.gdsc.global.common.constant.RegexConstant.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
-import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 public record RecruitmentCreateRequest(
@@ -19,4 +19,4 @@ public record RecruitmentCreateRequest(
                 Integer academicYear,
         @NotNull(message = "학기는 null이 될 수 없습니다.") @Schema(description = "학기") SemesterType semesterType,
         @NotNull(message = "모집 차수는 null이 될 수 없습니다.") @Schema(description = "모집 차수") RoundType roundType,
-        @NotNull(message = "회비는 null이 될 수 없습니다.") @Schema(description = "회비") Money fee) {}
+        @NotNull(message = "회비는 null이 될 수 없습니다.") @Schema(description = "회비") BigDecimal fee) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentCreateRequest.java
@@ -18,5 +18,5 @@ public record RecruitmentCreateRequest(
         @NotNull(message = "학년도는 null이 될 수 없습니다.") @Schema(description = "학년도", pattern = ACADEMIC_YEAR)
                 Integer academicYear,
         @NotNull(message = "학기는 null이 될 수 없습니다.") @Schema(description = "학기") SemesterType semesterType,
-        @NotNull(message = "회비는 null이 될 수 없습니다.") @Schema(description = "회비") Money fee,
-        @NotNull(message = "모집 차수는 null이 될 수 없습니다.") @Schema(description = "모집 차수") RoundType roundType) {}
+        @NotNull(message = "모집 차수는 null이 될 수 없습니다.") @Schema(description = "모집 차수") RoundType roundType,
+        @NotNull(message = "회비는 null이 될 수 없습니다.") @Schema(description = "회비") Money fee) {}

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -77,7 +77,7 @@ public enum ErrorCode {
     RECRUITMENT_PERIOD_MISMATCH_SEMESTER_TYPE(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 입력된 학기가 일치하지 않습니다."),
     RECRUITMENT_PERIOD_SEMESTER_TYPE_UNMAPPED(HttpStatus.CONFLICT, "모집 시작일과 종료일이 매핑되는 학기가 없습니다."),
     RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일이 학기 시작일로부터 2주 이내에 있지 않습니다."),
-    RECRUITMENT_ROUND_OVERLAP(HttpStatus.BAD_REQUEST, "모집 차수가 중복됩니다."),
+    RECRUITMENT_ROUND_TYPE_OVERLAP(HttpStatus.BAD_REQUEST, "모집 차수가 중복됩니다."),
 
     // Coupon
     COUPON_DISCOUNT_AMOUNT_NOT_POSITIVE(HttpStatus.CONFLICT, "쿠폰의 할인 금액은 0보다 커야 합니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -77,6 +77,7 @@ public enum ErrorCode {
     RECRUITMENT_PERIOD_MISMATCH_SEMESTER_TYPE(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 입력된 학기가 일치하지 않습니다."),
     RECRUITMENT_PERIOD_SEMESTER_TYPE_UNMAPPED(HttpStatus.CONFLICT, "모집 시작일과 종료일이 매핑되는 학기가 없습니다."),
     RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일이 학기 시작일로부터 2주 이내에 있지 않습니다."),
+    RECRUITMENT_ROUND_OVERLAP(HttpStatus.BAD_REQUEST, "모집 차수가 중복됩니다."),
 
     // Coupon
     COUPON_DISCOUNT_AMOUNT_NOT_POSITIVE(HttpStatus.CONFLICT, "쿠폰의 할인 금액은 0보다 커야 합니다."),

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -46,8 +46,8 @@ public class MembershipServiceTest extends IntegrationTest {
     }
 
     private Recruitment createRecruitment() {
-        Recruitment recruitment =
-                Recruitment.createRecruitment(RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE);
+        Recruitment recruitment = Recruitment.createRecruitment(
+                RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND);
         return recruitmentRepository.save(recruitment);
     }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -47,7 +47,7 @@ public class MembershipServiceTest extends IntegrationTest {
 
     private Recruitment createRecruitment() {
         Recruitment recruitment = Recruitment.createRecruitment(
-                RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND_TYPE);
+                RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
         return recruitmentRepository.save(recruitment);
     }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -47,7 +47,7 @@ public class MembershipServiceTest extends IntegrationTest {
 
     private Recruitment createRecruitment() {
         Recruitment recruitment = Recruitment.createRecruitment(
-                RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND);
+                RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND_TYPE);
         return recruitmentRepository.save(recruitment);
     }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
@@ -19,8 +19,8 @@ class MembershipTest {
         void 역할이_GUEST라면_멤버십_가입신청에_실패한다() {
             // given
             Member guestMember = Member.createGuestMember(OAUTH_ID);
-            Recruitment recruitment =
-                    Recruitment.createRecruitment(RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE);
+            Recruitment recruitment = Recruitment.createRecruitment(
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND);
 
             // when & then
             assertThatThrownBy(() -> Membership.createMembership(guestMember, recruitment))

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
@@ -20,7 +20,7 @@ class MembershipTest {
             // given
             Member guestMember = Member.createGuestMember(OAUTH_ID);
             Recruitment recruitment = Recruitment.createRecruitment(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND_TYPE);
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
 
             // when & then
             assertThatThrownBy(() -> Membership.createMembership(guestMember, recruitment))

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
@@ -20,7 +20,7 @@ class MembershipTest {
             // given
             Member guestMember = Member.createGuestMember(OAUTH_ID);
             Recruitment recruitment = Recruitment.createRecruitment(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND);
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND_TYPE);
 
             // when & then
             assertThatThrownBy(() -> Membership.createMembership(guestMember, recruitment))

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -25,7 +25,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
 
     private void createRecruitment() {
         Recruitment recruitment = Recruitment.createRecruitment(
-                RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND);
+                RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND_TYPE);
         recruitmentRepository.save(recruitment);
     }
 
@@ -36,7 +36,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
             // given
             createRecruitment();
             RecruitmentCreateRequest request = new RecruitmentCreateRequest(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND);
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND_TYPE);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
@@ -48,7 +48,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         void 모집_시작일과_종료일의_연도가_입력된_학년도와_다르다면_실패한다() {
             // given
             RecruitmentCreateRequest request = new RecruitmentCreateRequest(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, 2025, SEMESTER_TYPE, FEE, ROUND);
+                    RECRUITMENT_NAME, START_DATE, END_DATE, 2025, SEMESTER_TYPE, FEE, ROUND_TYPE);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
@@ -60,7 +60,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         void 모집_시작일과_종료일의_학기가_입력된_학기와_다르다면_실패한다() {
             // given
             RecruitmentCreateRequest request = new RecruitmentCreateRequest(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SemesterType.SECOND, FEE, ROUND);
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SemesterType.SECOND, FEE, ROUND_TYPE);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
@@ -78,7 +78,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
                     ACADEMIC_YEAR,
                     SEMESTER_TYPE,
                     FEE,
-                    ROUND);
+                    ROUND_TYPE);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
@@ -97,12 +97,12 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
                     ACADEMIC_YEAR,
                     SEMESTER_TYPE,
                     FEE,
-                    ROUND);
+                    ROUND_TYPE);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_ROUND_OVERLAP.getMessage());
+                    .hasMessage(RECRUITMENT_ROUND_TYPE_OVERLAP.getMessage());
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -24,8 +24,8 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
     private RecruitmentRepository recruitmentRepository;
 
     private void createRecruitment() {
-        Recruitment recruitment =
-                Recruitment.createRecruitment(RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE);
+        Recruitment recruitment = Recruitment.createRecruitment(
+                RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND);
         recruitmentRepository.save(recruitment);
     }
 
@@ -35,8 +35,8 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         void 기간이_중복되는_Recruitment가_있다면_실패한다() {
             // given
             createRecruitment();
-            RecruitmentCreateRequest request =
-                    new RecruitmentCreateRequest(RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE);
+            RecruitmentCreateRequest request = new RecruitmentCreateRequest(
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
@@ -47,8 +47,8 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         @Test
         void 모집_시작일과_종료일의_연도가_입력된_학년도와_다르다면_실패한다() {
             // given
-            RecruitmentCreateRequest request =
-                    new RecruitmentCreateRequest(RECRUITMENT_NAME, START_DATE, END_DATE, 2025, SEMESTER_TYPE);
+            RecruitmentCreateRequest request = new RecruitmentCreateRequest(
+                    RECRUITMENT_NAME, START_DATE, END_DATE, 2025, SEMESTER_TYPE, FEE, ROUND);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
@@ -60,7 +60,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         void 모집_시작일과_종료일의_학기가_입력된_학기와_다르다면_실패한다() {
             // given
             RecruitmentCreateRequest request = new RecruitmentCreateRequest(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SemesterType.SECOND);
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SemesterType.SECOND, FEE, ROUND);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
@@ -72,7 +72,13 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         void 모집_시작일과_종료일이_학기_시작일로부터_2주_이내에_있지_않다면_실패한다() {
             // given
             RecruitmentCreateRequest request = new RecruitmentCreateRequest(
-                    RECRUITMENT_NAME, START_DATE, LocalDateTime.of(2024, 4, 10, 00, 00), ACADEMIC_YEAR, SEMESTER_TYPE);
+                    RECRUITMENT_NAME,
+                    START_DATE,
+                    LocalDateTime.of(2024, 4, 10, 0, 0),
+                    ACADEMIC_YEAR,
+                    SEMESTER_TYPE,
+                    FEE,
+                    ROUND);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -25,7 +25,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
 
     private void createRecruitment() {
         Recruitment recruitment = Recruitment.createRecruitment(
-                RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND_TYPE);
+                RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
         recruitmentRepository.save(recruitment);
     }
 
@@ -36,7 +36,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
             // given
             createRecruitment();
             RecruitmentCreateRequest request = new RecruitmentCreateRequest(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND_TYPE);
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
@@ -48,7 +48,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         void 모집_시작일과_종료일의_연도가_입력된_학년도와_다르다면_실패한다() {
             // given
             RecruitmentCreateRequest request = new RecruitmentCreateRequest(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, 2025, SEMESTER_TYPE, FEE, ROUND_TYPE);
+                    RECRUITMENT_NAME, START_DATE, END_DATE, 2025, SEMESTER_TYPE, ROUND_TYPE, FEE);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
@@ -60,7 +60,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         void 모집_시작일과_종료일의_학기가_입력된_학기와_다르다면_실패한다() {
             // given
             RecruitmentCreateRequest request = new RecruitmentCreateRequest(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SemesterType.SECOND, FEE, ROUND_TYPE);
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SemesterType.SECOND, ROUND_TYPE, FEE);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
@@ -77,8 +77,8 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
                     LocalDateTime.of(2024, 4, 10, 0, 0),
                     ACADEMIC_YEAR,
                     SEMESTER_TYPE,
-                    FEE,
-                    ROUND_TYPE);
+                    ROUND_TYPE,
+                    FEE);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
@@ -96,8 +96,8 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
                     LocalDateTime.of(2024, 3, 13, 0, 0),
                     ACADEMIC_YEAR,
                     SEMESTER_TYPE,
-                    FEE,
-                    ROUND_TYPE);
+                    ROUND_TYPE,
+                    FEE);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -85,5 +85,24 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessage(RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS.getMessage());
         }
+
+        @Test
+        void 학년도_학기_차수가_모두_중복되는_리쿠르팅이라면_실패한다() {
+            // given
+            createRecruitment();
+            RecruitmentCreateRequest request = new RecruitmentCreateRequest(
+                    RECRUITMENT_NAME,
+                    LocalDateTime.of(2024, 3, 12, 0, 0),
+                    LocalDateTime.of(2024, 3, 13, 0, 0),
+                    ACADEMIC_YEAR,
+                    SEMESTER_TYPE,
+                    FEE,
+                    ROUND);
+
+            // when & then
+            assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(RECRUITMENT_ROUND_OVERLAP.getMessage());
+        }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -36,7 +36,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
             // given
             createRecruitment();
             RecruitmentCreateRequest request = new RecruitmentCreateRequest(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE_AMOUNT);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
@@ -48,7 +48,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         void 모집_시작일과_종료일의_연도가_입력된_학년도와_다르다면_실패한다() {
             // given
             RecruitmentCreateRequest request = new RecruitmentCreateRequest(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, 2025, SEMESTER_TYPE, ROUND_TYPE, FEE);
+                    RECRUITMENT_NAME, START_DATE, END_DATE, 2025, SEMESTER_TYPE, ROUND_TYPE, FEE_AMOUNT);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
@@ -60,7 +60,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         void 모집_시작일과_종료일의_학기가_입력된_학기와_다르다면_실패한다() {
             // given
             RecruitmentCreateRequest request = new RecruitmentCreateRequest(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SemesterType.SECOND, ROUND_TYPE, FEE);
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SemesterType.SECOND, ROUND_TYPE, FEE_AMOUNT);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
@@ -78,7 +78,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
                     ACADEMIC_YEAR,
                     SEMESTER_TYPE,
                     ROUND_TYPE,
-                    FEE);
+                    FEE_AMOUNT);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
@@ -97,7 +97,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
                     ACADEMIC_YEAR,
                     SEMESTER_TYPE,
                     ROUND_TYPE,
-                    FEE);
+                    FEE_AMOUNT);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
@@ -1,7 +1,6 @@
 package com.gdschongik.gdsc.domain.recruitment.domain;
 
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
-import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
@@ -19,7 +18,7 @@ class RecruitmentTest {
 
             // when
             Recruitment recruitment = Recruitment.createRecruitment(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND);
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND_TYPE);
 
             // then
             assertThat(recruitment.getPeriod().getStartDate()).isEqualTo(START_DATE);

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
@@ -18,7 +18,7 @@ class RecruitmentTest {
 
             // when
             Recruitment recruitment = Recruitment.createRecruitment(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND_TYPE);
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
 
             // then
             assertThat(recruitment.getPeriod().getStartDate()).isEqualTo(START_DATE);

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
@@ -18,8 +18,8 @@ class RecruitmentTest {
             Period period = Period.createPeriod(START_DATE, END_DATE);
 
             // when
-            Recruitment recruitment =
-                    Recruitment.createRecruitment(RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE);
+            Recruitment recruitment = Recruitment.createRecruitment(
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, FEE, ROUND);
 
             // then
             assertThat(recruitment.getPeriod().getStartDate()).isEqualTo(START_DATE);

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/RecruitmentConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/RecruitmentConstant.java
@@ -2,7 +2,7 @@ package com.gdschongik.gdsc.global.common.constant;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
-import com.gdschongik.gdsc.domain.recruitment.domain.Round;
+import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
@@ -14,7 +14,7 @@ public class RecruitmentConstant {
     public static final Integer ACADEMIC_YEAR = 2024;
     public static final SemesterType SEMESTER_TYPE = SemesterType.FIRST;
     public static final Money FEE = Money.from(BigDecimal.valueOf(20000));
-    public static final Round ROUND = Round.FIRST;
+    public static final RoundType ROUND_TYPE = RoundType.FIRST;
 
     private RecruitmentConstant() {}
 }

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/RecruitmentConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/RecruitmentConstant.java
@@ -14,6 +14,7 @@ public class RecruitmentConstant {
     public static final Integer ACADEMIC_YEAR = 2024;
     public static final SemesterType SEMESTER_TYPE = SemesterType.FIRST;
     public static final Money FEE = Money.from(BigDecimal.valueOf(20000));
+    public static final BigDecimal FEE_AMOUNT = BigDecimal.valueOf(20000);
     public static final RoundType ROUND_TYPE = RoundType.FIRST;
 
     private RecruitmentConstant() {}

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/RecruitmentConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/RecruitmentConstant.java
@@ -1,6 +1,9 @@
 package com.gdschongik.gdsc.global.common.constant;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.recruitment.domain.Round;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 public class RecruitmentConstant {
@@ -10,6 +13,8 @@ public class RecruitmentConstant {
     public static final LocalDateTime END_DATE = LocalDateTime.of(2024, 3, 11, 00, 00);
     public static final Integer ACADEMIC_YEAR = 2024;
     public static final SemesterType SEMESTER_TYPE = SemesterType.FIRST;
+    public static final Money FEE = Money.from(BigDecimal.valueOf(20000));
+    public static final Round ROUND = Round.FIRST;
 
     private RecruitmentConstant() {}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #369

## 📌 작업 내용 및 특이사항
- 리쿠르팅에 Money(회비)와 RoundType(차수)를 추가했습니다. RoundType은 Enum으로 관리합니다.
- `학년도, 학기, 차수가 모두 중복되는 리쿠르팅`은 생성하지 못하도록 리쿠르팅 생성 Api를 수정했습니다.
- test에서 수정된 파일이 많기는 하지만 대부분 `Recruitment.createRecruitment` 메서드 수정에 따른 변화입니다.

## 📝 참고사항
-

## 📚 기타
-
