### PR TITLE
test: 테스트 템플릿 위치 변경

### DIFF
--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/application/CouponServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/application/CouponServiceTest.java
@@ -10,7 +10,7 @@ import com.gdschongik.gdsc.domain.coupon.dao.IssuedCouponRepository;
 import com.gdschongik.gdsc.domain.coupon.dto.request.CouponCreateRequest;
 import com.gdschongik.gdsc.domain.coupon.dto.request.CouponIssueRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.integration.IntegrationTest;
+import com.gdschongik.gdsc.helper.IntegrationTest;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
@@ -17,7 +17,7 @@ import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
-import com.gdschongik.gdsc.integration.IntegrationTest;
+import com.gdschongik.gdsc.helper.IntegrationTest;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/MemberIntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/MemberIntegrationTest.java
@@ -10,7 +10,7 @@ import com.gdschongik.gdsc.domain.member.application.handler.MemberAssociateEven
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberAssociateEvent;
-import com.gdschongik.gdsc.integration.IntegrationTest;
+import com.gdschongik.gdsc.helper.IntegrationTest;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
@@ -10,7 +10,7 @@ import com.gdschongik.gdsc.domain.member.dto.response.MemberDashboardResponse;
 import com.gdschongik.gdsc.domain.recruitment.application.OnboardingRecruitmentService;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
-import com.gdschongik.gdsc.integration.IntegrationTest;
+import com.gdschongik.gdsc.helper.IntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryOption;
-import com.gdschongik.gdsc.repository.RepositoryTest;
+import com.gdschongik.gdsc.helper.RepositoryTest;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -10,7 +10,7 @@ import com.gdschongik.gdsc.domain.membership.dao.MembershipRepository;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.integration.IntegrationTest;
+import com.gdschongik.gdsc.helper.IntegrationTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -11,7 +11,7 @@ import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateUpdateRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.integration.IntegrationTest;
+import com.gdschongik.gdsc.helper.IntegrationTest;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/gdschongik/gdsc/helper/DatabaseCleaner.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/DatabaseCleaner.java
@@ -1,4 +1,4 @@
-package com.gdschongik.gdsc.integration;
+package com.gdschongik.gdsc.helper;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -1,4 +1,4 @@
-package com.gdschongik.gdsc.integration;
+package com.gdschongik.gdsc.helper;
 
 import static com.gdschongik.gdsc.domain.member.domain.Department.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;

--- a/src/test/java/com/gdschongik/gdsc/helper/RepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/RepositoryTest.java
@@ -1,8 +1,7 @@
-package com.gdschongik.gdsc.repository;
+package com.gdschongik.gdsc.helper;
 
 import com.gdschongik.gdsc.config.TestQuerydslConfig;
 import com.gdschongik.gdsc.config.TestRedisConfig;
-import com.gdschongik.gdsc.integration.DatabaseCleaner;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #293

## 📌 작업 내용 및 특이사항
- `IntegrationTest`와 `RepositoryTest` 모두 `DatabaseCleaner`를 사용하지만, 
지금의 디렉토리 구조는 `DatabaseCleaner`를 `IntegrationTest`에서만 사용하던 때의 구조입니다.
현재는 `RepositoryTest`에서도 사용하므로 config, domain, global과 같은 위치에 helper 패키지를 만들고 위의 세 가지 파일을 모두 안으로 넣었습니다.

## 📝 참고사항
-

## 📚 기타
-
