### PR TITLE
refactor: 디스코드 유저네임 활용 로직을 id 활용으로 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/DelegateMemberDiscordEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/DelegateMemberDiscordEventHandler.java
@@ -20,8 +20,7 @@ public class DelegateMemberDiscordEventHandler implements SpringEventHandler {
     public void delegate(Object context) {
         MemberRegularEvent event = (MemberRegularEvent) context;
         Guild guild = discordUtil.getCurrentGuild();
-        // TODO: 이름이 아닌 ID로 찾기 위해 전체 멤버의 디스코드 사용자 ID를 저장해야 함
-        Member member = discordUtil.getMemberByUsername(event.discordUsername());
+        Member member = discordUtil.getMemberById(event.discordId());
         Role role = discordUtil.findRoleByName(MEMBER_ROLE_NAME);
 
         guild.addRoleToMember(member, role).queue();

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberRegularEvent.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberRegularEvent.java
@@ -1,3 +1,3 @@
 package com.gdschongik.gdsc.domain.member.domain;
 
-public record MemberRegularEvent(Long memberId, String discordUsername) {}
+public record MemberRegularEvent(Long memberId, String discordId) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
@@ -95,7 +95,7 @@ public class Membership extends BaseSemesterEntity {
         regularRequirement.updatePaymentStatus(SATISFIED);
         regularRequirement.validateAllSatisfied();
 
-        registerEvent(new MemberRegularEvent(member.getId(), member.getDiscordUsername()));
+        registerEvent(new MemberRegularEvent(member.getId(), member.getDiscordId()));
     }
 
     // 데이터 전달 로직

--- a/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
@@ -1,7 +1,8 @@
 package com.gdschongik.gdsc.global.util;
 
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
 import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.global.property.DiscordProperty;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,7 @@ public class DiscordUtil {
     public Role findRoleByName(String roleName) {
         return jda.getRolesByName(roleName, true).stream()
                 .findFirst()
-                .orElseThrow(() -> new CustomException(ErrorCode.DISCORD_ROLE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(DISCORD_ROLE_NOT_FOUND));
     }
 
     public Guild getCurrentGuild() {
@@ -35,14 +36,14 @@ public class DiscordUtil {
         return getCurrentGuild().getMembersByName(username, true).stream().findFirst();
     }
 
-    public Member getMemberByUsername(String username) {
-        return getOptionalMemberByUsername(username)
-                .orElseThrow(() -> new CustomException(ErrorCode.DISCORD_MEMBER_NOT_FOUND));
+    public Member getMemberById(String discordId) {
+        return Optional.ofNullable(getCurrentGuild().getMemberById(discordId))
+                .orElseThrow(() -> new CustomException(DISCORD_MEMBER_NOT_FOUND));
     }
 
     public String getMemberIdByUsername(String username) {
         return getOptionalMemberByUsername(username)
-                .orElseThrow(() -> new CustomException(ErrorCode.DISCORD_MEMBER_NOT_FOUND))
+                .orElseThrow(() -> new CustomException(DISCORD_MEMBER_NOT_FOUND))
                 .getId();
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #332

## 📌 작업 내용 및 특이사항
- 디스코드 유저네임을 사용하여 Member를 찾던 `DelegateMemberDiscordEventHandler`에서 디스코드 id를 사용하도록 수정했습니다.

## 📝 참고사항
-

## 📚 기타
-
