### PR TITLE
feat: 온보딩 대시보드 페이지 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
@@ -4,6 +4,7 @@ import com.gdschongik.gdsc.domain.member.application.OnboardingMemberService;
 import com.gdschongik.gdsc.domain.member.dto.request.BasicMemberInfoRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.OnboardingMemberUpdateRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberBasicInfoResponse;
+import com.gdschongik.gdsc.domain.member.dto.response.MemberDashboardResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberInfoResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberUnivStatusResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,6 +40,13 @@ public class OnboardingMemberController {
     @GetMapping("/me")
     public ResponseEntity<MemberInfoResponse> getMemberInfo() {
         MemberInfoResponse response = onboardingMemberService.getMemberInfo();
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(summary = "내 대시보드 조회", description = "내 대시보드를 조회합니다.")
+    @GetMapping("/me/dashboard")
+    public ResponseEntity<MemberDashboardResponse> getDashboard() {
+        MemberDashboardResponse response = onboardingMemberService.getDashboard();
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
@@ -43,7 +43,7 @@ public class OnboardingMemberController {
         return ResponseEntity.ok().body(response);
     }
 
-    @Operation(summary = "내 대시보드 조회", description = "내 대시보드를 조회합니다.")
+    @Operation(summary = "내 대시보드 조회", description = "내 대시보드를 조회합니다. 2차 MVP 기능입니다.")
     @GetMapping("/me/dashboard")
     public ResponseEntity<MemberDashboardResponse> getDashboard() {
         MemberDashboardResponse response = onboardingMemberService.getDashboard();

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
@@ -16,6 +16,7 @@ import com.gdschongik.gdsc.domain.recruitment.application.OnboardingRecruitmentS
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -76,8 +77,8 @@ public class OnboardingMemberService {
     public MemberDashboardResponse getDashboard() {
         Member currentMember = memberUtil.getCurrentMember();
         Recruitment currentRecruitment = onboardingRecruitmentService.findCurrentRecruitment();
-        Membership myMembership = membershipService.findMyMembership(currentMember, currentRecruitment);
+        Optional<Membership> myMembership = membershipService.findMyMembership(currentMember, currentRecruitment);
 
-        return MemberDashboardResponse.from(currentMember, currentRecruitment, myMembership);
+        return MemberDashboardResponse.from(currentMember, currentRecruitment, myMembership.orElse(null));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
@@ -7,8 +7,13 @@ import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.dto.request.BasicMemberInfoRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.OnboardingMemberUpdateRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberBasicInfoResponse;
+import com.gdschongik.gdsc.domain.member.dto.response.MemberDashboardResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberInfoResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberUnivStatusResponse;
+import com.gdschongik.gdsc.domain.membership.application.MembershipService;
+import com.gdschongik.gdsc.domain.membership.domain.Membership;
+import com.gdschongik.gdsc.domain.recruitment.application.OnboardingRecruitmentService;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +26,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class OnboardingMemberService {
 
     private final MemberUtil memberUtil;
+    private final OnboardingRecruitmentService onboardingRecruitmentService;
+    private final MembershipService membershipService;
     private final MemberRepository memberRepository;
 
     @Deprecated
@@ -64,5 +71,13 @@ public class OnboardingMemberService {
     public MemberBasicInfoResponse getMemberBasicInfo() {
         Member currentMember = memberUtil.getCurrentMember();
         return MemberBasicInfoResponse.from(currentMember);
+    }
+
+    public MemberDashboardResponse getDashboard() {
+        Member currentMember = memberUtil.getCurrentMember();
+        Recruitment currentRecruitment = onboardingRecruitmentService.findCurrentRecruitment();
+        Membership myMembership = membershipService.findMyMembership(currentMember, currentRecruitment);
+
+        return MemberDashboardResponse.from(currentMember, currentRecruitment, myMembership);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/MemberFullDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/MemberFullDto.java
@@ -1,8 +1,10 @@
 package com.gdschongik.gdsc.domain.member.dto;
 
 import com.gdschongik.gdsc.domain.member.domain.AssociateRequirement;
+import com.gdschongik.gdsc.domain.member.domain.Department;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import java.util.Optional;
 
 public record MemberFullDto(
         Long memberId, MemberRole role, MemberBasicInfoDto basicInfo, AssociateRequirement associateRequirement) {
@@ -24,7 +26,9 @@ public record MemberFullDto(
                     member.getName(),
                     member.getStudentId(),
                     member.getEmail(),
-                    member.getDepartment().getDepartmentName(),
+                    Optional.ofNullable(member.getDepartment())
+                            .map(Department::getDepartmentName)
+                            .orElse(null),
                     member.getPhone(),
                     member.getDiscordUsername(),
                     member.getNickname());

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/MemberFullDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/MemberFullDto.java
@@ -4,6 +4,7 @@ import com.gdschongik.gdsc.domain.member.domain.AssociateRequirement;
 import com.gdschongik.gdsc.domain.member.domain.Department;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.global.util.formatter.PhoneFormatter;
 import java.util.Optional;
 
 public record MemberFullDto(
@@ -29,7 +30,9 @@ public record MemberFullDto(
                     Optional.ofNullable(member.getDepartment())
                             .map(Department::getDepartmentName)
                             .orElse(null),
-                    member.getPhone(),
+                    Optional.ofNullable(member.getPhone())
+                            .map(PhoneFormatter::format)
+                            .orElse(null),
                     member.getDiscordUsername(),
                     member.getNickname());
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/MemberFullDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/MemberFullDto.java
@@ -1,0 +1,33 @@
+package com.gdschongik.gdsc.domain.member.dto;
+
+import com.gdschongik.gdsc.domain.member.domain.AssociateRequirement;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+
+public record MemberFullDto(
+        Long memberId, MemberRole role, MemberBasicInfoDto basicInfo, AssociateRequirement associateRequirement) {
+    public static MemberFullDto from(Member member) {
+        return new MemberFullDto(
+                member.getId(), member.getRole(), MemberBasicInfoDto.from(member), member.getAssociateRequirement());
+    }
+
+    record MemberBasicInfoDto(
+            String name,
+            String studentId,
+            String email,
+            String department,
+            String phone,
+            String discordUsername,
+            String nickname) {
+        public static MemberBasicInfoDto from(Member member) {
+            return new MemberBasicInfoDto(
+                    member.getName(),
+                    member.getStudentId(),
+                    member.getEmail(),
+                    member.getDepartment().getDepartmentName(),
+                    member.getPhone(),
+                    member.getDiscordUsername(),
+                    member.getNickname());
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberDashboardResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberDashboardResponse.java
@@ -1,0 +1,19 @@
+package com.gdschongik.gdsc.domain.member.dto.response;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.dto.MemberFullDto;
+import com.gdschongik.gdsc.domain.membership.domain.Membership;
+import com.gdschongik.gdsc.domain.membership.dto.MembershipFullDto;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.dto.RecruitmentFullDto;
+
+public record MemberDashboardResponse(
+        MemberFullDto member, RecruitmentFullDto currentRecruitment, MembershipFullDto currentMembership) {
+    public static MemberDashboardResponse from(
+            Member member, Recruitment currentRecruitment, Membership currentMembership) {
+        return new MemberDashboardResponse(
+                MemberFullDto.from(member),
+                RecruitmentFullDto.from(currentRecruitment),
+                MembershipFullDto.from(currentMembership));
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberDashboardResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberDashboardResponse.java
@@ -6,14 +6,15 @@ import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.membership.dto.MembershipFullDto;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.dto.RecruitmentFullDto;
+import jakarta.annotation.Nullable;
 
 public record MemberDashboardResponse(
-        MemberFullDto member, RecruitmentFullDto currentRecruitment, MembershipFullDto currentMembership) {
+        MemberFullDto member, RecruitmentFullDto currentRecruitment, @Nullable MembershipFullDto currentMembership) {
     public static MemberDashboardResponse from(
             Member member, Recruitment currentRecruitment, Membership currentMembership) {
         return new MemberDashboardResponse(
                 MemberFullDto.from(member),
                 RecruitmentFullDto.from(currentRecruitment),
-                MembershipFullDto.from(currentMembership));
+                currentMembership == null ? null : MembershipFullDto.from(currentMembership));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberInfoResponse.java
@@ -3,6 +3,7 @@ package com.gdschongik.gdsc.domain.member.dto.response;
 import com.gdschongik.gdsc.domain.common.model.RequirementStatus;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.global.util.formatter.PhoneFormatter;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MemberInfoResponse(
@@ -26,11 +27,7 @@ public record MemberInfoResponse(
                 member.getId(),
                 member.getStudentId(),
                 member.getName(),
-                String.format(
-                        "%s-%s-%s",
-                        member.getPhone().substring(0, 3),
-                        member.getPhone().substring(3, 7),
-                        member.getPhone().substring(7)),
+                PhoneFormatter.format(member.getPhone()),
                 member.getDepartment().getDepartmentName(),
                 member.getEmail(),
                 member.getDiscordUsername(),

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -52,4 +52,10 @@ public class MembershipService {
                     throw new CustomException(MEMBERSHIP_ALREADY_APPLIED);
                 });
     }
+
+    public Membership findMyMembership(Member member, Recruitment recruitment) {
+        return membershipRepository
+                .findByMemberAndRecruitment(member, recruitment)
+                .orElseThrow(() -> new CustomException(MEMBERSHIP_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -10,6 +10,7 @@ import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,9 +54,7 @@ public class MembershipService {
                 });
     }
 
-    public Membership findMyMembership(Member member, Recruitment recruitment) {
-        return membershipRepository
-                .findByMemberAndRecruitment(member, recruitment)
-                .orElseThrow(() -> new CustomException(MEMBERSHIP_NOT_FOUND));
+    public Optional<Membership> findMyMembership(Member member, Recruitment recruitment) {
+        return membershipRepository.findByMemberAndRecruitment(member, recruitment);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipRepository.java
@@ -3,6 +3,7 @@ package com.gdschongik.gdsc.domain.membership.dao;
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,6 @@ public interface MembershipRepository extends JpaRepository<Membership, Long> {
 
     Optional<Membership> findByMemberAndAcademicYearAndSemesterType(
             Member member, Integer academicYear, SemesterType semesterType);
+
+    Optional<Membership> findByMemberAndRecruitment(Member member, Recruitment recruitment);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/dto/MembershipFullDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/dto/MembershipFullDto.java
@@ -1,0 +1,15 @@
+package com.gdschongik.gdsc.domain.membership.dto;
+
+import com.gdschongik.gdsc.domain.membership.domain.Membership;
+import com.gdschongik.gdsc.domain.membership.domain.RegularRequirement;
+
+public record MembershipFullDto(
+        Long membershipId, Long memberId, Long recruitmentId, RegularRequirement regularRequirement) {
+    public static MembershipFullDto from(Membership membership) {
+        return new MembershipFullDto(
+                membership.getId(),
+                membership.getMember().getId(),
+                membership.getRecruitment().getId(),
+                membership.getRegularRequirement());
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/OnboardingRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/OnboardingRecruitmentService.java
@@ -16,7 +16,7 @@ public class OnboardingRecruitmentService {
     // TODO: 모집기간과 별도로 표시기간 사용하여 필터링하도록 변경
     public Recruitment findCurrentRecruitment() {
         return recruitmentRepository.findAll().stream()
-                .filter(Recruitment::isOpen)
+                .filter(Recruitment::isOpen) // isOpen -> isDisplayable
                 .findFirst()
                 .orElseThrow();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/OnboardingRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/OnboardingRecruitmentService.java
@@ -1,0 +1,23 @@
+package com.gdschongik.gdsc.domain.recruitment.application;
+
+import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OnboardingRecruitmentService {
+
+    private final RecruitmentRepository recruitmentRepository;
+
+    // TODO: 모집기간과 별도로 표시기간 사용하여 필터링하도록 변경
+    public Recruitment findCurrentRecruitment() {
+        return recruitmentRepository.findAll().stream()
+                .filter(Recruitment::isOpen)
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/RecruitmentFullDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/RecruitmentFullDto.java
@@ -1,0 +1,19 @@
+package com.gdschongik.gdsc.domain.recruitment.dto;
+
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import java.math.BigDecimal;
+
+public record RecruitmentFullDto(
+        Long recruitmentId, String name, Period period, BigDecimal fee, RoundType roundType, String roundTypeValue) {
+    public static RecruitmentFullDto from(Recruitment recruitment) {
+        return new RecruitmentFullDto(
+                recruitment.getId(),
+                recruitment.getName(),
+                recruitment.getPeriod(),
+                recruitment.getFee().getAmount(),
+                recruitment.getRoundType(),
+                recruitment.getRoundType().getValue());
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -70,7 +70,6 @@ public enum ErrorCode {
     MEMBERSHIP_NOT_APPLICABLE(HttpStatus.CONFLICT, "멤버십 가입을 신청할 수 없는 회원입니다."),
     MEMBERSHIP_ALREADY_APPLIED(HttpStatus.CONFLICT, "이미 이번 학기에 멤버십 가입을 신청한 회원입니다."),
     MEMBERSHIP_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 이번 학기에 정회원 승급을 완료한 회원입니다."),
-    MEMBERSHIP_NOT_FOUND(HttpStatus.NOT_FOUND, "멤버십이 존재하지 않습니다."),
 
     // Recruitment
     DATE_PRECEDENCE_INVALID(HttpStatus.BAD_REQUEST, "종료일이 시작일과 같거나 앞설 수 없습니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -70,6 +70,7 @@ public enum ErrorCode {
     MEMBERSHIP_NOT_APPLICABLE(HttpStatus.CONFLICT, "멤버십 가입을 신청할 수 없는 회원입니다."),
     MEMBERSHIP_ALREADY_APPLIED(HttpStatus.CONFLICT, "이미 이번 학기에 멤버십 가입을 신청한 회원입니다."),
     MEMBERSHIP_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 이번 학기에 정회원 승급을 완료한 회원입니다."),
+    MEMBERSHIP_NOT_FOUND(HttpStatus.NOT_FOUND, "멤버십이 존재하지 않습니다."),
 
     // Recruitment
     DATE_PRECEDENCE_INVALID(HttpStatus.BAD_REQUEST, "종료일이 시작일과 같거나 앞설 수 없습니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/util/formatter/PhoneFormatter.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/formatter/PhoneFormatter.java
@@ -1,0 +1,17 @@
+package com.gdschongik.gdsc.global.util.formatter;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PhoneFormatter {
+    public static String format(String phone) {
+        return new StringBuilder(12)
+                .append(phone, 0, 3)
+                .append('-')
+                .append(phone, 3, 7)
+                .append('-')
+                .append(phone, 7, 11)
+                .toString();
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
@@ -1,0 +1,62 @@
+package com.gdschongik.gdsc.domain.member.application;
+
+import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.domain.recruitment.application.OnboardingRecruitmentService;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.integration.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class OnboardingMemberServiceTest extends IntegrationTest {
+
+    @Autowired
+    private OnboardingMemberService onboardingMemberService;
+
+    @Nested
+    class 대시보드_조회할때 {
+
+        /**
+         * {@link Period#isOpen()}에서 LocalDateTime.now()를 사용하기 때문에 고정된 리쿠르팅을 반환하도록 설정
+         * @see OnboardingRecruitmentService#findCurrentRecruitment()
+         */
+        @BeforeEach
+        void setUp() {
+            Recruitment recruitment = createRecruitment();
+            when(onboardingRecruitmentService.findCurrentRecruitment()).thenReturn(recruitment);
+        }
+
+        @Test
+        void 정회원_미신청시_멤버십_응답은_null이다() {
+            // given
+            createMember();
+            logoutAndReloginAs(1L, MemberRole.ASSOCIATE);
+
+            // when
+            var memberDashboardResponse = onboardingMemberService.getDashboard();
+
+            // then
+            assertThat(memberDashboardResponse.currentMembership()).isNull();
+        }
+
+        @Test
+        void 기본정보_미작성시_멤버_기본정보는_모두_null이다() {
+            // given
+            memberRepository.save(Member.createGuestMember(OAUTH_ID));
+            logoutAndReloginAs(1L, MemberRole.ASSOCIATE);
+
+            // when
+            var memberDashboardResponse = onboardingMemberService.getDashboard();
+
+            // then - 전체 필드가 null인지 확인
+            assertThat(memberDashboardResponse.member().basicInfo()).hasAllNullFieldsOrProperties();
+        }
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.domain.member.dto.response.MemberDashboardResponse;
 import com.gdschongik.gdsc.domain.recruitment.application.OnboardingRecruitmentService;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
@@ -40,10 +41,10 @@ class OnboardingMemberServiceTest extends IntegrationTest {
             logoutAndReloginAs(1L, MemberRole.ASSOCIATE);
 
             // when
-            var memberDashboardResponse = onboardingMemberService.getDashboard();
+            MemberDashboardResponse response = onboardingMemberService.getDashboard();
 
             // then
-            assertThat(memberDashboardResponse.currentMembership()).isNull();
+            assertThat(response.currentMembership()).isNull();
         }
 
         @Test
@@ -53,10 +54,10 @@ class OnboardingMemberServiceTest extends IntegrationTest {
             logoutAndReloginAs(1L, MemberRole.ASSOCIATE);
 
             // when
-            var memberDashboardResponse = onboardingMemberService.getDashboard();
+            MemberDashboardResponse response = onboardingMemberService.getDashboard();
 
             // then - 전체 필드가 null인지 확인
-            assertThat(memberDashboardResponse.member().basicInfo()).hasAllNullFieldsOrProperties();
+            assertThat(response.member().basicInfo()).hasAllNullFieldsOrProperties();
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -1,15 +1,12 @@
 package com.gdschongik.gdsc.domain.membership.application;
 
 import static com.gdschongik.gdsc.domain.member.domain.MemberRole.*;
-import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.dao.MembershipRepository;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
-import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.integration.IntegrationTest;
@@ -24,15 +21,6 @@ public class MembershipServiceTest extends IntegrationTest {
 
     @Autowired
     private MembershipRepository membershipRepository;
-
-    @Autowired
-    private RecruitmentRepository recruitmentRepository;
-
-    private Recruitment createRecruitment() {
-        Recruitment recruitment = Recruitment.createRecruitment(
-                RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
-        return recruitmentRepository.save(recruitment);
-    }
 
     private Membership createMembership(Member member, Recruitment recruitment) {
         Membership membership = Membership.createMembership(member, recruitment);

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/RecruitmentConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/RecruitmentConstant.java
@@ -10,6 +10,7 @@ public class RecruitmentConstant {
     // 1차 모집 상수
     public static final String RECRUITMENT_NAME = "2024학년도 1학기 1차 모집";
     public static final LocalDateTime START_DATE = LocalDateTime.of(2024, 3, 2, 0, 0);
+    public static final LocalDateTime BETWEEN_START_AND_END_DATE = LocalDateTime.of(2024, 3, 3, 0, 0);
     public static final LocalDateTime WRONG_END_DATE = LocalDateTime.of(2024, 3, 2, 0, 0);
     public static final LocalDateTime END_DATE = LocalDateTime.of(2024, 3, 5, 0, 0);
     public static final Integer ACADEMIC_YEAR = 2024;

--- a/src/test/java/com/gdschongik/gdsc/integration/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/integration/IntegrationTest.java
@@ -2,10 +2,13 @@ package com.gdschongik.gdsc.integration;
 
 import static com.gdschongik.gdsc.domain.member.domain.Department.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.global.security.PrincipalDetails;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +27,9 @@ public abstract class IntegrationTest {
 
     @Autowired
     protected MemberRepository memberRepository;
+
+    @Autowired
+    protected RecruitmentRepository recruitmentRepository;
 
     @BeforeEach
     void setUp() {
@@ -47,5 +53,11 @@ public abstract class IntegrationTest {
         member.verifyBevy();
 
         return memberRepository.save(member);
+    }
+
+    protected Recruitment createRecruitment() {
+        Recruitment recruitment = Recruitment.createRecruitment(
+                NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
+        return recruitmentRepository.save(recruitment);
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/integration/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/integration/IntegrationTest.java
@@ -7,12 +7,14 @@ import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.domain.recruitment.application.OnboardingRecruitmentService;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.global.security.PrincipalDetails;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -30,6 +32,9 @@ public abstract class IntegrationTest {
 
     @Autowired
     protected RecruitmentRepository recruitmentRepository;
+
+    @MockBean
+    protected OnboardingRecruitmentService onboardingRecruitmentService;
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #362

## 📌 작업 내용 및 특이사항
### DTO 컨벤션 추가
- 여러 DTO를 aggregate 하는 응답의 경우 각 엔티티에 대응되는 DTO를 조합하여 만듭니다.
- 이때 모든 필드가 대응되는 DTO의 경우 `XXXFullDto` 로, 일부 필드만 대응되는 DTO의 경우 `XXXSimpleDto` 로 네이밍합니다.
- `SimpleDto`의 경우 리스트 반환 시 원본 엔티티의 필드가 너무 많은 경우에만 사용하며, 그 외에는 사용하지 않습니다.

### 현재 열려있는 리쿠르팅 조회
- 추후 displayPeriod 등으로 리팩토링할 것으로 고려하여 현재는 `isOpen`으로 판단하게 했습니다.
- `isDisplayable` 생기면 간단하게 변경해주시면 됩니다.

### `Optional`
- 정회원 신청을 하지 않은 유저인 경우, 현재 열려있는 리쿠르팅에 대하여 멤버십이 존재하지 않을 수 있습니다.
- 이를 위해 `OnboardingMembershipService#findMyMembership`이 Optional로 리턴하도록 했습니다.
- 그리고 DTO 변환 시 null 이면 해당 DTO 필드도 null이 되도록 만들었습니다.
- 학과명 반환 시 NPE 방지 위해 Optional로 싸놨습니다.

### 테스트 변경사항
- 통합 테스트에 리쿠르팅 템플릿 만드는 메서드 추가했습니다.
- `isOpen`의 경우 `LocalDateTime.now()` 사용하는데 생성되는 템플릿은 과거 시점이므로 조회되지 않습니다. 이를 해결하기 위해 서비스를 모킹하여 `findCurrentRecruitment` 가 항상 템플릿 리쿠르팅을 반환하도록 만들었습니다.
- `@MockBean`의 경우 자식 테스트에 두면 해당 테스트 실행 시 컨텍스트를 재구성하므로, `IntegrationTest` 에 위치시켰습니다. 추후 다른 로직에서 이 서비스를 사용할 경우 동일하게 모킹하여 사용해야 합니다.
- 그 외 내용은 테스트 참고 바랍니다.


## 📝 참고사항
-

## 📚 기타
-
