### PR TITLE
rename: `VERIFIED`를 `SATISFIED`로 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/common/model/RequirementStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/model/RequirementStatus.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum RequirementStatus {
     PENDING("PENDING"),
-    VERIFIED("VERIFIED");
+    SATISFIED("SATISFIED");
 
     private final String value;
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/CommonDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/CommonDiscordService.java
@@ -29,9 +29,9 @@ public class CommonDiscordService {
 
     @Transactional
     public void batchDiscordId(RequirementStatus discordStatus) {
-        List<Member> discordVerifiedMembers = memberRepository.findAllByDiscordStatus(discordStatus);
+        List<Member> discordSatisfiedMembers = memberRepository.findAllByDiscordStatus(discordStatus);
 
-        discordVerifiedMembers.forEach(member -> {
+        discordSatisfiedMembers.forEach(member -> {
             String discordUsername = member.getDiscordUsername();
             String discordId = discordUtil.getMemberIdByUsername(discordUsername);
             member.updateDiscordId(discordId);

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/DiscordIdBatchCommandHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/DiscordIdBatchCommandHandler.java
@@ -22,7 +22,7 @@ public class DiscordIdBatchCommandHandler implements DiscordEventHandler {
 
         String discordUsername = event.getUser().getName();
         commonDiscordService.checkPermissionForCommand(discordUsername);
-        commonDiscordService.batchDiscordId(VERIFIED);
+        commonDiscordService.batchDiscordId(SATISFIED);
 
         event.getHook()
                 .sendMessage(REPLY_MESSAGE_BATCH_DISCORD_ID)

--- a/src/main/java/com/gdschongik/gdsc/domain/email/application/UnivEmailVerificationLinkSendService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/email/application/UnivEmailVerificationLinkSendService.java
@@ -45,7 +45,7 @@ public class UnivEmailVerificationLinkSendService {
 
     public void send(String univEmail) {
         hongikUnivEmailValidator.validate(univEmail);
-        validateUnivEmailNotVerified(univEmail);
+        validateUnivEmailNotSatisfied(univEmail);
 
         String verificationToken = generateVerificationToken(univEmail);
         String verificationLink = verificationLinkUtil.createLink(verificationToken);
@@ -53,10 +53,10 @@ public class UnivEmailVerificationLinkSendService {
         mailSender.send(univEmail, VERIFICATION_EMAIL_SUBJECT, mailContent);
     }
 
-    private void validateUnivEmailNotVerified(String univEmail) {
+    private void validateUnivEmailNotSatisfied(String univEmail) {
         Optional<Member> member = memberRepository.findByUnivEmail(univEmail);
         if (member.isPresent()) {
-            throw new CustomException(ErrorCode.UNIV_EMAIL_ALREADY_VERIFIED);
+            throw new CustomException(ErrorCode.UNIV_EMAIL_ALREADY_SATISFIED);
         }
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/AssociateRequirement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/AssociateRequirement.java
@@ -56,62 +56,62 @@ public class AssociateRequirement {
     // 상태 변경 로직
 
     public void verifyUniv() {
-        this.univStatus = VERIFIED;
+        this.univStatus = SATISFIED;
     }
 
     public void verifyDiscord() {
-        this.discordStatus = VERIFIED;
+        this.discordStatus = SATISFIED;
     }
 
     public void verifyBevy() {
-        this.bevyStatus = VERIFIED;
+        this.bevyStatus = SATISFIED;
     }
 
     public void verifyInfo() {
-        this.infoStatus = VERIFIED;
+        this.infoStatus = SATISFIED;
     }
 
     // 데이터 전달 로직
 
-    private boolean isUnivVerified() {
-        return this.univStatus == VERIFIED;
+    private boolean isUnivSatisfied() {
+        return this.univStatus == SATISFIED;
     }
 
-    private boolean isDiscordVerified() {
-        return this.discordStatus == VERIFIED;
+    private boolean isDiscordSatisfied() {
+        return this.discordStatus == SATISFIED;
     }
 
-    private boolean isBevyVerified() {
-        return this.bevyStatus == VERIFIED;
+    private boolean isBevySatisfied() {
+        return this.bevyStatus == SATISFIED;
     }
 
-    private boolean isInfoVerified() {
-        return this.infoStatus == VERIFIED;
+    private boolean isInfoSatisfied() {
+        return this.infoStatus == SATISFIED;
     }
 
     // 검증 로직
 
-    public void validateAllVerified() {
-        if (!isUnivVerified()) {
-            throw new CustomException(UNIV_NOT_VERIFIED);
+    public void validateAllSatisfied() {
+        if (!isUnivSatisfied()) {
+            throw new CustomException(UNIV_NOT_SATISFIED);
         }
 
-        if (!isDiscordVerified()) {
-            throw new CustomException(DISCORD_NOT_VERIFIED);
+        if (!isDiscordSatisfied()) {
+            throw new CustomException(DISCORD_NOT_SATISFIED);
         }
 
-        if (!isBevyVerified()) {
-            throw new CustomException(BEVY_NOT_VERIFIED);
+        if (!isBevySatisfied()) {
+            throw new CustomException(BEVY_NOT_SATISFIED);
         }
 
-        if (!isInfoVerified()) {
-            throw new CustomException(BASIC_INFO_NOT_VERIFIED);
+        if (!isInfoSatisfied()) {
+            throw new CustomException(BASIC_INFO_NOT_SATISFIED);
         }
     }
 
     public void checkVerifiableUniv() {
-        if (isUnivVerified()) {
-            throw new CustomException(EMAIL_ALREADY_VERIFIED);
+        if (isUnivSatisfied()) {
+            throw new CustomException(EMAIL_ALREADY_SATISFIED);
         }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -127,7 +127,7 @@ public class Member extends BaseTimeEntity {
             throw new CustomException(MEMBER_ALREADY_ASSOCIATE);
         }
 
-        associateRequirement.validateAllVerified();
+        associateRequirement.validateAllSatisfied();
     }
 
     /**

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -56,7 +56,7 @@ public class MembershipService {
                 .findByMemberAndAcademicYearAndSemesterType(currentMember, academicYear, semesterType)
                 .ifPresent(membership -> {
                     if (membership.isRegularRequirementAllSatisfied()) {
-                        throw new CustomException(MEMBERSHIP_ALREADY_VERIFIED);
+                        throw new CustomException(MEMBERSHIP_ALREADY_SATISFIED);
                     }
                     throw new CustomException(MEMBERSHIP_ALREADY_APPLIED);
                 });

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
@@ -64,7 +64,7 @@ public class Membership extends BaseSemesterEntity {
         return Membership.builder()
                 .member(member)
                 .recruitment(recruitment)
-                .regularRequirement(RegularRequirement.createUnverifiedRequirement())
+                .regularRequirement(RegularRequirement.createUnsatisfiedRequirement())
                 .academicYear(recruitment.getAcademicYear())
                 .semesterType(recruitment.getSemesterType())
                 .build();
@@ -83,7 +83,7 @@ public class Membership extends BaseSemesterEntity {
 
     public void validateRegularRequirement() {
         if (isRegularRequirementAllSatisfied()) {
-            throw new CustomException(MEMBERSHIP_ALREADY_VERIFIED);
+            throw new CustomException(MEMBERSHIP_ALREADY_SATISFIED);
         }
     }
 
@@ -92,8 +92,8 @@ public class Membership extends BaseSemesterEntity {
     public void verifyPaymentStatus() {
         validateRegularRequirement();
 
-        this.regularRequirement.updatePaymentStatus(VERIFIED);
-        regularRequirement.validateAllVerified();
+        this.regularRequirement.updatePaymentStatus(SATISFIED);
+        regularRequirement.validateAllSatisfied();
 
         registerEvent(new MemberRegularEvent(member.getId(), member.getDiscordUsername()));
     }
@@ -101,6 +101,6 @@ public class Membership extends BaseSemesterEntity {
     // 데이터 전달 로직
 
     public boolean isRegularRequirementAllSatisfied() {
-        return this.regularRequirement.isAllVerified();
+        return this.regularRequirement.isAllSatisfied();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/RegularRequirement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/RegularRequirement.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.membership.domain;
 
-import static com.gdschongik.gdsc.global.exception.ErrorCode.PAYMENT_NOT_VERIFIED;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.PAYMENT_NOT_SATISFIED;
 
 import com.gdschongik.gdsc.domain.common.model.RequirementStatus;
 import com.gdschongik.gdsc.global.exception.CustomException;
@@ -27,7 +27,7 @@ public class RegularRequirement {
         this.paymentStatus = paymentStatus;
     }
 
-    public static RegularRequirement createUnverifiedRequirement() {
+    public static RegularRequirement createUnsatisfiedRequirement() {
         return RegularRequirement.builder()
                 .paymentStatus(RequirementStatus.PENDING)
                 .build();
@@ -37,20 +37,20 @@ public class RegularRequirement {
         this.paymentStatus = paymentStatus;
     }
 
-    public boolean isPaymentVerified() {
-        return this.paymentStatus == RequirementStatus.VERIFIED;
+    public boolean isPaymentSatisfied() {
+        return this.paymentStatus == RequirementStatus.SATISFIED;
     }
 
     /**
      * 정회원 승급 조건은 추가될 가능성이 존재
      */
-    public boolean isAllVerified() {
-        return isPaymentVerified();
+    public boolean isAllSatisfied() {
+        return isPaymentSatisfied();
     }
 
-    public void validateAllVerified() {
-        if (!isPaymentVerified()) {
-            throw new CustomException(PAYMENT_NOT_VERIFIED);
+    public void validateAllSatisfied() {
+        if (!isPaymentSatisfied()) {
+            throw new CustomException(PAYMENT_NOT_SATISFIED);
         }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -41,14 +41,14 @@ public enum ErrorCode {
     MEMBER_NOT_ASSOCIATE(HttpStatus.CONFLICT, "준회원이 아닌 회원입니다."),
 
     // Requirement
-    UNIV_NOT_VERIFIED(HttpStatus.CONFLICT, "재학생 인증이 완료되지 않았습니다."),
-    DISCORD_NOT_VERIFIED(HttpStatus.CONFLICT, "디스코드 인증이 완료되지 않았습니다."),
-    BEVY_NOT_VERIFIED(HttpStatus.CONFLICT, "GDSC Bevy 가입이 완료되지 않았습니다."),
-    EMAIL_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 이메일 인증된 회원입니다."),
-    BASIC_INFO_NOT_VERIFIED(HttpStatus.CONFLICT, "기본 회원정보 작성이 완료되지 않았습니다."),
+    UNIV_NOT_SATISFIED(HttpStatus.CONFLICT, "재학생 인증이 완료되지 않았습니다."),
+    DISCORD_NOT_SATISFIED(HttpStatus.CONFLICT, "디스코드 인증이 완료되지 않았습니다."),
+    BEVY_NOT_SATISFIED(HttpStatus.CONFLICT, "GDSC Bevy 가입이 완료되지 않았습니다."),
+    EMAIL_ALREADY_SATISFIED(HttpStatus.CONFLICT, "이미 이메일 인증된 회원입니다."),
+    BASIC_INFO_NOT_SATISFIED(HttpStatus.CONFLICT, "기본 회원정보 작성이 완료되지 않았습니다."),
 
     // Univ Email Verification
-    UNIV_EMAIL_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 가입된 재학생 메일입니다."),
+    UNIV_EMAIL_ALREADY_SATISFIED(HttpStatus.CONFLICT, "이미 가입된 재학생 메일입니다."),
     UNIV_EMAIL_FORMAT_MISMATCH(HttpStatus.BAD_REQUEST, "형식에 맞지 않는 재학생 메일입니다."),
     UNIV_EMAIL_DOMAIN_MISMATCH(HttpStatus.BAD_REQUEST, "재학생 메일의 도메인이 맞지 않습니다."),
     MESSAGING_EXCEPTION(HttpStatus.BAD_REQUEST, "수신자 이메일이 올바르지 않습니다."),
@@ -67,10 +67,10 @@ public enum ErrorCode {
     DISCORD_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "디스코드 멤버를 찾을 수 없습니다."),
 
     // Membership
-    PAYMENT_NOT_VERIFIED(HttpStatus.CONFLICT, "회비 납부가 완료되지 않았습니다."),
+    PAYMENT_NOT_SATISFIED(HttpStatus.CONFLICT, "회비 납부가 완료되지 않았습니다."),
     MEMBERSHIP_NOT_APPLICABLE(HttpStatus.CONFLICT, "멤버십 가입을 신청할 수 없는 회원입니다."),
     MEMBERSHIP_ALREADY_APPLIED(HttpStatus.CONFLICT, "이미 이번 학기에 멤버십 가입을 신청한 회원입니다."),
-    MEMBERSHIP_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 이번 학기에 정회원 승급을 완료한 회원입니다."),
+    MEMBERSHIP_ALREADY_SATISFIED(HttpStatus.CONFLICT, "이미 이번 학기에 정회원 승급을 완료한 회원입니다."),
     MEMBERSHIP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 멤버십이 존재하지 않습니다."),
 
     // Recruitment

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -34,7 +34,6 @@ public enum ErrorCode {
     MEMBER_FORBIDDEN(HttpStatus.CONFLICT, "차단된 회원입니다."),
     MEMBER_ALREADY_ASSOCIATE(HttpStatus.CONFLICT, "이미 준회원 역할에 해당하는 회원입니다."),
     MEMBER_ALREADY_REGULAR(HttpStatus.CONFLICT, "이미 정회원 역할에 해당하는 회원입니다."),
-    MEMBER_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 인증된 상태입니다."),
     MEMBER_DISCORD_USERNAME_DUPLICATE(HttpStatus.CONFLICT, "이미 등록된 디스코드 유저네임입니다."),
     MEMBER_NICKNAME_DUPLICATE(HttpStatus.CONFLICT, "이미 사용중인 닉네임입니다."),
     MEMBER_NOT_APPLIED(HttpStatus.CONFLICT, "가입신청서를 제출하지 않은 회원입니다."),

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -71,7 +71,7 @@ class MemberTest {
 
             // then
             AssociateRequirement requirement = member.getAssociateRequirement();
-            assertThat(requirement.getInfoStatus()).isEqualTo(VERIFIED);
+            assertThat(requirement.getInfoStatus()).isEqualTo(SATISFIED);
         }
 
         @Test
@@ -84,7 +84,7 @@ class MemberTest {
 
             // then
             AssociateRequirement requirement = member.getAssociateRequirement();
-            assertThat(requirement.getUnivStatus()).isEqualTo(VERIFIED);
+            assertThat(requirement.getUnivStatus()).isEqualTo(SATISFIED);
         }
 
         @Test
@@ -97,7 +97,7 @@ class MemberTest {
 
             // then
             AssociateRequirement requirement = member.getAssociateRequirement();
-            assertThat(requirement.getDiscordStatus()).isEqualTo(VERIFIED);
+            assertThat(requirement.getDiscordStatus()).isEqualTo(SATISFIED);
         }
 
         @Test
@@ -110,7 +110,7 @@ class MemberTest {
 
             // then
             AssociateRequirement requirement = member.getAssociateRequirement();
-            assertThat(requirement.getBevyStatus()).isEqualTo(VERIFIED);
+            assertThat(requirement.getBevyStatus()).isEqualTo(SATISFIED);
         }
     }
 
@@ -129,7 +129,7 @@ class MemberTest {
             // when & then
             assertThatThrownBy(member::advanceToAssociate)
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(BASIC_INFO_NOT_VERIFIED.getMessage());
+                    .hasMessage(BASIC_INFO_NOT_SATISFIED.getMessage());
         }
 
         @Test
@@ -144,7 +144,7 @@ class MemberTest {
             // when & then
             assertThatThrownBy(member::advanceToAssociate)
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(DISCORD_NOT_VERIFIED.getMessage());
+                    .hasMessage(DISCORD_NOT_SATISFIED.getMessage());
         }
 
         @Test
@@ -159,7 +159,7 @@ class MemberTest {
             // when & then
             assertThatThrownBy(member::advanceToAssociate)
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(BEVY_NOT_VERIFIED.getMessage());
+                    .hasMessage(BEVY_NOT_SATISFIED.getMessage());
         }
 
         @Test

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.membership.application;
 
-import static com.gdschongik.gdsc.domain.common.model.RequirementStatus.VERIFIED;
+import static com.gdschongik.gdsc.domain.common.model.RequirementStatus.SATISFIED;
 import static com.gdschongik.gdsc.domain.member.domain.MemberRole.ASSOCIATE;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
@@ -58,7 +58,7 @@ public class MembershipServiceTest extends IntegrationTest {
             // then
             assertThatThrownBy(() -> membershipService.submitMembership(recruitment.getId()))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(MEMBERSHIP_ALREADY_VERIFIED.getMessage());
+                    .hasMessage(MEMBERSHIP_ALREADY_SATISFIED.getMessage());
         }
 
         @Test
@@ -101,7 +101,7 @@ public class MembershipServiceTest extends IntegrationTest {
         // when & then
         assertThatThrownBy(() -> membershipService.verifyPaymentStatus(membership.getId()))
                 .isInstanceOf(CustomException.class)
-                .hasMessage(MEMBERSHIP_ALREADY_VERIFIED.getMessage());
+                .hasMessage(MEMBERSHIP_ALREADY_SATISFIED.getMessage());
     }
 
     @Nested
@@ -119,7 +119,7 @@ public class MembershipServiceTest extends IntegrationTest {
             membership = membershipRepository.findById(membership.getId()).get();
 
             // then
-            assertThat(membership.getRegularRequirement().getPaymentStatus()).isEqualTo(VERIFIED);
+            assertThat(membership.getRegularRequirement().getPaymentStatus()).isEqualTo(SATISFIED);
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #390

## 📌 작업 내용 및 특이사항
- verified를 satisfied로 rename 했습니다.
- 관련 메서드들의 이름도 모두 변경했습니다.

## 📝 참고사항
- ErrorCode 중, `MEMBER_ALREADY_VERIFIED`는 사용처가 없어서 수정대신 제거했습니다.

## 📚 기타
-
