### PR TITLE
refactor: 대기중인 회원 조회 API 제거

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
@@ -43,14 +43,6 @@ public class AdminMemberController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "대기중인 회원 목록 조회", description = "대기중인 회원 목록을 조회합니다.")
-    @GetMapping("/pending")
-    public ResponseEntity<Page<AdminMemberResponse>> getPendingMembers(
-            MemberQueryOption queryOption, Pageable pageable) {
-        Page<AdminMemberResponse> response = adminMemberService.findAllPendingMembers(queryOption, pageable);
-        return ResponseEntity.ok().body(response);
-    }
-
     @Operation(summary = "회원 정보 수정", description = "회원 정보를 수정합니다.")
     @PutMapping("/{memberId}")
     public ResponseEntity<Void> updateMember(

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -1,6 +1,5 @@
 package com.gdschongik.gdsc.domain.member.application;
 
-import static com.gdschongik.gdsc.domain.member.domain.MemberRole.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
@@ -62,11 +61,6 @@ public class AdminMemberService {
                 request.email(),
                 request.discordUsername(),
                 request.nickname());
-    }
-
-    public Page<AdminMemberResponse> findAllPendingMembers(MemberQueryOption queryOption, Pageable pageable) {
-        Page<Member> members = memberRepository.findAllByRole(queryOption, pageable, GUEST);
-        return members.map(AdminMemberResponse::from);
     }
 
     public byte[] createExcel() throws IOException {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -32,11 +32,6 @@ public class AdminMemberService {
     private final ExcelUtil excelUtil;
     private final AdminRecruitmentService adminRecruitmentService;
 
-    public Page<AdminMemberResponse> findAll(MemberQueryOption queryOption, Pageable pageable) {
-        Page<Member> members = memberRepository.findAllByRole(queryOption, pageable, null);
-        return members.map(AdminMemberResponse::from);
-    }
-
     public Page<AdminMemberResponse> findAllByRole(
             MemberQueryOption queryOption, Pageable pageable, MemberRole memberRole) {
         Page<Member> members = memberRepository.findAllByRole(queryOption, pageable, memberRole);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #410

## 📌 작업 내용 및 특이사항
- 대기중인 회원 조회 API와 관련 서비스 메서드를 제거했습니다.

## 📝 참고사항
- `AdminMemberService`에서 대기중인 회원 조회 API와는 무관하지만 사용하지 않는 `findAll` 메서드가 있어서 같이 제거했습니다.

## 📚 기타
-
