### PR TITLE
refactor: 사용하지 않는 QueryDSL 로직 제거

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/email/dao/UnivEmailVerificationRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/email/dao/UnivEmailVerificationRepository.java
@@ -1,6 +1,0 @@
-package com.gdschongik.gdsc.domain.email.dao;
-
-import com.gdschongik.gdsc.domain.email.domain.UnivEmailVerification;
-import org.springframework.data.repository.CrudRepository;
-
-public interface UnivEmailVerificationRepository extends CrudRepository<UnivEmailVerification, String> {}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -25,22 +25,14 @@ public class MemberCustomRepositoryImpl extends MemberQueryMethod implements Mem
     public Page<Member> findAllByRole(MemberQueryOption queryOption, Pageable pageable, @Nullable MemberRole role) {
         List<Member> fetch = queryFactory
                 .selectFrom(member)
-                .where(
-                        matchesQueryOption(queryOption),
-                        eqRole(role),
-                        eqRequirementStatus(member.associateRequirement.infoStatus, VERIFIED))
+                .where(matchesQueryOption(queryOption), eqRole(role))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(member.createdAt.desc())
                 .fetch();
 
-        JPAQuery<Long> countQuery = queryFactory
-                .select(member.count())
-                .from(member)
-                .where(
-                        matchesQueryOption(queryOption),
-                        eqRole(role),
-                        eqRequirementStatus(member.associateRequirement.infoStatus, VERIFIED));
+        JPAQuery<Long> countQuery =
+                queryFactory.select(member.count()).from(member).where(matchesQueryOption(queryOption), eqRole(role));
 
         return PageableExecutionUtils.getPage(fetch, pageable, countQuery::fetchOne);
     }
@@ -49,7 +41,7 @@ public class MemberCustomRepositoryImpl extends MemberQueryMethod implements Mem
     public List<Member> findAllByRole(MemberRole role) {
         return queryFactory
                 .selectFrom(member)
-                .where(eqRole(role), eqRequirementStatus(member.associateRequirement.infoStatus, VERIFIED))
+                .where(eqRole(role))
                 .orderBy(member.studentId.asc(), member.name.asc())
                 .fetch();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.member.dao;
 
+import static com.gdschongik.gdsc.domain.common.model.RequirementStatus.*;
 import static com.gdschongik.gdsc.domain.member.domain.QMember.*;
-import static com.querydsl.core.group.GroupBy.*;
 
 import com.gdschongik.gdsc.domain.common.model.RequirementStatus;
 import com.gdschongik.gdsc.domain.member.domain.Member;
@@ -25,7 +25,10 @@ public class MemberCustomRepositoryImpl extends MemberQueryMethod implements Mem
     public Page<Member> findAllByRole(MemberQueryOption queryOption, Pageable pageable, @Nullable MemberRole role) {
         List<Member> fetch = queryFactory
                 .selectFrom(member)
-                .where(matchesQueryOption(queryOption), eqRole(role), isStudentIdNotNull())
+                .where(
+                        matchesQueryOption(queryOption),
+                        eqRole(role),
+                        eqRequirementStatus(member.associateRequirement.infoStatus, VERIFIED))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(member.createdAt.desc())
@@ -34,7 +37,10 @@ public class MemberCustomRepositoryImpl extends MemberQueryMethod implements Mem
         JPAQuery<Long> countQuery = queryFactory
                 .select(member.count())
                 .from(member)
-                .where(matchesQueryOption(queryOption), eqRole(role), isStudentIdNotNull());
+                .where(
+                        matchesQueryOption(queryOption),
+                        eqRole(role),
+                        eqRequirementStatus(member.associateRequirement.infoStatus, VERIFIED));
 
         return PageableExecutionUtils.getPage(fetch, pageable, countQuery::fetchOne);
     }
@@ -43,7 +49,7 @@ public class MemberCustomRepositoryImpl extends MemberQueryMethod implements Mem
     public List<Member> findAllByRole(MemberRole role) {
         return queryFactory
                 .selectFrom(member)
-                .where(eqRole(role), isStudentIdNotNull())
+                .where(eqRole(role), eqRequirementStatus(member.associateRequirement.infoStatus, VERIFIED))
                 .orderBy(member.studentId.asc(), member.name.asc())
                 .fetch();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberQueryMethod.java
@@ -1,6 +1,5 @@
 package com.gdschongik.gdsc.domain.member.dao;
 
-import static com.gdschongik.gdsc.domain.common.model.RequirementStatus.*;
 import static com.gdschongik.gdsc.domain.member.domain.QMember.*;
 
 import com.gdschongik.gdsc.domain.common.model.RequirementStatus;
@@ -42,10 +41,6 @@ public class MemberQueryMethod {
         return nickname != null ? member.nickname.containsIgnoreCase(nickname) : null;
     }
 
-    protected BooleanExpression eqOauthId(String oauthId) {
-        return member.oauthId.eq(oauthId);
-    }
-
     protected BooleanExpression eqRequirementStatus(
             EnumPath<RequirementStatus> requirement, RequirementStatus requirementStatus) {
         return requirementStatus != null ? requirement.eq(requirementStatus) : null;
@@ -53,25 +48,6 @@ public class MemberQueryMethod {
 
     protected BooleanExpression inDepartmentList(List<Department> departmentCodes) {
         return departmentCodes.isEmpty() ? null : member.department.in(departmentCodes);
-    }
-
-    protected BooleanExpression isStudentIdNotNull() {
-        return member.studentId.isNotNull();
-    }
-
-    protected BooleanBuilder isGrantAvailable() {
-        return new BooleanBuilder()
-                .and(eqRequirementStatus(member.associateRequirement.discordStatus, VERIFIED))
-                .and(eqRequirementStatus(member.associateRequirement.univStatus, VERIFIED))
-                .and(eqRequirementStatus(member.associateRequirement.bevyStatus, VERIFIED));
-    }
-
-    protected BooleanBuilder isAssociateAvailable() {
-        return new BooleanBuilder()
-                .and(eqRequirementStatus(member.associateRequirement.discordStatus, VERIFIED))
-                .and(eqRequirementStatus(member.associateRequirement.univStatus, VERIFIED))
-                .and(eqRequirementStatus(member.associateRequirement.infoStatus, VERIFIED))
-                .and(eqRequirementStatus(member.associateRequirement.bevyStatus, VERIFIED));
     }
 
     protected BooleanBuilder matchesQueryOption(MemberQueryOption queryOption) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
@@ -14,6 +14,4 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberCus
     Optional<Member> findByUnivEmail(String univEmail);
 
     Optional<Member> findByOauthId(String oauthId);
-
-    Optional<Member> findByEmail(String email);
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #385

## 📌 작업 내용 및 특이사항
- no usage인 repository 로직들을 제거했습니다.
- 가입 신청서 작성 여부를 판단하기 위해 사용하던 `isStudentIdNotNull()`는 
`eqRequirementStatus(member.associateRequirement.infoStatus, VERIFIED))`로 대체했습니다.

## 📝 참고사항
- #376 에서 제거 누락된 `UnivEmailVerificationRepository`를 제거했습니다.

## 📚 기타
-
