### PR TITLE
feat: Money VO에 대하여 `equals()` 가 동작하지 않는 문제 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/common/vo/Money.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/vo/Money.java
@@ -8,18 +8,26 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
 @Getter
 @Embeddable
-@EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Money {
+public final class Money {
 
     private BigDecimal amount;
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof Money other && this.amount.compareTo(other.amount) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.amount.stripTrailingZeros().hashCode();
+    }
 
     @Builder(access = AccessLevel.PRIVATE)
     private Money(BigDecimal amount) {

--- a/src/test/java/com/gdschongik/gdsc/domain/common/vo/MoneyTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/common/vo/MoneyTest.java
@@ -1,0 +1,77 @@
+package com.gdschongik.gdsc.domain.common.vo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class MoneyTest {
+
+    @Nested
+    class 금액_동등성_확인할때 {
+
+        @Test
+        void 스케일이_달라도_같은_값이면_동일한_금액이다() {
+            // given
+            Money money1 = Money.from(BigDecimal.valueOf(1000));
+            Money money2 = Money.from(BigDecimal.valueOf(1000));
+            Money money3 = Money.from(BigDecimal.valueOf(1000.0));
+            Money money4 = Money.from(BigDecimal.valueOf(1000.00));
+            Money money5 = Money.from(BigDecimal.valueOf(1000.000));
+            Money money6 = Money.from(BigDecimal.valueOf(1000.0000));
+
+            // when & then
+            assertThat(money1)
+                    .isEqualTo(money2)
+                    .isEqualTo(money3)
+                    .isEqualTo(money4)
+                    .isEqualTo(money5)
+                    .isEqualTo(money6);
+        }
+
+        @Test
+        void 다른_값이면_다른_금액이다() {
+            // given
+            Money money1 = Money.from(BigDecimal.valueOf(1000.01));
+            Money money2 = Money.from(BigDecimal.valueOf(1000.02));
+
+            // when & then
+            assertThat(money1).isNotEqualTo(money2);
+        }
+    }
+
+    // hashCode
+    @Nested
+    class 금액_해시코드_확인할때 {
+
+        @Test
+        void 스케일이_달라도_같은_값이면_동일한_해시코드이다() {
+            // given
+            Money money1 = Money.from(BigDecimal.valueOf(1000));
+            Money money2 = Money.from(BigDecimal.valueOf(1000));
+            Money money3 = Money.from(BigDecimal.valueOf(1000.0));
+            Money money4 = Money.from(BigDecimal.valueOf(1000.00));
+            Money money5 = Money.from(BigDecimal.valueOf(1000.000));
+            Money money6 = Money.from(BigDecimal.valueOf(1000.0000));
+
+            // when & then
+            assertThat(money1.hashCode())
+                    .isEqualTo(money2.hashCode())
+                    .isEqualTo(money3.hashCode())
+                    .isEqualTo(money4.hashCode())
+                    .isEqualTo(money5.hashCode())
+                    .isEqualTo(money6.hashCode());
+        }
+
+        @Test
+        void 다른_값이면_다른_해시코드이다() {
+            // given
+            Money money1 = Money.from(BigDecimal.valueOf(1000.01));
+            Money money2 = Money.from(BigDecimal.valueOf(1000.02));
+
+            // when & then
+            assertThat(money1.hashCode()).isNotEqualTo(money2.hashCode());
+        }
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #391

## 📌 작업 내용 및 특이사항

### 문제 원인
- lombok의 `@EqualsAndHashCode` 는 클래스 내부에 있는 필드 타입의 `equals()` 및 `hashCode()` 를 사용하여 해당 클래스의 메서드를 오버라이드한 메서드를 만들어줍니다.
- 이때 `BigDecimal`의 특성 때문에 문제가 발생합니다.
- `BigDecimal`은 내부적으로 값 뿐만이 아니라 스케일(scal)을 추가로 가집니다.
- 가령 `BigDecimal`에서 `1.0`과 `1.00`은 같은 값이지만 다른 스케일을 갖습니다. 이때 해당 클래스의 `equals()`는 값과 스케일을 모두 고려하므로, 값이 같더라도 false를 리턴하게 되는 것입니다. 마찬가지로 `hashCode()`도 값과 스케일 모두 고려하기 때문에 동일한 문제를 발생시킵니다.

### 해결책
- 아래와 같이 롬복을 사용하면서, 문제를 해결하는 방법이 있습니다.
```java
@EqualsAndHashCode
class MyClass {

    @EqualsAndHashCode.Exclude
    private BigDecimal myDecimal;

    @EqualsAndHashCode.Include
    private BigDecimal myDecimal() {
        return myDecimal != null ? myDecimal.stripTrailingZeros() : null;
    }
}
```
- 하지만 이 방식은 롬복의 특정 기능에 의존적이고, `BigDecimal` 에 대한 이해도를 낮춘다고 판단했습니다. 따라서 직접 `equals()` 및 `hashCode()` 를 오버라이드하기로 결정했습니다.
```java
@Override
public boolean equals(Object obj) {
    return obj instanceof Money other && this.amount.compareTo(other.amount) == 0;
}

@Override
public int hashCode() {
    return this.amount.stripTrailingZeros().hashCode();
}
```
- intellij의 auto-generated된 equals()를 사용하지 않고, java 17에서 preview로 등장한 pattern matching을 사용하면 equals를 좀 더 쉽게 구현할 수 있습니다. 미미하지만 pattern matching을 사용하면 기존 equals를 사용할 때보다 가독성도 좋고 성능적으로도 유리합니다. [(레퍼런스)](https://youtu.be/kuzjX_efuDs?si=GEM0_r_ojqjP0M6W)
- AS-IS
 ```java
@Override
public boolean equals(Object o) {
    if (this == o)
        return true;
    if (o == null || getClass() != o.getClass())
        return false;

    Money money = (Money)o;
    return Objects.equals(amount, money.amount);
}
```
- TO-BE
```java
@Override
public boolean equals(Object obj) {
    return obj instanceof Money other && this.amount.compareTo(other.amount) == 0;
}
```
- 한편 `getClass()` 방식에서 `instanceof` 로 변경하는 경우 서브클래스에 대한 `equals()` 허용 여부를 고려해야 합니다. `getClass()`는 같은 타입이 아니면 false이며, `instanceof` 는 서브타입도 허용합니다.
- Money VO의 경우 일반적으로 상속을 사용하지 않으며 따라서 서브타입을 허용해야 합니다. 추후 상속이 필요한 상황이 생기더라도 상속보다 컴포지션을 사용해야 합니다. 따라서 서브타입을 허용하지 않는 `getClass()` 방식이 권장됩니다.
- 하지만 pattern matching을 사용하기 위해서는 `instanceof` 를 사용해야 하므로, 상속을 막기 위해 VO 클래스를 `final` 로 변경해주었습니다.

## 📝 참고사항
-

## 📚 기타
-
