### PR TITLE
feat: 스터디 도메인 테이블 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/Difficulty.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/Difficulty.java
@@ -1,0 +1,14 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Difficulty {
+    HIGH("상"),
+    MEDIUM("중"),
+    LOW("하");
+
+    private final String value;
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
@@ -1,0 +1,52 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import com.gdschongik.gdsc.domain.common.model.BaseSemesterEntity;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Study extends BaseSemesterEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_id")
+    private Long id;
+
+    private String title;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member mentor;
+
+    @Embedded
+    private Period period;
+
+    // 총 주차수
+    private Long sessionCount;
+
+    // 스터디 상세 노션 링크(Text)
+    @Column(columnDefinition = "TEXT")
+    private String notionLink;
+
+    // 스터디 한줄 소개
+    private String introduction;
+
+    @Enumerated(EnumType.STRING)
+    private StudyType studyType;
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
@@ -24,7 +24,7 @@ public class StudyDetail extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "session_id")
+    @Column(name = "t ")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
@@ -24,7 +24,7 @@ public class StudyDetail extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "t ")
+    @Column(name = "study_detail_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
@@ -1,0 +1,45 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import com.gdschongik.gdsc.domain.common.model.BaseTimeEntity;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.domain.study.domain.vo.Assignment;
+import com.gdschongik.gdsc.domain.study.domain.vo.Session;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyDetail extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "session_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_id")
+    private Study study;
+
+    // 현 회차 값
+    private Long currentCount;
+
+    @Embedded
+    private Period period;
+
+    @Embedded
+    private Session session;
+
+    @Embedded
+    private Assignment assignment;
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
@@ -34,6 +34,8 @@ public class StudyDetail extends BaseTimeEntity {
     // 현 회차 값
     private Long currentCount;
 
+    private String attendanceNumber;
+
     @Embedded
     private Period period;
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -1,0 +1,34 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import com.gdschongik.gdsc.domain.common.model.BaseSemesterEntity;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyHistory extends BaseSemesterEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_history_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member mentor;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_id")
+    private Study study;
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyNotification.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyNotification.java
@@ -1,0 +1,34 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import com.gdschongik.gdsc.domain.common.model.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyNotification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_notification_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_id")
+    private Study study;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String link;
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyType.java
@@ -1,0 +1,14 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum StudyType {
+    ASSIGNMENT("과제"),
+    ONLINE("온라인"),
+    OFFLINE("오프라인");
+
+    private final String value;
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
@@ -1,0 +1,33 @@
+package com.gdschongik.gdsc.domain.study.domain.vo;
+
+import com.gdschongik.gdsc.domain.study.domain.Difficulty;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Assignment {
+
+    // 과제 마감 시각
+    private LocalDateTime assignmentDueAt;
+
+    private String assignmentTitle;
+
+    @Column(columnDefinition = "TEXT")
+    private String assignmentNotionLink;
+
+    // 과제 휴강 여부
+    private boolean isAssignmentCanceled;
+
+    @Enumerated(EnumType.STRING)
+    private Difficulty assignmentDifficulty;
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Session.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Session.java
@@ -1,0 +1,30 @@
+package com.gdschongik.gdsc.domain.study.domain.vo;
+
+import com.gdschongik.gdsc.domain.study.domain.Difficulty;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Session {
+
+    private LocalDateTime sessionStartAt;
+
+    private String sessionTitle;
+
+    private String sessionDescription;
+
+    @Enumerated(EnumType.STRING)
+    private Difficulty sessionDifficulty;
+
+    // 스터디 휴강 여부
+    private boolean isSessionCanceled;
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #409

## 📌 작업 내용 및 특이사항
- 스터디 테이블 (Study)
- 스터디 세션 테이블(커리큘럼 + 과제) (StudyDetail)
- 수강 히스토리 테이블 (StudyHistory)
- 스터디 공지사항 테이블 (StudyNotification)

이렇게 우선적으로 추가해두겠습니다.
추가 변경 및 추가사항 생기면 각 도메인 작업할때 추가해주세요!

StudyDetail은 Session, Assignmen 두개의 Vo와 공통데이터로 나눴습니다.

## 📝 참고사항
-

## 📚 기타
-
