### PR TITLE
refactor: 리쿠르팅 테이블 정규화

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
@@ -13,7 +13,7 @@ import com.gdschongik.gdsc.domain.member.dto.response.MemberUnivStatusResponse;
 import com.gdschongik.gdsc.domain.membership.application.MembershipService;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.recruitment.application.OnboardingRecruitmentService;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.util.Optional;
@@ -76,9 +76,9 @@ public class OnboardingMemberService {
 
     public MemberDashboardResponse getDashboard() {
         Member currentMember = memberUtil.getCurrentMember();
-        Recruitment currentRecruitment = onboardingRecruitmentService.findCurrentRecruitment();
-        Optional<Membership> myMembership = membershipService.findMyMembership(currentMember, currentRecruitment);
+        RecruitmentRound currentRecruitmentRound = onboardingRecruitmentService.findCurrentRecruitment();
+        Optional<Membership> myMembership = membershipService.findMyMembership(currentMember, currentRecruitmentRound);
 
-        return MemberDashboardResponse.from(currentMember, currentRecruitment, myMembership.orElse(null));
+        return MemberDashboardResponse.from(currentMember, currentRecruitmentRound, myMembership.orElse(null));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberDashboardResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberDashboardResponse.java
@@ -5,16 +5,18 @@ import com.gdschongik.gdsc.domain.member.dto.MemberFullDto;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.membership.dto.MembershipFullDto;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
-import com.gdschongik.gdsc.domain.recruitment.dto.RecruitmentFullDto;
+import com.gdschongik.gdsc.domain.recruitment.dto.RecruitmentRoundFullDto;
 import jakarta.annotation.Nullable;
 
 public record MemberDashboardResponse(
-        MemberFullDto member, RecruitmentFullDto currentRecruitment, @Nullable MembershipFullDto currentMembership) {
+        MemberFullDto member,
+        RecruitmentRoundFullDto currentRecruitment,
+        @Nullable MembershipFullDto currentMembership) {
     public static MemberDashboardResponse from(
             Member member, RecruitmentRound currentRecruitmentRound, Membership currentMembership) {
         return new MemberDashboardResponse(
                 MemberFullDto.from(member),
-                RecruitmentFullDto.from(currentRecruitmentRound),
+                RecruitmentRoundFullDto.from(currentRecruitmentRound),
                 currentMembership == null ? null : MembershipFullDto.from(currentMembership));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberDashboardResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberDashboardResponse.java
@@ -10,7 +10,7 @@ import jakarta.annotation.Nullable;
 
 public record MemberDashboardResponse(
         MemberFullDto member,
-        RecruitmentRoundFullDto currentRecruitment,
+        RecruitmentRoundFullDto currentRecruitmentRound,
         @Nullable MembershipFullDto currentMembership) {
     public static MemberDashboardResponse from(
             Member member, RecruitmentRound currentRecruitmentRound, Membership currentMembership) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberDashboardResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberDashboardResponse.java
@@ -4,17 +4,17 @@ import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.dto.MemberFullDto;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.membership.dto.MembershipFullDto;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.dto.RecruitmentFullDto;
 import jakarta.annotation.Nullable;
 
 public record MemberDashboardResponse(
         MemberFullDto member, RecruitmentFullDto currentRecruitment, @Nullable MembershipFullDto currentMembership) {
     public static MemberDashboardResponse from(
-            Member member, Recruitment currentRecruitment, Membership currentMembership) {
+            Member member, RecruitmentRound currentRecruitmentRound, Membership currentMembership) {
         return new MemberDashboardResponse(
                 MemberFullDto.from(member),
-                RecruitmentFullDto.from(currentRecruitment),
+                RecruitmentFullDto.from(currentRecruitmentRound),
                 currentMembership == null ? null : MembershipFullDto.from(currentMembership));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/api/MembershipController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/api/MembershipController.java
@@ -20,8 +20,8 @@ public class MembershipController {
 
     @Operation(summary = "멤버십 가입 신청 접수", description = "정회원 가입을 위해 멤버십 가입 신청을 접수합니다. 별도의 정회원 가입 조건을 만족해야 가입이 완료됩니다.")
     @PostMapping
-    public ResponseEntity<Void> submitMembership(@RequestParam(name = "recruitmentId") Long recruitmentId) {
-        membershipService.submitMembership(recruitmentId);
+    public ResponseEntity<Void> submitMembership(@RequestParam(name = "recruitmentRoundId") Long recruitmentRoundId) {
+        membershipService.submitMembership(recruitmentRoundId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -40,7 +40,7 @@ public class MembershipService {
 
         RecruitmentRound recruitmentRound = recruitmentRoundRepository
                 .findById(recruitmentRoundId)
-                .orElseThrow(() -> new CustomException(RECRUITMENT_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(RECRUITMENT_ROUND_NOT_FOUND));
 
         validateMembershipDuplicate(
                 currentMember, recruitmentRound.getAcademicYear(), recruitmentRound.getSemesterType());

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -44,15 +44,15 @@ public class MembershipService {
 
         validateMembershipDuplicate(
                 currentMember, recruitmentRound.getAcademicYear(), recruitmentRound.getSemesterType());
-        validateRecruitmentOpen(recruitmentRound);
+        validateRecruitmentRoundOpen(recruitmentRound);
 
         Membership membership = Membership.createMembership(currentMember, recruitmentRound);
         membershipRepository.save(membership);
     }
 
-    private void validateRecruitmentOpen(RecruitmentRound recruitmentRound) {
+    private void validateRecruitmentRoundOpen(RecruitmentRound recruitmentRound) {
         if (!recruitmentRound.isOpen()) {
-            throw new CustomException(RECRUITMENT_NOT_OPEN);
+            throw new CustomException(RECRUITMENT_ROUND_NOT_OPEN);
         }
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -5,7 +5,6 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.dao.MembershipRepository;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
-import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
@@ -21,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MembershipService {
     private final MembershipRepository membershipRepository;
-    private final RecruitmentRepository recruitmentRepository;
     private final RecruitmentRoundRepository recruitmentRoundRepository;
     private final MemberUtil memberUtil;
 

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -2,12 +2,12 @@ package com.gdschongik.gdsc.domain.membership.application;
 
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
-import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.dao.MembershipRepository;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
@@ -42,8 +42,7 @@ public class MembershipService {
                 .findById(recruitmentRoundId)
                 .orElseThrow(() -> new CustomException(RECRUITMENT_ROUND_NOT_FOUND));
 
-        validateMembershipDuplicate(
-                currentMember, recruitmentRound.getAcademicYear(), recruitmentRound.getSemesterType());
+        validateMembershipDuplicate(currentMember, recruitmentRound.getRecruitment());
         validateRecruitmentRoundOpen(recruitmentRound);
 
         Membership membership = Membership.createMembership(currentMember, recruitmentRound);
@@ -56,9 +55,11 @@ public class MembershipService {
         }
     }
 
-    private void validateMembershipDuplicate(Member currentMember, Integer academicYear, SemesterType semesterType) {
+    private void validateMembershipDuplicate(Member currentMember, Recruitment recruitment) {
         membershipRepository
-                .findByMemberAndAcademicYearAndSemesterType(currentMember, academicYear, semesterType)
+                .findByMember(currentMember)
+                .filter(membership ->
+                        membership.getRecruitmentRound().getRecruitment().equals(recruitment))
                 .ifPresent(membership -> {
                     if (membership.isRegularRequirementAllSatisfied()) {
                         throw new CustomException(MEMBERSHIP_ALREADY_SATISFIED);

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -42,9 +42,6 @@ public class MembershipService {
                 .findById(recruitmentRoundId)
                 .orElseThrow(() -> new CustomException(RECRUITMENT_NOT_FOUND));
 
-        // Recruitment recruitment = recruitmentRepository
-        //         .findById(recruitmentId)
-        //         .orElseThrow(() -> new CustomException(RECRUITMENT_NOT_FOUND));
         validateMembershipDuplicate(
                 currentMember, recruitmentRound.getAcademicYear(), recruitmentRound.getSemesterType());
         validateRecruitmentOpen(recruitmentRound);

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -7,7 +7,8 @@ import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.dao.MembershipRepository;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.util.Optional;
@@ -21,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MembershipService {
     private final MembershipRepository membershipRepository;
     private final RecruitmentRepository recruitmentRepository;
+    private final RecruitmentRoundRepository recruitmentRoundRepository;
     private final MemberUtil memberUtil;
 
     @Transactional
@@ -33,20 +35,26 @@ public class MembershipService {
     }
 
     @Transactional
-    public void submitMembership(Long recruitmentId) {
+    public void submitMembership(Long recruitmentRoundId) {
         Member currentMember = memberUtil.getCurrentMember();
-        Recruitment recruitment = recruitmentRepository
-                .findById(recruitmentId)
-                .orElseThrow(() -> new CustomException(RECRUITMENT_NOT_FOUND));
-        validateMembershipDuplicate(currentMember, recruitment.getAcademicYear(), recruitment.getSemesterType());
-        validateRecruitmentOpen(recruitment);
 
-        Membership membership = Membership.createMembership(currentMember, recruitment);
+        RecruitmentRound recruitmentRound = recruitmentRoundRepository
+                .findById(recruitmentRoundId)
+                .orElseThrow(() -> new CustomException(RECRUITMENT_NOT_FOUND));
+
+        // Recruitment recruitment = recruitmentRepository
+        //         .findById(recruitmentId)
+        //         .orElseThrow(() -> new CustomException(RECRUITMENT_NOT_FOUND));
+        validateMembershipDuplicate(
+                currentMember, recruitmentRound.getAcademicYear(), recruitmentRound.getSemesterType());
+        validateRecruitmentOpen(recruitmentRound);
+
+        Membership membership = Membership.createMembership(currentMember, recruitmentRound);
         membershipRepository.save(membership);
     }
 
-    private void validateRecruitmentOpen(Recruitment recruitment) {
-        if (!recruitment.isOpen()) {
+    private void validateRecruitmentOpen(RecruitmentRound recruitmentRound) {
+        if (!recruitmentRound.isOpen()) {
             throw new CustomException(RECRUITMENT_NOT_OPEN);
         }
     }
@@ -62,7 +70,7 @@ public class MembershipService {
                 });
     }
 
-    public Optional<Membership> findMyMembership(Member member, Recruitment recruitment) {
-        return membershipRepository.findByMemberAndRecruitment(member, recruitment);
+    public Optional<Membership> findMyMembership(Member member, RecruitmentRound recruitmentRound) {
+        return membershipRepository.findByMemberAndRecruitmentRound(member, recruitmentRound);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipRepository.java
@@ -1,6 +1,5 @@
 package com.gdschongik.gdsc.domain.membership.dao;
 
-import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
@@ -9,8 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MembershipRepository extends JpaRepository<Membership, Long> {
 
-    Optional<Membership> findByMemberAndAcademicYearAndSemesterType(
-            Member member, Integer academicYear, SemesterType semesterType);
+    Optional<Membership> findByMember(Member member);
 
     Optional<Membership> findByMemberAndRecruitmentRound(Member member, RecruitmentRound recruitmentRound);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipRepository.java
@@ -3,7 +3,7 @@ package com.gdschongik.gdsc.domain.membership.dao;
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,5 +12,5 @@ public interface MembershipRepository extends JpaRepository<Membership, Long> {
     Optional<Membership> findByMemberAndAcademicYearAndSemesterType(
             Member member, Integer academicYear, SemesterType semesterType);
 
-    Optional<Membership> findByMemberAndRecruitment(Member member, Recruitment recruitment);
+    Optional<Membership> findByMemberAndRecruitmentRound(Member member, RecruitmentRound recruitmentRound);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
@@ -3,8 +3,7 @@ package com.gdschongik.gdsc.domain.membership.domain;
 import static com.gdschongik.gdsc.domain.common.model.RequirementStatus.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
-import com.gdschongik.gdsc.domain.common.model.BaseSemesterEntity;
-import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRegularEvent;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
@@ -27,7 +26,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Membership extends BaseSemesterEntity {
+public class Membership extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -46,13 +45,7 @@ public class Membership extends BaseSemesterEntity {
     private RegularRequirement regularRequirement;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Membership(
-            Member member,
-            RecruitmentRound recruitmentRound,
-            RegularRequirement regularRequirement,
-            Integer academicYear,
-            SemesterType semesterType) {
-        super(academicYear, semesterType);
+    private Membership(Member member, RecruitmentRound recruitmentRound, RegularRequirement regularRequirement) {
         this.member = member;
         this.recruitmentRound = recruitmentRound;
         this.regularRequirement = regularRequirement;
@@ -65,8 +58,6 @@ public class Membership extends BaseSemesterEntity {
                 .member(member)
                 .recruitmentRound(recruitmentRound)
                 .regularRequirement(RegularRequirement.createUnsatisfiedRequirement())
-                .academicYear(recruitmentRound.getAcademicYear())
-                .semesterType(recruitmentRound.getSemesterType())
                 .build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
@@ -8,7 +8,7 @@ import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRegularEvent;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -39,8 +39,8 @@ public class Membership extends BaseSemesterEntity {
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "recruitment_id")
-    private Recruitment recruitment;
+    @JoinColumn(name = "recruitment_round_id")
+    private RecruitmentRound recruitmentRound;
 
     @Embedded
     private RegularRequirement regularRequirement;
@@ -48,25 +48,25 @@ public class Membership extends BaseSemesterEntity {
     @Builder(access = AccessLevel.PRIVATE)
     private Membership(
             Member member,
-            Recruitment recruitment,
+            RecruitmentRound recruitmentRound,
             RegularRequirement regularRequirement,
             Integer academicYear,
             SemesterType semesterType) {
         super(academicYear, semesterType);
         this.member = member;
-        this.recruitment = recruitment;
+        this.recruitmentRound = recruitmentRound;
         this.regularRequirement = regularRequirement;
     }
 
-    public static Membership createMembership(Member member, Recruitment recruitment) {
+    public static Membership createMembership(Member member, RecruitmentRound recruitmentRound) {
         validateMembershipApplicable(member);
 
         return Membership.builder()
                 .member(member)
-                .recruitment(recruitment)
+                .recruitmentRound(recruitmentRound)
                 .regularRequirement(RegularRequirement.createUnsatisfiedRequirement())
-                .academicYear(recruitment.getAcademicYear())
-                .semesterType(recruitment.getSemesterType())
+                .academicYear(recruitmentRound.getAcademicYear())
+                .semesterType(recruitmentRound.getSemesterType())
                 .build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/dto/MembershipFullDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/dto/MembershipFullDto.java
@@ -9,7 +9,7 @@ public record MembershipFullDto(
         return new MembershipFullDto(
                 membership.getId(),
                 membership.getMember().getId(),
-                membership.getRecruitment().getId(),
+                membership.getRecruitmentRound().getId(),
                 membership.getRegularRequirement());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.domain.recruitment.api;
 
 import com.gdschongik.gdsc.domain.recruitment.application.AdminRecruitmentService;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
+import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentRoundUpdateRequest;
 import com.gdschongik.gdsc.domain.recruitment.dto.response.AdminRecruitmentResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,7 +11,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -37,11 +40,11 @@ public class AdminRecruitmentController {
         return ResponseEntity.ok().body(response);
     }
 
-    // @Operation(summary = "리쿠르팅 수정", description = "기존 리쿠르팅(모집 기간)를 수정합니다.")
-    // @PutMapping("/{recruitmentRoundId}")
-    // public ResponseEntity<Void> updateRecruitment(
-    //         @PathVariable Long recruitmentRoundId, @Valid @RequestBody RecruitmentCreateUpdateRequest request) {
-    //     adminRecruitmentService.updateRecruitment(recruitmentRoundId, request);
-    //     return ResponseEntity.ok().build();
-    // }
+    @Operation(summary = "모집회차 수정", description = "기존 모집회차를 수정합니다.")
+    @PutMapping("rounds/{recruitmentRoundId}")
+    public ResponseEntity<Void> updateRecruitmentRound(
+            @PathVariable Long recruitmentRoundId, @Valid @RequestBody RecruitmentRoundUpdateRequest request) {
+        adminRecruitmentService.updateRecruitmentRound(recruitmentRoundId, request);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
@@ -40,10 +40,10 @@ public class AdminRecruitmentController {
     }
 
     @Operation(summary = "리쿠르팅 수정", description = "기존 리쿠르팅(모집 기간)를 수정합니다.")
-    @PutMapping("/{recruitmentId}")
+    @PutMapping("/{recruitmentRoundId}")
     public ResponseEntity<Void> updateRecruitment(
-            @PathVariable Long recruitmentId, @Valid @RequestBody RecruitmentCreateUpdateRequest request) {
-        adminRecruitmentService.updateRecruitment(recruitmentId, request);
+            @PathVariable Long recruitmentRoundId, @Valid @RequestBody RecruitmentCreateUpdateRequest request) {
+        adminRecruitmentService.updateRecruitment(recruitmentRoundId, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.recruitment.api;
 
 import com.gdschongik.gdsc.domain.recruitment.application.AdminRecruitmentService;
+import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateUpdateRequest;
 import com.gdschongik.gdsc.domain.recruitment.dto.response.AdminRecruitmentResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,7 +28,7 @@ public class AdminRecruitmentController {
 
     @Operation(summary = "리쿠르팅 생성", description = "새로운 리쿠르팅(모집 기간)를 생성합니다.")
     @PostMapping
-    public ResponseEntity<Void> createRecruitment(@Valid @RequestBody RecruitmentCreateUpdateRequest request) {
+    public ResponseEntity<Void> createRecruitment(@Valid @RequestBody RecruitmentCreateRequest request) {
         adminRecruitmentService.createRecruitment(request);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
@@ -2,7 +2,6 @@ package com.gdschongik.gdsc.domain.recruitment.api;
 
 import com.gdschongik.gdsc.domain.recruitment.application.AdminRecruitmentService;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
-import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateUpdateRequest;
 import com.gdschongik.gdsc.domain.recruitment.dto.response.AdminRecruitmentResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -11,9 +10,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,11 +37,11 @@ public class AdminRecruitmentController {
         return ResponseEntity.ok().body(response);
     }
 
-    @Operation(summary = "리쿠르팅 수정", description = "기존 리쿠르팅(모집 기간)를 수정합니다.")
-    @PutMapping("/{recruitmentRoundId}")
-    public ResponseEntity<Void> updateRecruitment(
-            @PathVariable Long recruitmentRoundId, @Valid @RequestBody RecruitmentCreateUpdateRequest request) {
-        adminRecruitmentService.updateRecruitment(recruitmentRoundId, request);
-        return ResponseEntity.ok().build();
-    }
+    // @Operation(summary = "리쿠르팅 수정", description = "기존 리쿠르팅(모집 기간)를 수정합니다.")
+    // @PutMapping("/{recruitmentRoundId}")
+    // public ResponseEntity<Void> updateRecruitment(
+    //         @PathVariable Long recruitmentRoundId, @Valid @RequestBody RecruitmentCreateUpdateRequest request) {
+    //     adminRecruitmentService.updateRecruitment(recruitmentRoundId, request);
+    //     return ResponseEntity.ok().build();
+    // }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
@@ -23,7 +23,7 @@ public class AdminRecruitmentController {
 
     private final AdminRecruitmentService adminRecruitmentService;
 
-    @Operation(summary = "리쿠르팅 생성", description = "새로운 리쿠르팅(모집 기간)를 생성합니다.")
+    @Operation(summary = "리쿠르팅 생성", description = "새로운 리쿠르팅을 생성합니다.")
     @PostMapping
     public ResponseEntity<Void> createRecruitment(@Valid @RequestBody RecruitmentCreateRequest request) {
         adminRecruitmentService.createRecruitment(request);

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -72,6 +72,8 @@ public class AdminRecruitmentService {
 
         recruitmentRound.updateRecruitmentRound(
                 request.name(), request.startDate(), request.endDate(), request.roundType());
+
+        log.info("[AdminRecruitmentService] 모집회차 수정: recruitmentRoundId={}", recruitmentRoundId);
     }
 
     private void validateRecruitmentOverlap(Integer academicYear, SemesterType semesterType) {

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -49,7 +49,7 @@ public class AdminRecruitmentService {
     }
 
     public List<AdminRecruitmentResponse> getAllRecruitments() {
-        List<RecruitmentRound> recruitments = recruitmentRoundRepository.findByOrderByPeriodStartDateDesc();
+        List<Recruitment> recruitments = recruitmentRepository.findByOrderBySemesterPeriodDesc();
         return recruitments.stream().map(AdminRecruitmentResponse::from).toList();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -13,6 +13,7 @@ import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
+import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentRoundUpdateRequest;
 import com.gdschongik.gdsc.domain.recruitment.dto.response.AdminRecruitmentResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import java.time.LocalDateTime;
@@ -53,38 +54,25 @@ public class AdminRecruitmentService {
         return recruitments.stream().map(AdminRecruitmentResponse::from).toList();
     }
 
-    // @Transactional
-    // public void updateRecruitment(Long recruitmentRoundId, RecruitmentCreateRequest request) {
-    //     RecruitmentRound recruitmentRound = recruitmentRoundRepository
-    //             .findById(recruitmentRoundId)
-    //             .orElseThrow(() -> new CustomException(RECRUITMENT_NOT_FOUND));
-    //
-    //     validatePeriodMatchesAcademicYear(request.periodStartDate(), request.periodEndDate(),
-    // request.academicYear());
-    //     validatePeriodMatchesSemesterType(request.periodStartDate(), request.periodEndDate(),
-    // request.semesterType());
-    //     validatePeriodWithinTwoWeeks(
-    //             request.periodStartDate(), request.periodEndDate(), request.academicYear(), request.semesterType());
-    //     validatePeriodOverlapExcludingCurrentRecruitment(
-    //             recruitmentRound.getAcademicYear(),
-    //             recruitmentRound.getSemesterType(),
-    //             request.periodStartDate(),
-    //             request.periodEndDate(),
-    //             recruitmentRound.getId());
-    //     validateRoundOverlapExcludingCurrentRecruitment(
-    //             request.academicYear(), request.semesterType(), request.roundType(), recruitmentRound.getId());
-    //
-    //     recruitmentRound.updateRecruitment(
-    //             request.name(),
-    //             request.periodStartDate(),
-    //             request.periodEndDate(),
-    //             request.academicYear(),
-    //             request.semesterType(),
-    //             request.roundType());
-    //
-    //     Recruitment recruitment = recruitmentRound.getRecruitment();
-    //     recruitment.updateFee(Money.from(request.fee()));
-    // }
+    @Transactional
+    public void updateRecruitmentRound(Long recruitmentRoundId, RecruitmentRoundUpdateRequest request) {
+        RecruitmentRound recruitmentRound = recruitmentRoundRepository
+                .findById(recruitmentRoundId)
+                .orElseThrow(() -> new CustomException(RECRUITMENT_ROUND_NOT_FOUND));
+
+        Integer academicYear = recruitmentRound.getRecruitment().getAcademicYear();
+        SemesterType semesterType = recruitmentRound.getRecruitment().getSemesterType();
+        validatePeriodMatchesAcademicYear(request.startDate(), request.endDate(), academicYear);
+        validatePeriodMatchesSemesterType(request.startDate(), request.endDate(), semesterType);
+        validatePeriodWithinTwoWeeks(request.startDate(), request.endDate(), academicYear, semesterType);
+        validatePeriodOverlapExcludingCurrentRecruitment(
+                academicYear, semesterType, request.startDate(), request.endDate(), recruitmentRound.getId());
+        validateRoundOverlapExcludingCurrentRecruitment(
+                academicYear, semesterType, request.roundType(), recruitmentRound.getId());
+
+        recruitmentRound.updateRecruitmentRound(
+                request.name(), request.startDate(), request.endDate(), request.roundType());
+    }
 
     private void validateRecruitmentOverlap(Integer academicYear, SemesterType semesterType) {
         if (recruitmentRepository.existsByAcademicYearAndSemesterType(academicYear, semesterType)) {

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -71,7 +71,7 @@ public class AdminRecruitmentService {
                 academicYear, semesterType, request.roundType(), recruitmentRound.getId());
 
         recruitmentRound.updateRecruitmentRound(
-                request.name(), request.startDate(), request.endDate(), request.roundType());
+                request.name(), Period.createPeriod(request.startDate(), request.endDate()), request.roundType());
 
         log.info("[AdminRecruitmentService] 모집회차 수정: recruitmentRoundId={}", recruitmentRoundId);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -166,7 +166,7 @@ public class AdminRecruitmentService {
         List<RecruitmentRound> recruitmentRounds =
                 recruitmentRoundRepository.findAllByAcademicYearAndSemesterType(academicYear, semesterType);
 
-        recruitmentRounds.forEach(recruitment -> recruitment.validatePeriodOverlap(startDate, endDate));
+        recruitmentRounds.forEach(recruitmentRound -> recruitmentRound.validatePeriodOverlap(startDate, endDate));
     }
 
     private void validateRoundOverlap(Integer academicYear, SemesterType semesterType, RoundType roundType) {

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -101,7 +101,7 @@ public class AdminRecruitmentService {
                 recruitmentRoundRepository.findAllByAcademicYearAndSemesterType(academicYear, semesterType);
 
         if (recruitmentRounds.isEmpty()) {
-            throw new CustomException(RECRUITMENT_NOT_FOUND);
+            throw new CustomException(RECRUITMENT_ROUND_NOT_FOUND);
         }
 
         recruitmentRounds.forEach(RecruitmentRound::validatePeriodNotStarted);

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/OnboardingRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/OnboardingRecruitmentService.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.recruitment.application;
 
-import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,12 +11,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class OnboardingRecruitmentService {
 
-    private final RecruitmentRepository recruitmentRepository;
+    private final RecruitmentRoundRepository recruitmentRoundRepository;
 
     // TODO: 모집기간과 별도로 표시기간 사용하여 필터링하도록 변경
-    public Recruitment findCurrentRecruitment() {
-        return recruitmentRepository.findAll().stream()
-                .filter(Recruitment::isOpen) // isOpen -> isDisplayable
+    public RecruitmentRound findCurrentRecruitment() {
+        return recruitmentRoundRepository.findAll().stream()
+                .filter(RecruitmentRound::isOpen) // isOpen -> isDisplayable
                 .findFirst()
                 .orElseThrow();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRepository.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.domain.recruitment.dao;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,6 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
     Optional<Recruitment> findByAcademicYearAndSemesterType(Integer academicYear, SemesterType semesterType);
 
     boolean existsByAcademicYearAndSemesterType(Integer academicYear, SemesterType semesterType);
+
+    List<Recruitment> findByOrderBySemesterPeriodDesc();
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRepository.java
@@ -3,12 +3,9 @@ package com.gdschongik.gdsc.domain.recruitment.dao;
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
-
-    Optional<Recruitment> findByAcademicYearAndSemesterType(Integer academicYear, SemesterType semesterType);
 
     boolean existsByAcademicYearAndSemesterType(Integer academicYear, SemesterType semesterType);
 

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRepository.java
@@ -2,16 +2,10 @@ package com.gdschongik.gdsc.domain.recruitment.dao;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
-import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
-import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
 
-    List<Recruitment> findAllByAcademicYearAndSemesterType(Integer academicYear, SemesterType semesterType);
-
-    List<Recruitment> findByOrderByPeriodStartDateDesc();
-
-    boolean existsByAcademicYearAndSemesterTypeAndRoundType(
-            Integer academicYear, SemesterType semesterType, RoundType roundType);
+    Optional<Recruitment> findByAcademicYearAndSemesterType(Integer academicYear, SemesterType semesterType);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
 
     Optional<Recruitment> findByAcademicYearAndSemesterType(Integer academicYear, SemesterType semesterType);
+
+    boolean existsByAcademicYearAndSemesterType(Integer academicYear, SemesterType semesterType);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRoundRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRoundRepository.java
@@ -12,6 +12,4 @@ public interface RecruitmentRoundRepository extends JpaRepository<RecruitmentRou
 
     boolean existsByAcademicYearAndSemesterTypeAndRoundType(
             Integer academicYear, SemesterType semesterType, RoundType roundType);
-
-    List<RecruitmentRound> findByOrderByPeriodStartDateDesc();
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRoundRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRoundRepository.java
@@ -1,0 +1,17 @@
+package com.gdschongik.gdsc.domain.recruitment.dao;
+
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
+import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecruitmentRoundRepository extends JpaRepository<RecruitmentRound, Long> {
+
+    List<RecruitmentRound> findAllByAcademicYearAndSemesterType(Integer academicYear, SemesterType semesterType);
+
+    boolean existsByAcademicYearAndSemesterTypeAndRoundType(
+            Integer academicYear, SemesterType semesterType, RoundType roundType);
+
+    List<RecruitmentRound> findByOrderByPeriodStartDateDesc();
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
@@ -27,7 +27,7 @@ public class Recruitment extends BaseSemesterEntity {
     private Period semesterPeriod;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Recruitment(Integer academicYear, SemesterType semesterType, Money fee, Period semesterPeriod) {
+    private Recruitment(Integer academicYear, SemesterType semesterType, Money fee, final Period semesterPeriod) {
         super(academicYear, semesterType);
         this.fee = fee;
         this.semesterPeriod = semesterPeriod;

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
@@ -3,6 +3,7 @@ package com.gdschongik.gdsc.domain.recruitment.domain;
 import com.gdschongik.gdsc.domain.common.model.BaseSemesterEntity;
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -22,17 +23,23 @@ public class Recruitment extends BaseSemesterEntity {
     @Embedded
     private Money fee;
 
+    @Embedded
+    private Period semesterPeriod;
+
     @Builder(access = AccessLevel.PRIVATE)
-    private Recruitment(Integer academicYear, SemesterType semesterType, Money fee) {
+    private Recruitment(Integer academicYear, SemesterType semesterType, Money fee, Period semesterPeriod) {
         super(academicYear, semesterType);
         this.fee = fee;
+        this.semesterPeriod = semesterPeriod;
     }
 
-    public static Recruitment createRecruitment(Integer academicYear, SemesterType semesterType, Money fee) {
+    public static Recruitment createRecruitment(
+            Integer academicYear, SemesterType semesterType, Money fee, Period semesterPeriod) {
         return Recruitment.builder()
                 .academicYear(academicYear)
                 .semesterType(semesterType)
                 .fee(fee)
+                .semesterPeriod(semesterPeriod)
                 .build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
@@ -42,8 +42,4 @@ public class Recruitment extends BaseSemesterEntity {
                 .semesterPeriod(semesterPeriod)
                 .build();
     }
-
-    public void updateFee(Money fee) {
-        this.fee = fee;
-    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
@@ -1,14 +1,9 @@
 package com.gdschongik.gdsc.domain.recruitment.domain;
 
-import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
-
 import com.gdschongik.gdsc.domain.common.model.BaseSemesterEntity;
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
-import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,81 +19,24 @@ public class Recruitment extends BaseSemesterEntity {
     @Column(name = "recruitment_id")
     private Long id;
 
-    private String name;
-
-    @Embedded
-    private Period period;
-
     @Embedded
     private Money fee;
 
-    @Enumerated(EnumType.STRING)
-    private RoundType roundType;
-
     @Builder(access = AccessLevel.PRIVATE)
-    private Recruitment(
-            String name,
-            final Period period,
-            Integer academicYear,
-            SemesterType semesterType,
-            Money fee,
-            RoundType roundType) {
+    private Recruitment(Integer academicYear, SemesterType semesterType, Money fee) {
         super(academicYear, semesterType);
-        this.name = name;
-        this.period = period;
         this.fee = fee;
-        this.roundType = roundType;
     }
 
-    public static Recruitment createRecruitment(
-            String name,
-            LocalDateTime startDate,
-            LocalDateTime endDate,
-            Integer academicYear,
-            SemesterType semesterType,
-            RoundType roundType,
-            Money fee) {
-        Period period = Period.createPeriod(startDate, endDate);
+    public static Recruitment createRecruitment(Integer academicYear, SemesterType semesterType, Money fee) {
         return Recruitment.builder()
-                .name(name)
-                .period(period)
                 .academicYear(academicYear)
                 .semesterType(semesterType)
-                .roundType(roundType)
                 .fee(fee)
                 .build();
     }
 
-    public boolean isOpen() {
-        return period.isOpen();
-    }
-
-    public void validatePeriodOverlap(LocalDateTime startDate, LocalDateTime endDate) {
-        period.validatePeriodOverlap(startDate, endDate);
-    }
-
-    public void updateRecruitment(
-            String name,
-            LocalDateTime startDate,
-            LocalDateTime endDate,
-            Integer academicYear,
-            SemesterType semesterType,
-            RoundType roundType,
-            Money fee) {
-        validatePeriodNotStarted();
-
-        this.name = name;
-        this.period = Period.createPeriod(startDate, endDate);
-        super.updateAcademicYear(academicYear);
-        super.updateSemesterType(semesterType);
-        this.roundType = roundType;
+    public void updateFee(Money fee) {
         this.fee = fee;
-    }
-
-    public void validatePeriodNotStarted() {
-        LocalDateTime now = LocalDateTime.now();
-        if (now.isAfter(period.getStartDate())) {
-            throw new CustomException(RECRUITMENT_STARTDATE_ALREADY_PASSED);
-        }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
@@ -47,7 +47,7 @@ public class RecruitmentRound extends BaseSemesterEntity {
     @Builder(access = AccessLevel.PRIVATE)
     private RecruitmentRound(
             String name,
-            Period period,
+            final Period period,
             Integer academicYear,
             SemesterType semesterType,
             Recruitment recruitment,
@@ -80,12 +80,11 @@ public class RecruitmentRound extends BaseSemesterEntity {
         period.validatePeriodOverlap(startDate, endDate);
     }
 
-    public void updateRecruitmentRound(
-            String name, LocalDateTime startDate, LocalDateTime endDate, RoundType roundType) {
+    public void updateRecruitmentRound(String name, Period period, RoundType roundType) {
         validatePeriodNotStarted();
 
         this.name = name;
-        this.period = Period.createPeriod(startDate, endDate);
+        this.period = period;
         this.roundType = roundType;
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
@@ -92,7 +92,7 @@ public class RecruitmentRound extends BaseSemesterEntity {
     public void validatePeriodNotStarted() {
         LocalDateTime now = LocalDateTime.now();
         if (now.isAfter(period.getStartDate())) {
-            throw new CustomException(RECRUITMENT_STARTDATE_ALREADY_PASSED);
+            throw new CustomException(RECRUITMENT_ROUND_STARTDATE_ALREADY_PASSED);
         }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -37,6 +38,7 @@ public class RecruitmentRound extends BaseSemesterEntity {
     private Period period;
 
     @ManyToOne
+    @JoinColumn(name = "recruitment_id")
     private Recruitment recruitment;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
@@ -80,19 +80,12 @@ public class RecruitmentRound extends BaseSemesterEntity {
         period.validatePeriodOverlap(startDate, endDate);
     }
 
-    public void updateRecruitment(
-            String name,
-            LocalDateTime startDate,
-            LocalDateTime endDate,
-            Integer academicYear,
-            SemesterType semesterType,
-            RoundType roundType) {
+    public void updateRecruitmentRound(
+            String name, LocalDateTime startDate, LocalDateTime endDate, RoundType roundType) {
         validatePeriodNotStarted();
 
         this.name = name;
         this.period = Period.createPeriod(startDate, endDate);
-        super.updateAcademicYear(academicYear);
-        super.updateSemesterType(semesterType);
         this.roundType = roundType;
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
@@ -1,0 +1,103 @@
+package com.gdschongik.gdsc.domain.recruitment.domain;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.domain.common.model.BaseSemesterEntity;
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecruitmentRound extends BaseSemesterEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recruitment_round_id")
+    private Long id;
+
+    private String name;
+
+    @Embedded
+    private Period period;
+
+    @ManyToOne
+    private Recruitment recruitment;
+
+    @Enumerated(EnumType.STRING)
+    private RoundType roundType;
+
+    @Builder
+    private RecruitmentRound(
+            String name,
+            Period period,
+            Integer academicYear,
+            SemesterType semesterType,
+            Recruitment recruitment,
+            RoundType roundType) {
+        super(academicYear, semesterType);
+        this.name = name;
+        this.period = period;
+        this.recruitment = recruitment;
+        this.roundType = roundType;
+    }
+
+    public static RecruitmentRound create(
+            String name, LocalDateTime startDate, LocalDateTime endDate, Recruitment recruitment, RoundType roundType) {
+        Period period = Period.createPeriod(startDate, endDate);
+        return RecruitmentRound.builder()
+                .name(name)
+                .period(period)
+                .academicYear(recruitment.getAcademicYear())
+                .semesterType(recruitment.getSemesterType())
+                .recruitment(recruitment)
+                .roundType(roundType)
+                .build();
+    }
+
+    public boolean isOpen() {
+        return period.isOpen();
+    }
+
+    public void validatePeriodOverlap(LocalDateTime startDate, LocalDateTime endDate) {
+        period.validatePeriodOverlap(startDate, endDate);
+    }
+
+    public void updateRecruitment(
+            String name,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            Integer academicYear,
+            SemesterType semesterType,
+            RoundType roundType) {
+        validatePeriodNotStarted();
+
+        this.name = name;
+        this.period = Period.createPeriod(startDate, endDate);
+        super.updateAcademicYear(academicYear);
+        super.updateSemesterType(semesterType);
+        this.roundType = roundType;
+    }
+
+    public void validatePeriodNotStarted() {
+        LocalDateTime now = LocalDateTime.now();
+        if (now.isAfter(period.getStartDate())) {
+            throw new CustomException(RECRUITMENT_STARTDATE_ALREADY_PASSED);
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
@@ -44,7 +44,7 @@ public class RecruitmentRound extends BaseSemesterEntity {
     @Enumerated(EnumType.STRING)
     private RoundType roundType;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private RecruitmentRound(
             String name,
             Period period,

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/vo/Period.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/vo/Period.java
@@ -46,7 +46,7 @@ public class Period {
         if (this.endDate.isBefore(startDate) || this.startDate.isAfter(endDate)) {
             return;
         }
-        throw new CustomException(RECRUITMENT_PERIOD_OVERLAP);
+        throw new CustomException(PERIOD_OVERLAP);
     }
 
     @Override

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/RecruitmentFullDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/RecruitmentFullDto.java
@@ -1,19 +1,19 @@
 package com.gdschongik.gdsc.domain.recruitment.dto;
 
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import java.math.BigDecimal;
 
 public record RecruitmentFullDto(
         Long recruitmentId, String name, Period period, BigDecimal fee, RoundType roundType, String roundTypeValue) {
-    public static RecruitmentFullDto from(Recruitment recruitment) {
+    public static RecruitmentFullDto from(RecruitmentRound recruitmentRound) {
         return new RecruitmentFullDto(
-                recruitment.getId(),
-                recruitment.getName(),
-                recruitment.getPeriod(),
-                recruitment.getFee().getAmount(),
-                recruitment.getRoundType(),
-                recruitment.getRoundType().getValue());
+                recruitmentRound.getId(),
+                recruitmentRound.getName(),
+                recruitmentRound.getPeriod(),
+                recruitmentRound.getRecruitment().getFee().getAmount(),
+                recruitmentRound.getRoundType(),
+                recruitmentRound.getRoundType().getValue());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/RecruitmentRoundFullDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/RecruitmentRoundFullDto.java
@@ -5,10 +5,10 @@ import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import java.math.BigDecimal;
 
-public record RecruitmentFullDto(
+public record RecruitmentRoundFullDto(
         Long recruitmentId, String name, Period period, BigDecimal fee, RoundType roundType, String roundTypeValue) {
-    public static RecruitmentFullDto from(RecruitmentRound recruitmentRound) {
-        return new RecruitmentFullDto(
+    public static RecruitmentRoundFullDto from(RecruitmentRound recruitmentRound) {
+        return new RecruitmentRoundFullDto(
                 recruitmentRound.getId(),
                 recruitmentRound.getName(),
                 recruitmentRound.getPeriod(),

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentCreateRequest.java
@@ -3,20 +3,16 @@ package com.gdschongik.gdsc.domain.recruitment.dto.request;
 import static com.gdschongik.gdsc.global.common.constant.RegexConstant.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
-import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Future;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-public record RecruitmentCreateUpdateRequest(
-        @NotBlank @Schema(description = "이름") String name,
-        @Future @Schema(description = "모집기간 시작일", pattern = DATETIME) LocalDateTime startDate,
-        @Future @Schema(description = "모집기간 종료일", pattern = DATETIME) LocalDateTime endDate,
+public record RecruitmentCreateRequest(
+        @Future @Schema(description = "학기 시작일", pattern = DATETIME) LocalDateTime periodStartDate,
+        @Future @Schema(description = "학기 종료일", pattern = DATETIME) LocalDateTime periodEndDate,
         @NotNull(message = "학년도는 null이 될 수 없습니다.") @Schema(description = "학년도", pattern = ACADEMIC_YEAR)
                 Integer academicYear,
         @NotNull(message = "학기는 null이 될 수 없습니다.") @Schema(description = "학기") SemesterType semesterType,
-        @NotNull(message = "모집 차수는 null이 될 수 없습니다.") @Schema(description = "모집 차수") RoundType roundType,
         @NotNull(message = "회비는 null이 될 수 없습니다.") @Schema(description = "회비") BigDecimal fee) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentRoundUpdateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentRoundUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.gdschongik.gdsc.domain.recruitment.dto.request;
+
+import static com.gdschongik.gdsc.global.common.constant.RegexConstant.*;
+
+import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record RecruitmentRoundUpdateRequest(
+        @NotBlank @Schema(description = "이름") String name,
+        @Future @Schema(description = "모집기간 시작일", pattern = DATETIME) LocalDateTime startDate,
+        @Future @Schema(description = "모집기간 종료일", pattern = DATETIME) LocalDateTime endDate,
+        @NotNull(message = "모집 차수는 null이 될 수 없습니다.") @Schema(description = "모집 차수") RoundType roundType) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/response/AdminRecruitmentResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/response/AdminRecruitmentResponse.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.recruitment.dto.response;
 
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
@@ -12,16 +12,16 @@ public record AdminRecruitmentResponse(
         @Schema(description = "신청기간 시작일") LocalDateTime startDate,
         @Schema(description = "신청기간 종료일") LocalDateTime endDate) {
 
-    public static AdminRecruitmentResponse from(Recruitment recruitment) {
+    public static AdminRecruitmentResponse from(RecruitmentRound recruitmentRound) {
         return new AdminRecruitmentResponse(
-                recruitment.getId(),
+                recruitmentRound.getId(),
                 String.format(
                         "%d-%s",
-                        recruitment.getAcademicYear(),
-                        recruitment.getSemesterType().getValue()),
-                recruitment.getRoundType().getValue(),
-                recruitment.getName(),
-                recruitment.getPeriod().getStartDate(),
-                recruitment.getPeriod().getEndDate());
+                        recruitmentRound.getAcademicYear(),
+                        recruitmentRound.getSemesterType().getValue()),
+                recruitmentRound.getRoundType().getValue(),
+                recruitmentRound.getName(),
+                recruitmentRound.getPeriod().getStartDate(),
+                recruitmentRound.getPeriod().getEndDate());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/response/AdminRecruitmentResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/response/AdminRecruitmentResponse.java
@@ -1,27 +1,28 @@
 package com.gdschongik.gdsc.domain.recruitment.dto.response;
 
-import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.text.DecimalFormat;
 import java.time.LocalDateTime;
 
 public record AdminRecruitmentResponse(
         Long recruitmentId,
         @Schema(description = "활동 학기") String semester,
-        @Schema(description = "차수") String round,
-        String name,
-        @Schema(description = "신청기간 시작일") LocalDateTime startDate,
-        @Schema(description = "신청기간 종료일") LocalDateTime endDate) {
+        @Schema(description = "학기 시작일") LocalDateTime semesterStartDate,
+        @Schema(description = "학기 종료일") LocalDateTime semesterEndDate,
+        @Schema(description = "회비") String recruitmentFee) {
 
-    public static AdminRecruitmentResponse from(RecruitmentRound recruitmentRound) {
+    public static AdminRecruitmentResponse from(Recruitment recruitment) {
+        DecimalFormat decimalFormat = new DecimalFormat("#,###");
+
         return new AdminRecruitmentResponse(
-                recruitmentRound.getId(),
+                recruitment.getId(),
                 String.format(
                         "%d-%s",
-                        recruitmentRound.getAcademicYear(),
-                        recruitmentRound.getSemesterType().getValue()),
-                recruitmentRound.getRoundType().getValue(),
-                recruitmentRound.getName(),
-                recruitmentRound.getPeriod().getStartDate(),
-                recruitmentRound.getPeriod().getEndDate());
+                        recruitment.getAcademicYear(),
+                        recruitment.getSemesterType().getValue()),
+                recruitment.getSemesterPeriod().getStartDate(),
+                recruitment.getSemesterPeriod().getEndDate(),
+                String.format("%s원", decimalFormat.format(recruitment.getFee().getAmount())));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -74,6 +74,7 @@ public enum ErrorCode {
 
     // Recruitment
     DATE_PRECEDENCE_INVALID(HttpStatus.BAD_REQUEST, "종료일이 시작일과 같거나 앞설 수 없습니다."),
+    RECRUITMENT_OVERLAP(HttpStatus.BAD_REQUEST, "해당 학기에 이미 리크루팅이 존재합니다."),
     RECRUITMENT_NOT_OPEN(HttpStatus.CONFLICT, "리크루팅 모집기간이 아닙니다."),
     RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "리크루팅이 존재하지 않습니다."),
     RECRUITMENT_PERIOD_OVERLAP(HttpStatus.BAD_REQUEST, "모집 기간이 중복됩니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -28,6 +28,9 @@ public enum ErrorCode {
     // Money
     MONEY_AMOUNT_NOT_NULL(HttpStatus.INTERNAL_SERVER_ERROR, "금액은 null이 될 수 없습니다."),
 
+    // Period
+    PERIOD_OVERLAP(HttpStatus.CONFLICT, "기간이 중복됩니다."),
+
     // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 커뮤니티 멤버입니다."),
     MEMBER_DELETED(HttpStatus.CONFLICT, "탈퇴한 회원입니다."),
@@ -77,7 +80,6 @@ public enum ErrorCode {
     RECRUITMENT_OVERLAP(HttpStatus.BAD_REQUEST, "해당 학기에 이미 리크루팅이 존재합니다."),
     RECRUITMENT_ROUND_NOT_OPEN(HttpStatus.CONFLICT, "리크루팅 모집기간이 아닙니다."),
     RECRUITMENT_ROUND_NOT_FOUND(HttpStatus.NOT_FOUND, "리크루팅이 존재하지 않습니다."),
-    RECRUITMENT_PERIOD_OVERLAP(HttpStatus.BAD_REQUEST, "모집 기간이 중복됩니다."),
     RECRUITMENT_PERIOD_MISMATCH_ACADEMIC_YEAR(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 연도가 학년도와 일치하지 않습니다."),
     RECRUITMENT_PERIOD_MISMATCH_SEMESTER_TYPE(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 입력된 학기가 일치하지 않습니다."),
     RECRUITMENT_PERIOD_SEMESTER_TYPE_UNMAPPED(HttpStatus.CONFLICT, "모집 시작일과 종료일이 매핑되는 학기가 없습니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -75,7 +75,7 @@ public enum ErrorCode {
     // Recruitment
     DATE_PRECEDENCE_INVALID(HttpStatus.BAD_REQUEST, "종료일이 시작일과 같거나 앞설 수 없습니다."),
     RECRUITMENT_OVERLAP(HttpStatus.BAD_REQUEST, "해당 학기에 이미 리크루팅이 존재합니다."),
-    RECRUITMENT_NOT_OPEN(HttpStatus.CONFLICT, "리크루팅 모집기간이 아닙니다."),
+    RECRUITMENT_ROUND_NOT_OPEN(HttpStatus.CONFLICT, "리크루팅 모집기간이 아닙니다."),
     RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "리크루팅이 존재하지 않습니다."),
     RECRUITMENT_PERIOD_OVERLAP(HttpStatus.BAD_REQUEST, "모집 기간이 중복됩니다."),
     RECRUITMENT_PERIOD_MISMATCH_ACADEMIC_YEAR(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 연도가 학년도와 일치하지 않습니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -78,14 +78,14 @@ public enum ErrorCode {
     // Recruitment
     DATE_PRECEDENCE_INVALID(HttpStatus.BAD_REQUEST, "종료일이 시작일과 같거나 앞설 수 없습니다."),
     RECRUITMENT_OVERLAP(HttpStatus.BAD_REQUEST, "해당 학기에 이미 리크루팅이 존재합니다."),
-    RECRUITMENT_ROUND_NOT_OPEN(HttpStatus.CONFLICT, "리크루팅 모집기간이 아닙니다."),
-    RECRUITMENT_ROUND_NOT_FOUND(HttpStatus.NOT_FOUND, "리크루팅이 존재하지 않습니다."),
+    RECRUITMENT_ROUND_NOT_OPEN(HttpStatus.CONFLICT, "리크루팅 회차 모집기간이 아닙니다."),
+    RECRUITMENT_ROUND_NOT_FOUND(HttpStatus.NOT_FOUND, "리크루팅 회차가 존재하지 않습니다."),
     RECRUITMENT_PERIOD_MISMATCH_ACADEMIC_YEAR(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 연도가 학년도와 일치하지 않습니다."),
     RECRUITMENT_PERIOD_MISMATCH_SEMESTER_TYPE(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 입력된 학기가 일치하지 않습니다."),
     RECRUITMENT_PERIOD_SEMESTER_TYPE_UNMAPPED(HttpStatus.CONFLICT, "모집 시작일과 종료일이 매핑되는 학기가 없습니다."),
     RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일이 학기 시작일로부터 2주 이내에 있지 않습니다."),
     RECRUITMENT_ROUND_TYPE_OVERLAP(HttpStatus.BAD_REQUEST, "모집 차수가 중복됩니다."),
-    RECRUITMENT_ROUND_STARTDATE_ALREADY_PASSED(HttpStatus.BAD_REQUEST, "이미 모집 시작일이 지난 리크루팅입니다."),
+    RECRUITMENT_ROUND_STARTDATE_ALREADY_PASSED(HttpStatus.BAD_REQUEST, "이미 모집 시작일이 지난 리크루팅 회차입니다."),
 
     // Coupon
     COUPON_DISCOUNT_AMOUNT_NOT_POSITIVE(HttpStatus.CONFLICT, "쿠폰의 할인 금액은 0보다 커야 합니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -76,7 +76,7 @@ public enum ErrorCode {
     DATE_PRECEDENCE_INVALID(HttpStatus.BAD_REQUEST, "종료일이 시작일과 같거나 앞설 수 없습니다."),
     RECRUITMENT_OVERLAP(HttpStatus.BAD_REQUEST, "해당 학기에 이미 리크루팅이 존재합니다."),
     RECRUITMENT_ROUND_NOT_OPEN(HttpStatus.CONFLICT, "리크루팅 모집기간이 아닙니다."),
-    RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "리크루팅이 존재하지 않습니다."),
+    RECRUITMENT_ROUND_NOT_FOUND(HttpStatus.NOT_FOUND, "리크루팅이 존재하지 않습니다."),
     RECRUITMENT_PERIOD_OVERLAP(HttpStatus.BAD_REQUEST, "모집 기간이 중복됩니다."),
     RECRUITMENT_PERIOD_MISMATCH_ACADEMIC_YEAR(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 연도가 학년도와 일치하지 않습니다."),
     RECRUITMENT_PERIOD_MISMATCH_SEMESTER_TYPE(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 입력된 학기가 일치하지 않습니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -85,7 +85,7 @@ public enum ErrorCode {
     RECRUITMENT_PERIOD_SEMESTER_TYPE_UNMAPPED(HttpStatus.CONFLICT, "모집 시작일과 종료일이 매핑되는 학기가 없습니다."),
     RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일이 학기 시작일로부터 2주 이내에 있지 않습니다."),
     RECRUITMENT_ROUND_TYPE_OVERLAP(HttpStatus.BAD_REQUEST, "모집 차수가 중복됩니다."),
-    RECRUITMENT_STARTDATE_ALREADY_PASSED(HttpStatus.BAD_REQUEST, "이미 모집 시작일이 지난 리크루팅입니다."),
+    RECRUITMENT_ROUND_STARTDATE_ALREADY_PASSED(HttpStatus.BAD_REQUEST, "이미 모집 시작일이 지난 리크루팅입니다."),
 
     // Coupon
     COUPON_DISCOUNT_AMOUNT_NOT_POSITIVE(HttpStatus.CONFLICT, "쿠폰의 할인 금액은 0보다 커야 합니다."),

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
@@ -62,7 +62,7 @@ class AdminMemberServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> adminMemberService.demoteAllRegularMembersToAssociate(request))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_NOT_FOUND.getMessage());
+                    .hasMessage(RECRUITMENT_ROUND_NOT_FOUND.getMessage());
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
@@ -45,7 +45,8 @@ class AdminMemberServiceTest extends IntegrationTest {
         @Test
         void 해당_학기에_이미_시작된_모집기간이_있다면_실패한다() {
             // given
-            createRecruitment(RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
+            createRecruitmentRound(
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
             MemberDemoteRequest request = new MemberDemoteRequest(ACADEMIC_YEAR, SEMESTER_TYPE);
 
             // when & then

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
@@ -5,20 +5,14 @@ import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
-import com.gdschongik.gdsc.domain.common.model.SemesterType;
-import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Department;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberDemoteRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberUpdateRequest;
-import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
-import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.helper.IntegrationTest;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,22 +24,6 @@ class AdminMemberServiceTest extends IntegrationTest {
 
     @Autowired
     private AdminMemberService adminMemberService;
-
-    @Autowired
-    private RecruitmentRepository recruitmentRepository;
-
-    private Recruitment createRecruitment(
-            String name,
-            LocalDateTime startDate,
-            LocalDateTime endDate,
-            Integer academicYear,
-            SemesterType semesterType,
-            RoundType roundType,
-            Money fee) {
-        Recruitment recruitment =
-                Recruitment.createRecruitment(name, startDate, endDate, academicYear, semesterType, roundType, fee);
-        return recruitmentRepository.save(recruitment);
-    }
 
     @Test
     void status가_DELETED라면_예외_발생() {

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
@@ -52,7 +52,7 @@ class AdminMemberServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> adminMemberService.demoteAllRegularMembersToAssociate(request))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_STARTDATE_ALREADY_PASSED.getMessage());
+                    .hasMessage(RECRUITMENT_ROUND_STARTDATE_ALREADY_PASSED.getMessage());
         }
 
         @Test

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
@@ -8,7 +8,7 @@ import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberDashboardResponse;
 import com.gdschongik.gdsc.domain.recruitment.application.OnboardingRecruitmentService;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.helper.IntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,8 +30,8 @@ class OnboardingMemberServiceTest extends IntegrationTest {
          */
         @BeforeEach
         void setUp() {
-            Recruitment recruitment = createRecruitment();
-            when(onboardingRecruitmentService.findCurrentRecruitment()).thenReturn(recruitment);
+            RecruitmentRound recruitmentRound = createRecruitmentRound();
+            when(onboardingRecruitmentService.findCurrentRecruitment()).thenReturn(recruitmentRound);
         }
 
         @Test

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -26,7 +26,7 @@ public class MembershipServiceTest extends IntegrationTest {
     @Nested
     class 멤버십_가입신청시 {
         @Test
-        void Recruitment가_없다면_실패한다() {
+        void RecruitmentRound가_없다면_실패한다() {
             // given
             createMember();
             logoutAndReloginAs(1L, ASSOCIATE);
@@ -35,7 +35,7 @@ public class MembershipServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> membershipService.submitMembership(recruitmentId))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_NOT_FOUND.getMessage());
+                    .hasMessage(RECRUITMENT_ROUND_NOT_FOUND.getMessage());
         }
 
         @Test

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -71,7 +71,7 @@ public class MembershipServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 해당_Recruitment의_모집기간이_아니라면_실패한다() {
+        void 해당_RecruitmentRound의_모집기간이_아니라면_실패한다() {
             // given
             createMember();
             logoutAndReloginAs(1L, ASSOCIATE);
@@ -80,7 +80,7 @@ public class MembershipServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> membershipService.submitMembership(recruitmentRound.getId()))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_NOT_OPEN.getMessage());
+                    .hasMessage(RECRUITMENT_ROUND_NOT_OPEN.getMessage());
         }
     }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.*;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.dao.MembershipRepository;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.IntegrationTest;
 import org.junit.jupiter.api.Nested;
@@ -23,8 +23,8 @@ public class MembershipServiceTest extends IntegrationTest {
     @Autowired
     private MembershipRepository membershipRepository;
 
-    private Membership createMembership(Member member, Recruitment recruitment) {
-        Membership membership = Membership.createMembership(member, recruitment);
+    private Membership createMembership(Member member, RecruitmentRound recruitmentRound) {
+        Membership membership = Membership.createMembership(member, recruitmentRound);
         return membershipRepository.save(membership);
     }
 
@@ -48,15 +48,15 @@ public class MembershipServiceTest extends IntegrationTest {
             // given
             Member member = createMember();
             logoutAndReloginAs(1L, ASSOCIATE);
-            Recruitment recruitment = createRecruitment();
-            Membership membership = createMembership(member, recruitment);
+            RecruitmentRound recruitmentRound = createRecruitmentRound();
+            Membership membership = createMembership(member, recruitmentRound);
 
             // when
             membership.verifyPaymentStatus();
             membershipRepository.save(membership);
 
             // then
-            assertThatThrownBy(() -> membershipService.submitMembership(recruitment.getId()))
+            assertThatThrownBy(() -> membershipService.submitMembership(recruitmentRound.getId()))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(MEMBERSHIP_ALREADY_SATISFIED.getMessage());
         }
@@ -66,11 +66,11 @@ public class MembershipServiceTest extends IntegrationTest {
             // given
             Member member = createMember();
             logoutAndReloginAs(1L, ASSOCIATE);
-            Recruitment recruitment = createRecruitment();
-            createMembership(member, recruitment);
+            RecruitmentRound recruitmentRound = createRecruitmentRound();
+            createMembership(member, recruitmentRound);
 
             // when & then
-            assertThatThrownBy(() -> membershipService.submitMembership(recruitment.getId()))
+            assertThatThrownBy(() -> membershipService.submitMembership(recruitmentRound.getId()))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(MEMBERSHIP_ALREADY_APPLIED.getMessage());
         }
@@ -80,10 +80,10 @@ public class MembershipServiceTest extends IntegrationTest {
             // given
             createMember();
             logoutAndReloginAs(1L, ASSOCIATE);
-            Recruitment recruitment = createRecruitment();
+            RecruitmentRound recruitmentRound = createRecruitmentRound();
 
             // when & then
-            assertThatThrownBy(() -> membershipService.submitMembership(recruitment.getId()))
+            assertThatThrownBy(() -> membershipService.submitMembership(recruitmentRound.getId()))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(RECRUITMENT_NOT_OPEN.getMessage());
         }
@@ -94,8 +94,8 @@ public class MembershipServiceTest extends IntegrationTest {
         // given
         Member member = createMember();
         logoutAndReloginAs(1L, ASSOCIATE);
-        Recruitment recruitment = createRecruitment();
-        Membership membership = createMembership(member, recruitment);
+        RecruitmentRound recruitmentRound = createRecruitmentRound();
+        Membership membership = createMembership(member, recruitmentRound);
         membershipService.verifyPaymentStatus(membership.getId());
 
         // when & then
@@ -111,8 +111,8 @@ public class MembershipServiceTest extends IntegrationTest {
             // given
             Member member = createMember();
             logoutAndReloginAs(1L, ASSOCIATE);
-            Recruitment recruitment = createRecruitment();
-            Membership membership = createMembership(member, recruitment);
+            RecruitmentRound recruitmentRound = createRecruitmentRound();
+            Membership membership = createMembership(member, recruitmentRound);
 
             // when
             membershipService.verifyPaymentStatus(membership.getId());

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -23,12 +23,6 @@ public class MembershipServiceTest extends IntegrationTest {
     @Autowired
     private MembershipRepository membershipRepository;
 
-    // todo: 주석 제거
-    // private Membership createMembership(Member member, RecruitmentRound recruitmentRound) {
-    //     Membership membership = Membership.createMembership(member, recruitmentRound);
-    //     return membershipRepository.save(membership);
-    // }
-
     @Nested
     class 멤버십_가입신청시 {
         @Test

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,11 +20,12 @@ class MembershipTest {
         void 역할이_GUEST라면_멤버십_가입신청에_실패한다() {
             // given
             Member guestMember = Member.createGuestMember(OAUTH_ID);
-            Recruitment recruitment = Recruitment.createRecruitment(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
+            Recruitment recruitment = Recruitment.createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE);
+            RecruitmentRound recruitmentRound =
+                    RecruitmentRound.create(RECRUITMENT_NAME, START_DATE, END_DATE, recruitment, ROUND_TYPE);
 
             // when & then
-            assertThatThrownBy(() -> Membership.createMembership(guestMember, recruitment))
+            assertThatThrownBy(() -> Membership.createMembership(guestMember, recruitmentRound))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(MEMBERSHIP_NOT_APPLICABLE.getMessage());
         }

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
@@ -2,12 +2,14 @@ package com.gdschongik.gdsc.domain.membership.domain;
 
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.SemesterConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,7 +22,8 @@ class MembershipTest {
         void 역할이_GUEST라면_멤버십_가입신청에_실패한다() {
             // given
             Member guestMember = Member.createGuestMember(OAUTH_ID);
-            Recruitment recruitment = Recruitment.createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE);
+            Recruitment recruitment = Recruitment.createRecruitment(
+                    ACADEMIC_YEAR, SEMESTER_TYPE, FEE, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
             RecruitmentRound recruitmentRound =
                     RecruitmentRound.create(RECRUITMENT_NAME, START_DATE, END_DATE, recruitment, ROUND_TYPE);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -39,7 +39,7 @@ class OrderServiceTest extends IntegrationTest {
             // given
             Member member = createMember();
             logoutAndReloginAs(1L, MemberRole.ASSOCIATE);
-            RecruitmentRound recruitmentRound = createRecruitment(
+            RecruitmentRound recruitmentRound = createRecruitmentRound(
                     RECRUITMENT_NAME,
                     LocalDateTime.now().minusDays(1),
                     LocalDateTime.now().plusDays(1),

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
@@ -4,6 +4,7 @@ import static com.gdschongik.gdsc.domain.member.domain.Department.*;
 import static com.gdschongik.gdsc.domain.member.domain.Member.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.SemesterConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -16,6 +17,7 @@ import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -48,7 +50,8 @@ class OrderValidatorTest {
             Integer academicYear,
             SemesterType semesterType,
             Money fee) {
-        Recruitment recruitment = Recruitment.createRecruitment(academicYear, semesterType, fee);
+        Recruitment recruitment = Recruitment.createRecruitment(
+                academicYear, semesterType, fee, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
 
         return RecruitmentRound.create(RECRUITMENT_NAME, startDate, endDate, recruitment, RoundType.FIRST);
     }

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
@@ -44,7 +44,7 @@ class OrderValidatorTest {
         return member;
     }
 
-    private RecruitmentRound createRecruitment(
+    private RecruitmentRound createRecruitmentRound(
             LocalDateTime startDate,
             LocalDateTime endDate,
             Integer academicYear,
@@ -70,7 +70,7 @@ class OrderValidatorTest {
         // given
         Member currentMember = createAssociateMember(1L);
 
-        RecruitmentRound recruitmentRound = createRecruitment(
+        RecruitmentRound recruitmentRound = createRecruitmentRound(
                 LocalDateTime.now().minusDays(1),
                 LocalDateTime.now().plusDays(1),
                 2024,
@@ -95,7 +95,7 @@ class OrderValidatorTest {
         // given
         Member currentMember = createAssociateMember(1L);
 
-        RecruitmentRound recruitmentRound = createRecruitment(
+        RecruitmentRound recruitmentRound = createRecruitmentRound(
                 LocalDateTime.now().minusDays(1),
                 LocalDateTime.now().plusDays(1),
                 2024,
@@ -123,7 +123,7 @@ class OrderValidatorTest {
         LocalDateTime invalidStartDate = LocalDateTime.now().minusDays(2);
         LocalDateTime invalidEndDate = LocalDateTime.now().minusDays(1);
         RecruitmentRound recruitmentRound =
-                createRecruitment(invalidStartDate, invalidEndDate, 2024, SemesterType.FIRST, MONEY_20000_WON);
+                createRecruitmentRound(invalidStartDate, invalidEndDate, 2024, SemesterType.FIRST, MONEY_20000_WON);
 
         Membership membership = createMembership(currentMember, recruitmentRound);
 
@@ -142,7 +142,7 @@ class OrderValidatorTest {
         // given
         Member currentMember = createAssociateMember(1L);
 
-        RecruitmentRound recruitmentRound = createRecruitment(
+        RecruitmentRound recruitmentRound = createRecruitmentRound(
                 LocalDateTime.now().minusDays(1),
                 LocalDateTime.now().plusDays(1),
                 2024,
@@ -167,7 +167,7 @@ class OrderValidatorTest {
         // given
         Member currentMember = createAssociateMember(1L);
 
-        RecruitmentRound recruitmentRound = createRecruitment(
+        RecruitmentRound recruitmentRound = createRecruitmentRound(
                 LocalDateTime.now().minusDays(1),
                 LocalDateTime.now().plusDays(1),
                 2024,
@@ -192,7 +192,7 @@ class OrderValidatorTest {
         // given
         Member currentMember = createAssociateMember(1L);
 
-        RecruitmentRound recruitmentRound = createRecruitment(
+        RecruitmentRound recruitmentRound = createRecruitmentRound(
                 LocalDateTime.now().minusDays(1),
                 LocalDateTime.now().plusDays(1),
                 2024,
@@ -217,7 +217,7 @@ class OrderValidatorTest {
         // given
         Member currentMember = createAssociateMember(1L);
 
-        RecruitmentRound recruitmentRound = createRecruitment(
+        RecruitmentRound recruitmentRound = createRecruitmentRound(
                 LocalDateTime.now().minusDays(1),
                 LocalDateTime.now().plusDays(1),
                 2024,
@@ -241,7 +241,7 @@ class OrderValidatorTest {
         // given
         Member currentMember = createAssociateMember(1L);
 
-        RecruitmentRound recruitmentRound = createRecruitment(
+        RecruitmentRound recruitmentRound = createRecruitmentRound(
                 LocalDateTime.now().minusDays(1),
                 LocalDateTime.now().plusDays(1),
                 2024,
@@ -262,7 +262,7 @@ class OrderValidatorTest {
         // given
         Member currentMember = createAssociateMember(1L);
 
-        RecruitmentRound recruitmentRound = createRecruitment(
+        RecruitmentRound recruitmentRound = createRecruitmentRound(
                 LocalDateTime.now().minusDays(1),
                 LocalDateTime.now().plusDays(1),
                 2024,

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -5,9 +5,8 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
-import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateUpdateRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
@@ -24,19 +23,6 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
 
     @Autowired
     private RecruitmentRepository recruitmentRepository;
-
-    private Recruitment createRecruitment(
-            String name,
-            LocalDateTime startDate,
-            LocalDateTime endDate,
-            Integer academicYear,
-            SemesterType semesterType,
-            RoundType roundType,
-            Money fee) {
-        Recruitment recruitment =
-                Recruitment.createRecruitment(name, startDate, endDate, academicYear, semesterType, roundType, fee);
-        return recruitmentRepository.save(recruitment);
-    }
 
     @Nested
     class 모집기간_생성시 {
@@ -120,7 +106,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         @Test
         void 모집_시작일이_지났다면_수정_실패한다() {
             // given
-            Recruitment recruitment = createRecruitment(
+            RecruitmentRound recruitmentRound = createRecruitment(
                     RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
             RecruitmentCreateUpdateRequest request = new RecruitmentCreateUpdateRequest(
                     RECRUITMENT_NAME,
@@ -132,7 +118,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
                     FEE_AMOUNT);
 
             // when & then
-            assertThatThrownBy(() -> adminRecruitmentService.updateRecruitment(recruitment.getId(), request))
+            assertThatThrownBy(() -> adminRecruitmentService.updateRecruitment(recruitmentRound.getId(), request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(RECRUITMENT_STARTDATE_ALREADY_PASSED.getMessage());
         }
@@ -140,9 +126,9 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         @Test
         void 기간이_중복되는_Recruitment가_있다면_실패한다() {
             // given
-            Recruitment recruitmentRoundOne = createRecruitment(
+            RecruitmentRound recruitmentRoundOne = createRecruitment(
                     RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
-            Recruitment recruitmentRoundTwo = createRecruitment(
+            RecruitmentRound recruitmentRoundTwo = createRecruitment(
                     ROUND_TWO_RECRUITMENT_NAME,
                     ROUND_TWO_START_DATE,
                     ROUND_TWO_END_DATE,
@@ -162,9 +148,9 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         @Test
         void 차수가_중복되는_Recruitment가_있다면_실패한다() {
             // given
-            Recruitment recruitmentRoundOne = createRecruitment(
+            RecruitmentRound recruitmentRoundOne = createRecruitment(
                     RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
-            Recruitment recruitmentRoundTwo = createRecruitment(
+            RecruitmentRound recruitmentRoundTwo = createRecruitment(
                     ROUND_TWO_RECRUITMENT_NAME,
                     ROUND_TWO_START_DATE,
                     ROUND_TWO_END_DATE,

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -81,7 +81,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.updateRecruitmentRound(recruitmentRound.getId(), request))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_STARTDATE_ALREADY_PASSED.getMessage());
+                    .hasMessage(RECRUITMENT_ROUND_STARTDATE_ALREADY_PASSED.getMessage());
         }
 
         @Test

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -5,9 +5,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
-import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
-import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
-import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateUpdateRequest;
+import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.IntegrationTest;
 import java.time.LocalDateTime;
@@ -23,23 +21,10 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
     @Nested
     class 모집기간_생성시 {
         @Test
-        void 기간이_중복되는_Recruitment가_있다면_실패한다() {
+        void 학기_시작일과_종료일의_연도가_입력된_학년도와_다르다면_실패한다() {
             // given
-            createRecruitment(RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
-            RecruitmentCreateUpdateRequest request = new RecruitmentCreateUpdateRequest(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE_AMOUNT);
-
-            // when & then
-            assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_PERIOD_OVERLAP.getMessage());
-        }
-
-        @Test
-        void 모집_시작일과_종료일의_연도가_입력된_학년도와_다르다면_실패한다() {
-            // given
-            RecruitmentCreateUpdateRequest request = new RecruitmentCreateUpdateRequest(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, 2025, SEMESTER_TYPE, ROUND_TYPE, FEE_AMOUNT);
+            RecruitmentCreateRequest request =
+                    new RecruitmentCreateRequest(START_DATE, END_DATE, 2025, SEMESTER_TYPE, FEE_AMOUNT);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
@@ -48,10 +33,10 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 모집_시작일과_종료일의_학기가_입력된_학기와_다르다면_실패한다() {
+        void 학기_시작일과_종료일의_학기가_입력된_학기와_다르다면_실패한다() {
             // given
-            RecruitmentCreateUpdateRequest request = new RecruitmentCreateUpdateRequest(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SemesterType.SECOND, ROUND_TYPE, FEE_AMOUNT);
+            RecruitmentCreateRequest request =
+                    new RecruitmentCreateRequest(START_DATE, END_DATE, ACADEMIC_YEAR, SemesterType.SECOND, FEE_AMOUNT);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
@@ -60,113 +45,93 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 모집_시작일과_종료일이_학기_시작일로부터_2주_이내에_있지_않다면_실패한다() {
+        void 학년도_학기가_모두_중복되는_리쿠르팅이라면_실패한다() {
             // given
-            RecruitmentCreateUpdateRequest request = new RecruitmentCreateUpdateRequest(
-                    RECRUITMENT_NAME,
-                    START_DATE,
-                    LocalDateTime.of(2024, 4, 10, 0, 0),
+            createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE);
+            RecruitmentCreateRequest request = new RecruitmentCreateRequest(
+                    LocalDateTime.of(2024, 3, 12, 0, 0),
+                    LocalDateTime.of(2024, 3, 13, 0, 0),
                     ACADEMIC_YEAR,
                     SEMESTER_TYPE,
-                    ROUND_TYPE,
                     FEE_AMOUNT);
 
             // when & then
             assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS.getMessage());
-        }
-
-        @Test
-        void 학년도_학기_차수가_모두_중복되는_리쿠르팅이라면_실패한다() {
-            // given
-            createRecruitment(RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
-            RecruitmentCreateUpdateRequest request = new RecruitmentCreateUpdateRequest(
-                    RECRUITMENT_NAME,
-                    LocalDateTime.of(2024, 3, 12, 0, 0),
-                    LocalDateTime.of(2024, 3, 13, 0, 0),
-                    ACADEMIC_YEAR,
-                    SEMESTER_TYPE,
-                    ROUND_TYPE,
-                    FEE_AMOUNT);
-
-            // when & then
-            assertThatThrownBy(() -> adminRecruitmentService.createRecruitment(request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_ROUND_TYPE_OVERLAP.getMessage());
+                    .hasMessage(RECRUITMENT_OVERLAP.getMessage());
         }
     }
 
-    @Nested
-    class 모집기간_수정시 {
-        @Test
-        void 모집_시작일이_지났다면_수정_실패한다() {
-            // given
-            RecruitmentRound recruitmentRound = createRecruitment(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
-            RecruitmentCreateUpdateRequest request = new RecruitmentCreateUpdateRequest(
-                    RECRUITMENT_NAME,
-                    LocalDateTime.of(2024, 3, 12, 0, 0),
-                    LocalDateTime.of(2024, 3, 13, 0, 0),
-                    ACADEMIC_YEAR,
-                    SEMESTER_TYPE,
-                    ROUND_TYPE,
-                    FEE_AMOUNT);
-
-            // when & then
-            assertThatThrownBy(() -> adminRecruitmentService.updateRecruitment(recruitmentRound.getId(), request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_STARTDATE_ALREADY_PASSED.getMessage());
-        }
-
-        @Test
-        void 기간이_중복되는_Recruitment가_있다면_실패한다() {
-            // given
-            RecruitmentRound recruitmentRoundOne = createRecruitment(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
-            RecruitmentRound recruitmentRoundTwo = createRecruitment(
-                    ROUND_TWO_RECRUITMENT_NAME,
-                    ROUND_TWO_START_DATE,
-                    ROUND_TWO_END_DATE,
-                    ACADEMIC_YEAR,
-                    SEMESTER_TYPE,
-                    RoundType.SECOND,
-                    FEE);
-            RecruitmentCreateUpdateRequest request = new RecruitmentCreateUpdateRequest(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE_AMOUNT);
-
-            // when & then
-            assertThatThrownBy(() -> adminRecruitmentService.updateRecruitment(recruitmentRoundTwo.getId(), request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_PERIOD_OVERLAP.getMessage());
-        }
-
-        @Test
-        void 차수가_중복되는_Recruitment가_있다면_실패한다() {
-            // given
-            RecruitmentRound recruitmentRoundOne = createRecruitment(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
-            RecruitmentRound recruitmentRoundTwo = createRecruitment(
-                    ROUND_TWO_RECRUITMENT_NAME,
-                    ROUND_TWO_START_DATE,
-                    ROUND_TWO_END_DATE,
-                    ACADEMIC_YEAR,
-                    SEMESTER_TYPE,
-                    RoundType.SECOND,
-                    FEE);
-            RecruitmentCreateUpdateRequest request = new RecruitmentCreateUpdateRequest(
-                    RECRUITMENT_NAME,
-                    ROUND_TWO_START_DATE,
-                    ROUND_TWO_END_DATE,
-                    ACADEMIC_YEAR,
-                    SEMESTER_TYPE,
-                    ROUND_TYPE,
-                    FEE_AMOUNT);
-
-            // when & then
-            assertThatThrownBy(() -> adminRecruitmentService.updateRecruitment(recruitmentRoundTwo.getId(), request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_ROUND_TYPE_OVERLAP.getMessage());
-        }
-    }
+    // @Nested
+    // class 모집기간_수정시 {
+    //     @Test
+    //     void 모집_시작일이_지났다면_수정_실패한다() {
+    //         // given
+    //         RecruitmentRound recruitmentRound = createRecruitmentRound(
+    //                 RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
+    //         RecruitmentCreateRequest request = new RecruitmentCreateRequest(
+    //                 RECRUITMENT_NAME,
+    //                 LocalDateTime.of(2024, 3, 12, 0, 0),
+    //                 LocalDateTime.of(2024, 3, 13, 0, 0),
+    //                 ACADEMIC_YEAR,
+    //                 SEMESTER_TYPE,
+    //                 ROUND_TYPE,
+    //                 FEE_AMOUNT);
+    //
+    //         // when & then
+    //         assertThatThrownBy(() -> adminRecruitmentService.updateRecruitment(recruitmentRound.getId(), request))
+    //                 .isInstanceOf(CustomException.class)
+    //                 .hasMessage(RECRUITMENT_STARTDATE_ALREADY_PASSED.getMessage());
+    //     }
+    //
+    //     @Test
+    //     void 기간이_중복되는_Recruitment가_있다면_실패한다() {
+    //         // given
+    //         RecruitmentRound recruitmentRoundOne = createRecruitmentRound(
+    //                 RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
+    //         RecruitmentRound recruitmentRoundTwo = createRecruitmentRound(
+    //                 ROUND_TWO_RECRUITMENT_NAME,
+    //                 ROUND_TWO_START_DATE,
+    //                 ROUND_TWO_END_DATE,
+    //                 ACADEMIC_YEAR,
+    //                 SEMESTER_TYPE,
+    //                 RoundType.SECOND,
+    //                 FEE);
+    //         RecruitmentCreateRequest request = new RecruitmentCreateRequest(
+    //                 RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE_AMOUNT);
+    //
+    //         // when & then
+    //         assertThatThrownBy(() -> adminRecruitmentService.updateRecruitment(recruitmentRoundTwo.getId(), request))
+    //                 .isInstanceOf(CustomException.class)
+    //                 .hasMessage(RECRUITMENT_PERIOD_OVERLAP.getMessage());
+    //     }
+    //
+    //     @Test
+    //     void 차수가_중복되는_Recruitment가_있다면_실패한다() {
+    //         // given
+    //         RecruitmentRound recruitmentRoundOne = createRecruitmentRound(
+    //                 RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
+    //         RecruitmentRound recruitmentRoundTwo = createRecruitmentRound(
+    //                 ROUND_TWO_RECRUITMENT_NAME,
+    //                 ROUND_TWO_START_DATE,
+    //                 ROUND_TWO_END_DATE,
+    //                 ACADEMIC_YEAR,
+    //                 SEMESTER_TYPE,
+    //                 RoundType.SECOND,
+    //                 FEE);
+    //         RecruitmentCreateRequest request = new RecruitmentCreateRequest(
+    //                 RECRUITMENT_NAME,
+    //                 ROUND_TWO_START_DATE,
+    //                 ROUND_TWO_END_DATE,
+    //                 ACADEMIC_YEAR,
+    //                 SEMESTER_TYPE,
+    //                 ROUND_TYPE,
+    //                 FEE_AMOUNT);
+    //
+    //         // when & then
+    //         assertThatThrownBy(() -> adminRecruitmentService.updateRecruitment(recruitmentRoundTwo.getId(), request))
+    //                 .isInstanceOf(CustomException.class)
+    //                 .hasMessage(RECRUITMENT_ROUND_TYPE_OVERLAP.getMessage());
+    //     }
+    // }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -104,7 +104,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
             assertThatThrownBy(
                             () -> adminRecruitmentService.updateRecruitmentRound(recruitmentRoundTwo.getId(), request))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_PERIOD_OVERLAP.getMessage());
+                    .hasMessage(PERIOD_OVERLAP.getMessage());
         }
 
         @Test

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -5,7 +5,10 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
+import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
+import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentRoundUpdateRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.IntegrationTest;
 import java.time.LocalDateTime;
@@ -19,7 +22,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
     private AdminRecruitmentService adminRecruitmentService;
 
     @Nested
-    class 모집기간_생성시 {
+    class 리쿠르팅_생성시 {
         @Test
         void 학기_시작일과_종료일의_연도가_입력된_학년도와_다르다면_실패한다() {
             // given
@@ -62,76 +65,69 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         }
     }
 
-    // @Nested
-    // class 모집기간_수정시 {
-    //     @Test
-    //     void 모집_시작일이_지났다면_수정_실패한다() {
-    //         // given
-    //         RecruitmentRound recruitmentRound = createRecruitmentRound(
-    //                 RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
-    //         RecruitmentCreateRequest request = new RecruitmentCreateRequest(
-    //                 RECRUITMENT_NAME,
-    //                 LocalDateTime.of(2024, 3, 12, 0, 0),
-    //                 LocalDateTime.of(2024, 3, 13, 0, 0),
-    //                 ACADEMIC_YEAR,
-    //                 SEMESTER_TYPE,
-    //                 ROUND_TYPE,
-    //                 FEE_AMOUNT);
-    //
-    //         // when & then
-    //         assertThatThrownBy(() -> adminRecruitmentService.updateRecruitment(recruitmentRound.getId(), request))
-    //                 .isInstanceOf(CustomException.class)
-    //                 .hasMessage(RECRUITMENT_STARTDATE_ALREADY_PASSED.getMessage());
-    //     }
-    //
-    //     @Test
-    //     void 기간이_중복되는_Recruitment가_있다면_실패한다() {
-    //         // given
-    //         RecruitmentRound recruitmentRoundOne = createRecruitmentRound(
-    //                 RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
-    //         RecruitmentRound recruitmentRoundTwo = createRecruitmentRound(
-    //                 ROUND_TWO_RECRUITMENT_NAME,
-    //                 ROUND_TWO_START_DATE,
-    //                 ROUND_TWO_END_DATE,
-    //                 ACADEMIC_YEAR,
-    //                 SEMESTER_TYPE,
-    //                 RoundType.SECOND,
-    //                 FEE);
-    //         RecruitmentCreateRequest request = new RecruitmentCreateRequest(
-    //                 RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE_AMOUNT);
-    //
-    //         // when & then
-    //         assertThatThrownBy(() -> adminRecruitmentService.updateRecruitment(recruitmentRoundTwo.getId(), request))
-    //                 .isInstanceOf(CustomException.class)
-    //                 .hasMessage(RECRUITMENT_PERIOD_OVERLAP.getMessage());
-    //     }
-    //
-    //     @Test
-    //     void 차수가_중복되는_Recruitment가_있다면_실패한다() {
-    //         // given
-    //         RecruitmentRound recruitmentRoundOne = createRecruitmentRound(
-    //                 RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
-    //         RecruitmentRound recruitmentRoundTwo = createRecruitmentRound(
-    //                 ROUND_TWO_RECRUITMENT_NAME,
-    //                 ROUND_TWO_START_DATE,
-    //                 ROUND_TWO_END_DATE,
-    //                 ACADEMIC_YEAR,
-    //                 SEMESTER_TYPE,
-    //                 RoundType.SECOND,
-    //                 FEE);
-    //         RecruitmentCreateRequest request = new RecruitmentCreateRequest(
-    //                 RECRUITMENT_NAME,
-    //                 ROUND_TWO_START_DATE,
-    //                 ROUND_TWO_END_DATE,
-    //                 ACADEMIC_YEAR,
-    //                 SEMESTER_TYPE,
-    //                 ROUND_TYPE,
-    //                 FEE_AMOUNT);
-    //
-    //         // when & then
-    //         assertThatThrownBy(() -> adminRecruitmentService.updateRecruitment(recruitmentRoundTwo.getId(), request))
-    //                 .isInstanceOf(CustomException.class)
-    //                 .hasMessage(RECRUITMENT_ROUND_TYPE_OVERLAP.getMessage());
-    //     }
-    // }
+    @Nested
+    class 모집회차_수정시 {
+        @Test
+        void 모집_시작일이_지났다면_수정_실패한다() {
+            // given
+            RecruitmentRound recruitmentRound = createRecruitmentRound(
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
+            RecruitmentRoundUpdateRequest request = new RecruitmentRoundUpdateRequest(
+                    RECRUITMENT_NAME,
+                    LocalDateTime.of(2024, 3, 12, 0, 0),
+                    LocalDateTime.of(2024, 3, 13, 0, 0),
+                    ROUND_TYPE);
+
+            // when & then
+            assertThatThrownBy(() -> adminRecruitmentService.updateRecruitmentRound(recruitmentRound.getId(), request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(RECRUITMENT_STARTDATE_ALREADY_PASSED.getMessage());
+        }
+
+        @Test
+        void 기간이_중복되는_RecruitmentRound가_있다면_실패한다() {
+            // given
+            RecruitmentRound recruitmentRoundOne = createRecruitmentRound(
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
+            RecruitmentRound recruitmentRoundTwo = createRecruitmentRound(
+                    ROUND_TWO_RECRUITMENT_NAME,
+                    ROUND_TWO_START_DATE,
+                    ROUND_TWO_END_DATE,
+                    ACADEMIC_YEAR,
+                    SEMESTER_TYPE,
+                    RoundType.SECOND,
+                    FEE);
+            RecruitmentRoundUpdateRequest request =
+                    new RecruitmentRoundUpdateRequest(RECRUITMENT_NAME, START_DATE, END_DATE, ROUND_TYPE);
+
+            // when & then
+            assertThatThrownBy(
+                            () -> adminRecruitmentService.updateRecruitmentRound(recruitmentRoundTwo.getId(), request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(RECRUITMENT_PERIOD_OVERLAP.getMessage());
+        }
+
+        @Test
+        void 차수가_중복되는_RecruitmentRound가_있다면_실패한다() {
+            // given
+            RecruitmentRound recruitmentRoundOne = createRecruitmentRound(
+                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
+            RecruitmentRound recruitmentRoundTwo = createRecruitmentRound(
+                    ROUND_TWO_RECRUITMENT_NAME,
+                    ROUND_TWO_START_DATE,
+                    ROUND_TWO_END_DATE,
+                    ACADEMIC_YEAR,
+                    SEMESTER_TYPE,
+                    RoundType.SECOND,
+                    FEE);
+            RecruitmentRoundUpdateRequest request = new RecruitmentRoundUpdateRequest(
+                    RECRUITMENT_NAME, ROUND_TWO_START_DATE, ROUND_TWO_END_DATE, ROUND_TYPE);
+
+            // when & then
+            assertThatThrownBy(
+                            () -> adminRecruitmentService.updateRecruitmentRound(recruitmentRoundTwo.getId(), request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(RECRUITMENT_ROUND_TYPE_OVERLAP.getMessage());
+        }
+    }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.recruitment.domain;
 
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.SemesterConstant.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
@@ -14,18 +15,16 @@ class RecruitmentTest {
         @Test
         void Period가_제대로_생성된다() {
             // given
-            Period period = Period.createPeriod(START_DATE, END_DATE);
+            Period period = Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE);
 
             // when
-            Recruitment recruitment = Recruitment.createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE);
-
-            RecruitmentRound recruitmentRound =
-                    RecruitmentRound.create(RECRUITMENT_NAME, START_DATE, END_DATE, recruitment, ROUND_TYPE);
+            Recruitment recruitment = Recruitment.createRecruitment(
+                    ACADEMIC_YEAR, SEMESTER_TYPE, FEE, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
 
             // then
-            assertThat(recruitmentRound.getPeriod().getStartDate()).isEqualTo(START_DATE);
-            assertThat(recruitmentRound.getPeriod().getEndDate()).isEqualTo(END_DATE);
-            assertThat(recruitmentRound.getPeriod().equals(period)).isTrue();
+            assertThat(recruitment.getSemesterPeriod().getStartDate()).isEqualTo(SEMESTER_START_DATE);
+            assertThat(recruitment.getSemesterPeriod().getEndDate()).isEqualTo(SEMESTER_END_DATE);
+            assertThat(recruitment.getSemesterPeriod().equals(period)).isTrue();
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
@@ -17,13 +17,15 @@ class RecruitmentTest {
             Period period = Period.createPeriod(START_DATE, END_DATE);
 
             // when
-            Recruitment recruitment = Recruitment.createRecruitment(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
+            Recruitment recruitment = Recruitment.createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE);
+
+            RecruitmentRound recruitmentRound =
+                    RecruitmentRound.create(RECRUITMENT_NAME, START_DATE, END_DATE, recruitment, ROUND_TYPE);
 
             // then
-            assertThat(recruitment.getPeriod().getStartDate()).isEqualTo(START_DATE);
-            assertThat(recruitment.getPeriod().getEndDate()).isEqualTo(END_DATE);
-            assertThat(recruitment.getPeriod().equals(period)).isTrue();
+            assertThat(recruitmentRound.getPeriod().getStartDate()).isEqualTo(START_DATE);
+            assertThat(recruitmentRound.getPeriod().getEndDate()).isEqualTo(END_DATE);
+            assertThat(recruitmentRound.getPeriod().equals(period)).isTrue();
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/SemesterConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/SemesterConstant.java
@@ -1,0 +1,10 @@
+package com.gdschongik.gdsc.global.common.constant;
+
+import java.time.LocalDateTime;
+
+public class SemesterConstant {
+    public static final LocalDateTime SEMESTER_START_DATE = LocalDateTime.of(2024, 3, 2, 0, 0);
+    public static final LocalDateTime SEMESTER_END_DATE = LocalDateTime.of(2024, 8, 31, 0, 0);
+
+    private SemesterConstant() {}
+}

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -99,7 +99,7 @@ public abstract class IntegrationTest {
         return recruitmentRoundRepository.save(recruitmentRound);
     }
 
-    protected RecruitmentRound createRecruitment(
+    protected RecruitmentRound createRecruitmentRound(
             String name,
             LocalDateTime startDate,
             LocalDateTime endDate,

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -87,14 +87,10 @@ public abstract class IntegrationTest {
     }
 
     protected RecruitmentRound createRecruitmentRound() {
-        // todo: template의 메서드 활용하도록 수정
-        Recruitment recruitment = Recruitment.createRecruitment(
-                ACADEMIC_YEAR, SEMESTER_TYPE, FEE, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
-
-        recruitmentRepository.save(recruitment);
+        Recruitment recruitment = createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE);
 
         RecruitmentRound recruitmentRound =
-                RecruitmentRound.create(NAME, START_DATE, END_DATE, recruitment, ROUND_TYPE);
+                RecruitmentRound.create(RECRUITMENT_NAME, START_DATE, END_DATE, recruitment, ROUND_TYPE);
 
         return recruitmentRoundRepository.save(recruitmentRound);
     }
@@ -107,9 +103,7 @@ public abstract class IntegrationTest {
             SemesterType semesterType,
             RoundType roundType,
             Money fee) {
-        Recruitment recruitment = Recruitment.createRecruitment(
-                academicYear, semesterType, fee, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
-        recruitmentRepository.save(recruitment);
+        Recruitment recruitment = createRecruitment(academicYear, semesterType, fee);
 
         RecruitmentRound recruitmentRound = RecruitmentRound.create(name, startDate, endDate, recruitment, roundType);
         return recruitmentRoundRepository.save(recruitmentRound);

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -3,6 +3,7 @@ package com.gdschongik.gdsc.helper;
 import static com.gdschongik.gdsc.domain.member.domain.Department.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.SemesterConstant.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
@@ -21,6 +22,7 @@ import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.security.PrincipalDetails;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -85,7 +87,9 @@ public abstract class IntegrationTest {
     }
 
     protected RecruitmentRound createRecruitmentRound() {
-        Recruitment recruitment = Recruitment.createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE);
+        // todo: template의 메서드 활용하도록 수정
+        Recruitment recruitment = Recruitment.createRecruitment(
+                ACADEMIC_YEAR, SEMESTER_TYPE, FEE, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
 
         recruitmentRepository.save(recruitment);
 
@@ -103,11 +107,18 @@ public abstract class IntegrationTest {
             SemesterType semesterType,
             RoundType roundType,
             Money fee) {
-        Recruitment recruitment = Recruitment.createRecruitment(academicYear, semesterType, fee);
+        Recruitment recruitment = Recruitment.createRecruitment(
+                academicYear, semesterType, fee, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
         recruitmentRepository.save(recruitment);
 
         RecruitmentRound recruitmentRound = RecruitmentRound.create(name, startDate, endDate, recruitment, roundType);
         return recruitmentRoundRepository.save(recruitmentRound);
+    }
+
+    protected Recruitment createRecruitment(Integer academicYear, SemesterType semesterType, Money fee) {
+        Recruitment recruitment = Recruitment.createRecruitment(
+                academicYear, semesterType, fee, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
+        return recruitmentRepository.save(recruitment);
     }
 
     protected Membership createMembership(Member member, RecruitmentRound recruitmentRound) {

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -4,13 +4,19 @@ import static com.gdschongik.gdsc.domain.member.domain.Department.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import com.gdschongik.gdsc.domain.recruitment.application.OnboardingRecruitmentService;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
+import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
+import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import com.gdschongik.gdsc.global.security.PrincipalDetails;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -32,6 +38,9 @@ public abstract class IntegrationTest {
 
     @Autowired
     protected RecruitmentRepository recruitmentRepository;
+
+    @Autowired
+    protected RecruitmentRoundRepository recruitmentRoundRepository;
 
     @MockBean
     protected OnboardingRecruitmentService onboardingRecruitmentService;
@@ -60,9 +69,29 @@ public abstract class IntegrationTest {
         return memberRepository.save(member);
     }
 
-    protected Recruitment createRecruitment() {
-        Recruitment recruitment = Recruitment.createRecruitment(
-                NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
-        return recruitmentRepository.save(recruitment);
+    protected RecruitmentRound createRecruitmentRound() {
+        Recruitment recruitment = Recruitment.createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE);
+
+        recruitmentRepository.save(recruitment);
+
+        RecruitmentRound recruitmentRound =
+                RecruitmentRound.create(NAME, START_DATE, END_DATE, recruitment, ROUND_TYPE);
+
+        return recruitmentRoundRepository.save(recruitmentRound);
+    }
+
+    protected RecruitmentRound createRecruitment(
+            String name,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            Integer academicYear,
+            SemesterType semesterType,
+            RoundType roundType,
+            Money fee) {
+        Recruitment recruitment = Recruitment.createRecruitment(academicYear, semesterType, fee);
+        recruitmentRepository.save(recruitment);
+
+        RecruitmentRound recruitmentRound = RecruitmentRound.create(name, startDate, endDate, recruitment, roundType);
+        return recruitmentRoundRepository.save(recruitmentRound);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #426

## 📌 작업 내용 및 특이사항
- Recruitment의 회차 정보를 RecruitmentRound로 분리했습니다. 
네이밍은 일단 `RecruitmentRound`로 해뒀는데 더 적절한 의견있으면 반영하겠습니다.
- 아래의 7가지 기능에 수정이 필요합니다. 
1, 2, 3, 5번은 이번 이슈에서 수정했고, 4, 6번은 아직 없는 기능이라 별도 이슈에서 처리하겠습니다.
   1. 일괄 강등하기
   2. 활동학기 생성하기
   3. 활동학기 조회하기
   4. 모집회차 생성하기
   5. 모집회차 수정하기
   6. 모집회차 조회하기
   7. 멤버십 가입 신청
      -  멤버십이 기존에는 리쿠르팅 id를 가졌지만, 이제는 모집회차를 가지므로 수정이 발생합니다.

## 📝 참고사항
- `AdminMemberServiceTest`에서는 createRecruitment 메서드를 IntegrationTest에 있는 메서드로 대체했습니다.
- service외에는 대체로 네이밍 변경입니다.

## 📚 기타
- pr을 이렇게 크게 만들고 싶지 않았는데, 끊어서 작업하기 어려운 부분이라 양해부탁드립니다..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - `RecruitmentRound` 엔티티 추가로 모집 라운드 기능 도입.

- **버그 수정**
  - 모집 라운드 관련 오류 메시지 추가 (`RECRUITMENT_OVERLAP`, `RECRUITMENT_ROUND_NOT_OPEN`, `RECRUITMENT_ROUND_NOT_FOUND`).

- **리팩토링**
  - `Recruitment`에서 `RecruitmentRound`로 변경된 필드 및 메서드 시그니처.

- **테스트**
  - 테스트 코드에서 `Recruitment`를 `RecruitmentRound`로 수정.
  - `createRecruitmentRound` 메서드 추가 및 관련 테스트 케이스 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->