### PR TITLE
feat: 임시 주문 생성 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // Querydsl
-    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
@@ -33,7 +33,7 @@ public class Coupon extends BaseTimeEntity {
     private Money discountAmount;
 
     @Builder(access = AccessLevel.PRIVATE)
-    public Coupon(String name, Money discountAmount) {
+    private Coupon(String name, Money discountAmount) {
         this.name = name;
         this.discountAmount = discountAmount;
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
@@ -61,7 +61,7 @@ public class IssuedCoupon extends BaseTimeEntity {
 
     // 검증 로직
 
-    private void validateUsable() {
+    public void validateUsable() {
         if (isRevoked.equals(TRUE)) {
             throw new CustomException(COUPON_NOT_USABLE_REVOKED);
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -288,6 +288,10 @@ public class Member extends BaseTimeEntity {
 
     // 데이터 전달 로직
 
+    public boolean isAssociate() {
+        return role.equals(ASSOCIATE);
+    }
+
     public boolean isRegular() {
         return role.equals(REGULAR);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
@@ -73,6 +73,7 @@ public class Membership extends BaseSemesterEntity {
     // 검증 로직
 
     // TODO validateRegularRequirement처럼 로직 변경
+    // TODO: 어드민인 경우 리쿠르팅 지원 및 결제에 대한 정책 검토 필요. 현재는 불가능하도록 설정
     private static void validateMembershipApplicable(Member member) {
         if (member.getRole().equals(MemberRole.ASSOCIATE)) {
             return;

--- a/src/main/java/com/gdschongik/gdsc/domain/order/api/OnboardingOrderController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/api/OnboardingOrderController.java
@@ -1,0 +1,29 @@
+package com.gdschongik.gdsc.domain.order.api;
+
+import com.gdschongik.gdsc.domain.order.application.OrderService;
+import com.gdschongik.gdsc.domain.order.dto.request.OrderCreateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Onboarding Order", description = "주문 온보딩 API입니다.")
+@RestController
+@RequestMapping("/onboarding/orders")
+@RequiredArgsConstructor
+public class OnboardingOrderController {
+
+    private final OrderService orderService;
+
+    @Operation(summary = "임시 주문 생성", description = "임시 주문을 생성합니다.")
+    @PostMapping
+    public ResponseEntity<Void> createPendingOrder(@Valid @RequestBody OrderCreateRequest request) {
+        orderService.createPendingOrder(request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
@@ -10,6 +10,8 @@ import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.order.dao.OrderRepository;
 import com.gdschongik.gdsc.domain.order.domain.Order;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCreateRequest;
+import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderService {
 
     private final OrderRepository orderRepository;
+    private final RecruitmentRepository recruitmentRepository;
     private final IssuedCouponRepository issuedCouponRepository;
     private final MemberRepository memberRepository;
 
@@ -31,13 +34,18 @@ public class OrderService {
         Member member =
                 memberRepository.findById(request.memberId()).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 
+        Recruitment recruitment = recruitmentRepository
+                .findById(request.recruitmentId())
+                .orElseThrow(() -> new CustomException(RECRUITMENT_NOT_FOUND));
+
         IssuedCoupon issuedCoupon = issuedCouponRepository
                 .findById(request.issuedCouponId())
                 .orElseThrow(() -> new CustomException(ISSUED_COUPON_NOT_FOUND));
 
         Order order = Order.createPending(
-                request.nanoId(),
+                request.orderNanoId(),
                 member,
+                recruitment,
                 issuedCoupon,
                 Money.from(request.totalAmount()),
                 Money.from(request.discountAmount()),

--- a/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
@@ -33,7 +33,6 @@ public class OrderService {
 
     @Transactional
     public void createPendingOrder(OrderCreateRequest request) {
-
         Membership membership = membershipRepository
                 .findById(request.membershipId())
                 .orElseThrow(() -> new CustomException(MEMBERSHIP_NOT_FOUND));

--- a/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
@@ -1,0 +1,50 @@
+package com.gdschongik.gdsc.domain.order.application;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.coupon.dao.IssuedCouponRepository;
+import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
+import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.order.dao.OrderRepository;
+import com.gdschongik.gdsc.domain.order.domain.Order;
+import com.gdschongik.gdsc.domain.order.dto.request.OrderCreateRequest;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final IssuedCouponRepository issuedCouponRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void createPendingOrder(OrderCreateRequest request) {
+
+        Member member =
+                memberRepository.findById(request.memberId()).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+        IssuedCoupon issuedCoupon = issuedCouponRepository
+                .findById(request.issuedCouponId())
+                .orElseThrow(() -> new CustomException(ISSUED_COUPON_NOT_FOUND));
+
+        Order order = Order.createPending(
+                request.nanoId(),
+                member,
+                issuedCoupon,
+                Money.from(request.totalAmount()),
+                Money.from(request.discountAmount()),
+                Money.from(request.finalPaymentAmount()));
+
+        orderRepository.save(order);
+
+        log.info("[OrderService] 임시 주문 생성: orderId={}", order.getId());
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
@@ -5,14 +5,16 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.coupon.dao.IssuedCouponRepository;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
-import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.membership.dao.MembershipRepository;
+import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.order.dao.OrderRepository;
+import com.gdschongik.gdsc.domain.order.domain.MoneyInfo;
 import com.gdschongik.gdsc.domain.order.domain.Order;
+import com.gdschongik.gdsc.domain.order.domain.OrderValidator;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCreateRequest;
-import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,36 +25,40 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OrderService {
 
+    private final MemberUtil memberUtil;
     private final OrderRepository orderRepository;
-    private final RecruitmentRepository recruitmentRepository;
+    private final MembershipRepository membershipRepository;
     private final IssuedCouponRepository issuedCouponRepository;
-    private final MemberRepository memberRepository;
+    private final OrderValidator orderValidator;
 
     @Transactional
     public void createPendingOrder(OrderCreateRequest request) {
 
-        Member member =
-                memberRepository.findById(request.memberId()).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+        Membership membership = membershipRepository
+                .findById(request.membershipId())
+                .orElseThrow(() -> new CustomException(MEMBERSHIP_NOT_FOUND));
 
-        Recruitment recruitment = recruitmentRepository
-                .findById(request.recruitmentId())
-                .orElseThrow(() -> new CustomException(RECRUITMENT_NOT_FOUND));
+        IssuedCoupon issuedCoupon = request.issuedCouponId() == null ? null : getIssuedCoupon(request.issuedCouponId());
 
-        IssuedCoupon issuedCoupon = issuedCouponRepository
-                .findById(request.issuedCouponId())
-                .orElseThrow(() -> new CustomException(ISSUED_COUPON_NOT_FOUND));
-
-        Order order = Order.createPending(
-                request.orderNanoId(),
-                member,
-                recruitment,
-                issuedCoupon,
+        MoneyInfo moneyInfo = MoneyInfo.of(
                 Money.from(request.totalAmount()),
                 Money.from(request.discountAmount()),
                 Money.from(request.finalPaymentAmount()));
 
+        Member currentMember = memberUtil.getCurrentMember();
+
+        orderValidator.validatePendingOrderCreate(membership, issuedCoupon, moneyInfo, currentMember);
+
+        Order order = Order.createPending(request.orderNanoId(), membership, issuedCoupon, moneyInfo);
+
         orderRepository.save(order);
 
         log.info("[OrderService] 임시 주문 생성: orderId={}", order.getId());
+    }
+
+    private IssuedCoupon getIssuedCoupon(Long issuedCouponId) {
+        return issuedCouponRepository
+                .findById(issuedCouponId)
+                .orElseThrow(() -> new CustomException(ISSUED_COUPON_NOT_FOUND));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderRepository.java
@@ -1,0 +1,6 @@
+package com.gdschongik.gdsc.domain.order.dao;
+
+import com.gdschongik.gdsc.domain.order.domain.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/MoneyInfo.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/MoneyInfo.java
@@ -1,0 +1,56 @@
+package com.gdschongik.gdsc.domain.order.domain;
+
+import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.exception.ErrorCode;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MoneyInfo {
+
+    @Comment("주문총액")
+    @Embedded
+    private Money totalAmount;
+
+    @Comment("쿠폰할인금액")
+    @Embedded
+    private Money discountAmount;
+
+    @Comment("최종결제금액")
+    @Embedded
+    private Money finalPaymentAmount;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private MoneyInfo(Money totalAmount, Money discountAmount, Money finalPaymentAmount) {
+        this.totalAmount = totalAmount;
+        this.discountAmount = discountAmount;
+        this.finalPaymentAmount = finalPaymentAmount;
+    }
+
+    public static MoneyInfo of(Money totalAmount, Money discountAmount, Money finalPaymentAmount) {
+        validateFinalPaymentAmount(totalAmount, discountAmount, finalPaymentAmount);
+
+        return MoneyInfo.builder()
+                .totalAmount(totalAmount)
+                .discountAmount(discountAmount)
+                .finalPaymentAmount(finalPaymentAmount)
+                .build();
+    }
+
+    private static void validateFinalPaymentAmount(Money totalAmount, Money discountAmount, Money finalPaymentAmount) {
+        Money expectedFinalPaymentAmount = totalAmount.subtract(discountAmount);
+        if (!finalPaymentAmount.equals(expectedFinalPaymentAmount)) {
+            throw new CustomException(ErrorCode.ORDER_FINAL_PAYMENT_AMOUNT_MISMATCH);
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/MoneyInfo.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/MoneyInfo.java
@@ -3,6 +3,8 @@ package com.gdschongik.gdsc.domain.order.domain;
 import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
 import lombok.AccessLevel;
@@ -20,14 +22,17 @@ public class MoneyInfo {
 
     @Comment("주문총액")
     @Embedded
+    @AttributeOverride(name = "amount", column = @Column(name = "total_amount"))
     private Money totalAmount;
 
     @Comment("쿠폰할인금액")
     @Embedded
+    @AttributeOverride(name = "amount", column = @Column(name = "discount_amount"))
     private Money discountAmount;
 
     @Comment("최종결제금액")
     @Embedded
+    @AttributeOverride(name = "amount", column = @Column(name = "final_payment_amount"))
     private Money finalPaymentAmount;
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
@@ -4,6 +4,7 @@ import com.gdschongik.gdsc.domain.common.model.BaseTimeEntity;
 import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -39,6 +40,9 @@ public class Order extends BaseTimeEntity {
     @Comment("주문자 ID")
     private Long memberId;
 
+    @Comment("신청하려는 리쿠르팅 ID")
+    private Long recruitmentId;
+
     @Comment("사용한 발급쿠폰 ID")
     private Long issuedCouponId;
 
@@ -59,6 +63,7 @@ public class Order extends BaseTimeEntity {
             OrderStatus status,
             String nanoId,
             Long memberId,
+            Long recruitmentId,
             Long issuedCouponId,
             Money totalAmount,
             Money discountAmount,
@@ -66,6 +71,7 @@ public class Order extends BaseTimeEntity {
         this.status = status;
         this.nanoId = nanoId;
         this.memberId = memberId;
+        this.recruitmentId = recruitmentId;
         this.issuedCouponId = issuedCouponId;
         this.totalAmount = totalAmount;
         this.discountAmount = discountAmount;
@@ -78,6 +84,7 @@ public class Order extends BaseTimeEntity {
     public static Order createPending(
             String nanoId,
             Member member,
+            Recruitment recruitment,
             IssuedCoupon issuedCoupon,
             Money totalAmount,
             Money discountAmount,
@@ -86,6 +93,7 @@ public class Order extends BaseTimeEntity {
                 .status(OrderStatus.PENDING)
                 .nanoId(nanoId)
                 .memberId(member.getId())
+                .recruitmentId(recruitment.getId())
                 .issuedCouponId(issuedCoupon.getId())
                 .totalAmount(totalAmount)
                 .discountAmount(discountAmount)

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
@@ -1,0 +1,53 @@
+package com.gdschongik.gdsc.domain.order.domain;
+
+import com.gdschongik.gdsc.domain.common.model.BaseTimeEntity;
+import com.gdschongik.gdsc.domain.common.vo.Money;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_id")
+    private Long id;
+
+    @Comment("주문상태")
+    @Enumerated(EnumType.STRING)
+    private OrderStatus status;
+
+    @Comment("주문 nanoId")
+    @Column(unique = true, length = 21)
+    private String nanoId;
+
+    @Comment("주문자 ID")
+    private Long memberId;
+
+    @Comment("사용한 발급쿠폰 ID")
+    private Long issuedCouponId;
+
+    @Comment("주문총액")
+    @Embedded
+    private Money totalAmount;
+
+    @Comment("쿠폰할인금액")
+    @Embedded
+    private Money discountAmount;
+
+    @Comment("최종결제금액")
+    @Embedded
+    private Money finalPaymentAmount;
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
@@ -1,10 +1,9 @@
 package com.gdschongik.gdsc.domain.order.domain;
 
 import com.gdschongik.gdsc.domain.common.model.BaseTimeEntity;
-import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
-import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.membership.domain.Membership;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -40,64 +39,50 @@ public class Order extends BaseTimeEntity {
     @Comment("주문자 ID")
     private Long memberId;
 
+    @Comment("주문 대상 멤버십 ID")
+    private Long membershipId;
+
     @Comment("신청하려는 리쿠르팅 ID")
     private Long recruitmentId;
 
-    @Comment("사용한 발급쿠폰 ID")
+    @Comment("사용하려는 발급쿠폰 ID")
     private Long issuedCouponId;
 
-    @Comment("주문총액")
     @Embedded
-    private Money totalAmount;
-
-    @Comment("쿠폰할인금액")
-    @Embedded
-    private Money discountAmount;
-
-    @Comment("최종결제금액")
-    @Embedded
-    private Money finalPaymentAmount;
+    private MoneyInfo moneyInfo;
 
     @Builder(access = AccessLevel.PRIVATE)
     private Order(
             OrderStatus status,
             String nanoId,
             Long memberId,
+            Long membershipId,
             Long recruitmentId,
             Long issuedCouponId,
-            Money totalAmount,
-            Money discountAmount,
-            Money finalPaymentAmount) {
+            MoneyInfo moneyInfo) {
         this.status = status;
         this.nanoId = nanoId;
         this.memberId = memberId;
+        this.membershipId = membershipId;
         this.recruitmentId = recruitmentId;
         this.issuedCouponId = issuedCouponId;
-        this.totalAmount = totalAmount;
-        this.discountAmount = discountAmount;
-        this.finalPaymentAmount = finalPaymentAmount;
+        this.moneyInfo = moneyInfo;
     }
 
     /**
      * 결제 요청 전 임시 주문을 생성합니다.
+     * 쿠폰의 경우 사용 여부를 선택할 수 있습니다.
      */
     public static Order createPending(
-            String nanoId,
-            Member member,
-            Recruitment recruitment,
-            IssuedCoupon issuedCoupon,
-            Money totalAmount,
-            Money discountAmount,
-            Money finalPaymentAmount) {
+            String nanoId, Membership membership, @Nullable IssuedCoupon issuedCoupon, MoneyInfo moneyInfo) {
         return Order.builder()
                 .status(OrderStatus.PENDING)
                 .nanoId(nanoId)
-                .memberId(member.getId())
-                .recruitmentId(recruitment.getId())
-                .issuedCouponId(issuedCoupon.getId())
-                .totalAmount(totalAmount)
-                .discountAmount(discountAmount)
-                .finalPaymentAmount(finalPaymentAmount)
+                .memberId(membership.getMember().getId())
+                .membershipId(membership.getId())
+                .recruitmentId(membership.getRecruitment().getId())
+                .issuedCouponId(issuedCoupon != null ? issuedCoupon.getId() : null)
+                .moneyInfo(moneyInfo)
                 .build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
@@ -2,6 +2,8 @@ package com.gdschongik.gdsc.domain.order.domain;
 
 import com.gdschongik.gdsc.domain.common.model.BaseTimeEntity;
 import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
+import com.gdschongik.gdsc.domain.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -11,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
@@ -50,4 +53,43 @@ public class Order extends BaseTimeEntity {
     @Comment("최종결제금액")
     @Embedded
     private Money finalPaymentAmount;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Order(
+            OrderStatus status,
+            String nanoId,
+            Long memberId,
+            Long issuedCouponId,
+            Money totalAmount,
+            Money discountAmount,
+            Money finalPaymentAmount) {
+        this.status = status;
+        this.nanoId = nanoId;
+        this.memberId = memberId;
+        this.issuedCouponId = issuedCouponId;
+        this.totalAmount = totalAmount;
+        this.discountAmount = discountAmount;
+        this.finalPaymentAmount = finalPaymentAmount;
+    }
+
+    /**
+     * 결제 요청 전 임시 주문을 생성합니다.
+     */
+    public static Order createPending(
+            String nanoId,
+            Member member,
+            IssuedCoupon issuedCoupon,
+            Money totalAmount,
+            Money discountAmount,
+            Money finalPaymentAmount) {
+        return Order.builder()
+                .status(OrderStatus.PENDING)
+                .nanoId(nanoId)
+                .memberId(member.getId())
+                .issuedCouponId(issuedCoupon.getId())
+                .totalAmount(totalAmount)
+                .discountAmount(discountAmount)
+                .finalPaymentAmount(finalPaymentAmount)
+                .build();
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.order.domain;
 
-import com.gdschongik.gdsc.domain.common.model.BaseTimeEntity;
+import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import jakarta.annotation.Nullable;
@@ -21,7 +21,7 @@ import org.hibernate.annotations.Comment;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Order extends BaseTimeEntity {
+public class Order extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderStatus.java
@@ -3,5 +3,6 @@ package com.gdschongik.gdsc.domain.order.domain;
 public enum OrderStatus {
     PENDING,
     COMPLETE,
+    CANCELED
     ;
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderStatus.java
@@ -3,6 +3,6 @@ package com.gdschongik.gdsc.domain.order.domain;
 public enum OrderStatus {
     PENDING,
     COMPLETE,
-    CANCELED
+    CANCELED,
     ;
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderStatus.java
@@ -1,0 +1,7 @@
+package com.gdschongik.gdsc.domain.order.domain;
+
+public enum OrderStatus {
+    PENDING,
+    COMPLETE,
+    ;
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderValidator.java
@@ -47,7 +47,7 @@ public class OrderValidator {
         Money totalAmount = moneyInfo.getTotalAmount();
         Money discountAmount = moneyInfo.getDiscountAmount();
 
-        if (totalAmount.equals(recruitment.getFee())) {
+        if (!totalAmount.equals(recruitment.getFee())) {
             throw new CustomException(ORDER_TOTAL_AMOUNT_MISMATCH);
         }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderValidator.java
@@ -33,7 +33,7 @@ public class OrderValidator {
         Recruitment recruitment = membership.getRecruitment();
 
         if (!recruitment.isOpen()) {
-            throw new CustomException(ORDER_RECRUITMENT_CLOSED);
+            throw new CustomException(ORDER_RECRUITMENT_PERIOD_INVALID);
         }
 
         // 발급쿠폰 관련 검증

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderValidator.java
@@ -18,13 +18,6 @@ public class OrderValidator {
     public void validatePendingOrderCreate(
             Membership membership, @Nullable IssuedCoupon issuedCoupon, MoneyInfo moneyInfo, Member currentMember) {
 
-        // 멤버 관련 검증
-
-        // TODO: 어드민인 경우 리쿠르팅 지원 및 결제에 대한 정책 검토 필요. 현재는 불가능하도록 처리
-        if (!currentMember.isAssociate()) {
-            throw new CustomException(ORDER_MEMBER_NOT_ASSOCIATE);
-        }
-
         // 멤버십 관련 검증
 
         if (!membership.getMember().getId().equals(currentMember.getId())) {

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderValidator.java
@@ -1,0 +1,87 @@
+package com.gdschongik.gdsc.domain.order.domain;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.membership.domain.Membership;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import jakarta.annotation.Nullable;
+import java.math.BigDecimal;
+import org.springframework.stereotype.Component;
+
+@Component // 추후 도메인 서비스로 교체
+public class OrderValidator {
+
+    public void validatePendingOrderCreate(
+            Membership membership, @Nullable IssuedCoupon issuedCoupon, MoneyInfo moneyInfo, Member currentMember) {
+
+        // 멤버 관련 검증
+
+        // TODO: 어드민인 경우 리쿠르팅 지원 및 결제에 대한 정책 검토 필요. 현재는 불가능하도록 처리
+        if (!currentMember.isAssociate()) {
+            throw new CustomException(ORDER_MEMBER_NOT_ASSOCIATE);
+        }
+
+        // 멤버십 관련 검증
+
+        if (!membership.getMember().getId().equals(currentMember.getId())) {
+            throw new CustomException(ORDER_MEMBERSHIP_MEMBER_MISMATCH);
+        }
+
+        if (membership.getRegularRequirement().isPaymentSatisfied()) {
+            throw new CustomException(ORDER_MEMBERSHIP_ALREADY_PAID);
+        }
+
+        // 리쿠르팅 관련 검증
+
+        Recruitment recruitment = membership.getRecruitment();
+
+        if (!recruitment.isOpen()) {
+            throw new CustomException(ORDER_RECRUITMENT_CLOSED);
+        }
+
+        // 발급쿠폰 관련 검증
+
+        if (issuedCoupon != null) {
+            validateIssuedCouponOwnership(issuedCoupon, currentMember);
+        }
+
+        // 금액 관련 검증
+
+        Money totalAmount = moneyInfo.getTotalAmount();
+        Money discountAmount = moneyInfo.getDiscountAmount();
+
+        if (totalAmount.equals(recruitment.getFee())) {
+            throw new CustomException(ORDER_TOTAL_AMOUNT_MISMATCH);
+        }
+
+        if (issuedCoupon == null) {
+            validateDiscountAmountZero(discountAmount);
+        } else {
+            validateDiscountAmountMatches(discountAmount, issuedCoupon);
+        }
+    }
+
+    private void validateIssuedCouponOwnership(IssuedCoupon issuedCoupon, Member currentMember) {
+        if (issuedCoupon.getMember().getId().equals(currentMember.getId())) {
+            throw new CustomException(ORDER_ISSUED_COUPON_MEMBER_MISMATCH);
+        }
+
+        issuedCoupon.validateUsable();
+    }
+
+    private void validateDiscountAmountZero(Money discountAmount) {
+        if (!discountAmount.equals(Money.from(BigDecimal.ZERO))) {
+            throw new CustomException(ORDER_DISCOUNT_AMOUNT_NOT_ZERO);
+        }
+    }
+
+    private void validateDiscountAmountMatches(Money discountAmount, IssuedCoupon issuedCoupon) {
+        if (!discountAmount.equals(issuedCoupon.getCoupon().getDiscountAmount())) {
+            throw new CustomException(ORDER_DISCOUNT_AMOUNT_MISMATCH);
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderValidator.java
@@ -59,7 +59,7 @@ public class OrderValidator {
     }
 
     private void validateIssuedCouponOwnership(IssuedCoupon issuedCoupon, Member currentMember) {
-        if (issuedCoupon.getMember().getId().equals(currentMember.getId())) {
+        if (!issuedCoupon.getMember().getId().equals(currentMember.getId())) {
             throw new CustomException(ORDER_ISSUED_COUPON_MEMBER_MISMATCH);
         }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderValidator.java
@@ -40,6 +40,7 @@ public class OrderValidator {
 
         if (issuedCoupon != null) {
             validateIssuedCouponOwnership(issuedCoupon, currentMember);
+            issuedCoupon.validateUsable();
         }
 
         // 금액 관련 검증
@@ -62,8 +63,6 @@ public class OrderValidator {
         if (!issuedCoupon.getMember().getId().equals(currentMember.getId())) {
             throw new CustomException(ORDER_ISSUED_COUPON_MEMBER_MISMATCH);
         }
-
-        issuedCoupon.validateUsable();
     }
 
     private void validateDiscountAmountZero(Money discountAmount) {

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dto/request/OrderCreateRequest.java
@@ -1,0 +1,14 @@
+package com.gdschongik.gdsc.domain.order.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+
+public record OrderCreateRequest(
+        @Size(min = 21, max = 21) String nanoId,
+        @Positive Long memberId,
+        @Positive Long issuedCouponId,
+        @NotNull BigDecimal totalAmount,
+        @NotNull BigDecimal discountAmount,
+        @NotNull BigDecimal finalPaymentAmount) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dto/request/OrderCreateRequest.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.domain.order.dto.request;
 
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
@@ -7,9 +8,8 @@ import java.math.BigDecimal;
 
 public record OrderCreateRequest(
         @Size(min = 21, max = 21) String orderNanoId,
-        @NotNull @Positive Long memberId,
-        @NotNull @Positive Long recruitmentId,
-        @Positive Long issuedCouponId,
+        @NotNull @Positive Long membershipId,
+        @Nullable @Positive Long issuedCouponId,
         @NotNull BigDecimal totalAmount,
         @NotNull BigDecimal discountAmount,
         @NotNull BigDecimal finalPaymentAmount) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dto/request/OrderCreateRequest.java
@@ -6,8 +6,9 @@ import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 
 public record OrderCreateRequest(
-        @Size(min = 21, max = 21) String nanoId,
-        @Positive Long memberId,
+        @Size(min = 21, max = 21) String orderNanoId,
+        @NotNull @Positive Long memberId,
+        @NotNull @Positive Long recruitmentId,
         @Positive Long issuedCouponId,
         @NotNull BigDecimal totalAmount,
         @NotNull BigDecimal discountAmount,

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -92,6 +92,19 @@ public enum ErrorCode {
     COUPON_NOT_REVOKABLE_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용한 쿠폰은 회수할 수 없습니다."),
     COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 쿠폰입니다."),
     ISSUED_COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 발급쿠폰입니다."),
+
+    // Order
+    ORDER_MEMBER_NOT_ASSOCIATE(HttpStatus.CONFLICT, "준회원만 주문할 수 있습니다."),
+    ORDER_MEMBERSHIP_MEMBER_MISMATCH(HttpStatus.CONFLICT, "주문 대상 멤버십의 멤버와 현재 로그인한 멤버가 일치하지 않습니다."),
+    ORDER_MEMBERSHIP_ALREADY_PAID(HttpStatus.CONFLICT, "주문 대상 멤버십의 회비가 이미 납부되었습니다."),
+    ORDER_RECRUITMENT_CLOSED(HttpStatus.CONFLICT, "주문 대상 멤버십의 리크루팅이 종료되었습니다."),
+    ORDER_ISSUED_COUPON_MEMBER_MISMATCH(HttpStatus.CONFLICT, "주문 시 사용할 발급쿠폰의 멤버와 현재 로그인한 멤버가 일치하지 않습니다."),
+    ORDER_TOTAL_AMOUNT_MISMATCH(HttpStatus.CONFLICT, "주문 금액은 리쿠르팅 회비와 일치해야 합니다."),
+    ORDER_DISCOUNT_AMOUNT_NOT_ZERO(HttpStatus.CONFLICT, "쿠폰 미사용시 할인 금액은 0이어야 합니다."),
+    ORDER_DISCOUNT_AMOUNT_MISMATCH(HttpStatus.CONFLICT, "쿠폰 사용시 할인 금액은 쿠폰의 할인 금액과 일치해야 합니다."),
+
+    // Order - MoneyInfo
+    ORDER_FINAL_PAYMENT_AMOUNT_MISMATCH(HttpStatus.CONFLICT, "주문 최종결제금액은 주문총액에서 할인금액을 뺀 값이어야 합니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -94,7 +94,6 @@ public enum ErrorCode {
     ISSUED_COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 발급쿠폰입니다."),
 
     // Order
-    ORDER_MEMBER_NOT_ASSOCIATE(HttpStatus.CONFLICT, "준회원만 주문할 수 있습니다."),
     ORDER_MEMBERSHIP_MEMBER_MISMATCH(HttpStatus.CONFLICT, "주문 대상 멤버십의 멤버와 현재 로그인한 멤버가 일치하지 않습니다."),
     ORDER_MEMBERSHIP_ALREADY_PAID(HttpStatus.CONFLICT, "주문 대상 멤버십의 회비가 이미 납부되었습니다."),
     ORDER_RECRUITMENT_CLOSED(HttpStatus.CONFLICT, "주문 대상 멤버십의 리크루팅이 종료되었습니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -96,7 +96,7 @@ public enum ErrorCode {
     // Order
     ORDER_MEMBERSHIP_MEMBER_MISMATCH(HttpStatus.CONFLICT, "주문 대상 멤버십의 멤버와 현재 로그인한 멤버가 일치하지 않습니다."),
     ORDER_MEMBERSHIP_ALREADY_PAID(HttpStatus.CONFLICT, "주문 대상 멤버십의 회비가 이미 납부되었습니다."),
-    ORDER_RECRUITMENT_CLOSED(HttpStatus.CONFLICT, "주문 대상 멤버십의 리크루팅이 종료되었습니다."),
+    ORDER_RECRUITMENT_PERIOD_INVALID(HttpStatus.CONFLICT, "주문 대상 멤버십의 리크루팅의 지원기간이 아닙니다."),
     ORDER_ISSUED_COUPON_MEMBER_MISMATCH(HttpStatus.CONFLICT, "주문 시 사용할 발급쿠폰의 멤버와 현재 로그인한 멤버가 일치하지 않습니다."),
     ORDER_TOTAL_AMOUNT_MISMATCH(HttpStatus.CONFLICT, "주문 금액은 리쿠르팅 회비와 일치해야 합니다."),
     ORDER_DISCOUNT_AMOUNT_NOT_ZERO(HttpStatus.CONFLICT, "쿠폰 미사용시 할인 금액은 0이어야 합니다."),

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -23,11 +23,6 @@ public class MembershipServiceTest extends IntegrationTest {
     @Autowired
     private MembershipRepository membershipRepository;
 
-    private Membership createMembership(Member member, Recruitment recruitment) {
-        Membership membership = Membership.createMembership(member, recruitment);
-        return membershipRepository.save(membership);
-    }
-
     @Nested
     class 멤버십_가입신청시 {
         @Test

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -1,0 +1,61 @@
+package com.gdschongik.gdsc.domain.order.application;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.domain.membership.domain.Membership;
+import com.gdschongik.gdsc.domain.order.dao.OrderRepository;
+import com.gdschongik.gdsc.domain.order.dto.request.OrderCreateRequest;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.helper.IntegrationTest;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class OrderServiceTest extends IntegrationTest {
+
+    public static final Money MONEY_20000_WON = Money.from(BigDecimal.valueOf(20000));
+    public static final Money MONEY_15000_WON = Money.from(BigDecimal.valueOf(15000));
+    public static final Money MONEY_10000_WON = Money.from(BigDecimal.valueOf(10000));
+    public static final Money MONEY_5000_WON = Money.from(BigDecimal.valueOf(5000));
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Nested
+    class 임시주문_생성할때 {
+
+        @Test
+        void 성공한다() {
+            // given
+            Member member = createMember();
+            logoutAndReloginAs(1L, MemberRole.ASSOCIATE);
+            Recruitment recruitment = createRecruitment(
+                    LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1), MONEY_20000_WON);
+            Membership membership = createMembership(member, recruitment);
+
+            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
+
+            // when
+            var request = new OrderCreateRequest(
+                    "HnbMWoSZRq3qK1W3tPXCW",
+                    membership.getId(),
+                    issuedCoupon.getId(),
+                    BigDecimal.valueOf(20000),
+                    BigDecimal.valueOf(5000),
+                    BigDecimal.valueOf(15000));
+            orderService.createPendingOrder(request);
+
+            // then
+            assertThat(orderRepository.findAll()).hasSize(1);
+        }
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/MoneyInfoTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/MoneyInfoTest.java
@@ -21,9 +21,8 @@ class MoneyInfoTest {
         MoneyInfo moneyInfo = MoneyInfo.of(totalAmount, discountAmount, finalPaymentAmount);
 
         // then
-        assertThat(moneyInfo.getTotalAmount()).isEqualTo(totalAmount);
-        assertThat(moneyInfo.getDiscountAmount()).isEqualTo(discountAmount);
-        assertThat(moneyInfo.getFinalPaymentAmount()).isEqualTo(finalPaymentAmount);
+        Money expectedFinalPaymentAmount = totalAmount.subtract(discountAmount);
+        assertThat(moneyInfo.getFinalPaymentAmount()).isEqualTo(expectedFinalPaymentAmount);
     }
 
     @Test

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/MoneyInfoTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/MoneyInfoTest.java
@@ -1,0 +1,60 @@
+package com.gdschongik.gdsc.domain.order.domain;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+class MoneyInfoTest {
+
+    @Test
+    void 최종결제금액은_주문총액에서_쿠폰할인금액을_뺀_금액이다() {
+        // given
+        Money totalAmount = Money.from(BigDecimal.valueOf(10000));
+        Money discountAmount = Money.from(BigDecimal.valueOf(3000));
+        Money finalPaymentAmount = Money.from(BigDecimal.valueOf(7000));
+
+        // when
+        MoneyInfo moneyInfo = MoneyInfo.of(totalAmount, discountAmount, finalPaymentAmount);
+
+        // then
+        assertThat(moneyInfo.getTotalAmount()).isEqualTo(totalAmount);
+        assertThat(moneyInfo.getDiscountAmount()).isEqualTo(discountAmount);
+        assertThat(moneyInfo.getFinalPaymentAmount()).isEqualTo(finalPaymentAmount);
+    }
+
+    @Test
+    void 최종결제금액이_주문총액에서_쿠폰할인금액을_뺀_금액과_다르면_실패한다() {
+        // given
+        Money totalAmount = Money.from(BigDecimal.valueOf(10000));
+        Money discountAmount = Money.from(BigDecimal.valueOf(3000));
+        Money finalPaymentAmount = Money.from(BigDecimal.valueOf(8000));
+
+        // when & then
+        assertThatThrownBy(() -> MoneyInfo.of(totalAmount, discountAmount, finalPaymentAmount))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ORDER_FINAL_PAYMENT_AMOUNT_MISMATCH.getMessage());
+    }
+
+    @Test
+    void 모든_금액이_같으면_같은_객체이다() {
+        // given
+        Money totalAmount1 = Money.from(BigDecimal.valueOf(10000));
+        Money discountAmount1 = Money.from(BigDecimal.valueOf(3000));
+        Money finalPaymentAmount1 = Money.from(BigDecimal.valueOf(7000));
+
+        Money totalAmount2 = Money.from(BigDecimal.valueOf(10000));
+        Money discountAmount2 = Money.from(BigDecimal.valueOf(3000));
+        Money finalPaymentAmount2 = Money.from(BigDecimal.valueOf(7000));
+
+        // when
+        MoneyInfo moneyInfo1 = MoneyInfo.of(totalAmount1, discountAmount1, finalPaymentAmount1);
+        MoneyInfo moneyInfo2 = MoneyInfo.of(totalAmount2, discountAmount2, finalPaymentAmount2);
+
+        // then
+        assertThat(moneyInfo1).isEqualTo(moneyInfo2);
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
@@ -1,0 +1,43 @@
+package com.gdschongik.gdsc.domain.order.domain;
+
+import static com.gdschongik.gdsc.domain.member.domain.Department.*;
+import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.membership.domain.Membership;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
+import java.time.LocalDateTime;
+
+class OrderValidatorTest {
+
+    OrderValidator orderValidator = new OrderValidator();
+
+    private Member createAssociateMember() {
+        Member member = Member.createGuestMember(OAUTH_ID);
+        member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
+        member.completeUnivEmailVerification(UNIV_EMAIL);
+        member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
+        member.verifyBevy();
+        member.advanceToAssociate();
+        return member;
+    }
+
+    private Recruitment createRecruitment(
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            Integer academicYear,
+            SemesterType semesterType,
+            Money fee) {
+        return Recruitment.createRecruitment(
+                RECRUITMENT_NAME, startDate, endDate, academicYear, semesterType, RoundType.FIRST, fee);
+    }
+
+    private Membership createMembership(Member member, Recruitment recruitment) {
+        return Membership.createMembership(member, recruitment);
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
@@ -1,29 +1,43 @@
 package com.gdschongik.gdsc.domain.order.domain;
 
 import static com.gdschongik.gdsc.domain.member.domain.Department.*;
+import static com.gdschongik.gdsc.domain.member.domain.Member.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.coupon.domain.Coupon;
+import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 class OrderValidatorTest {
 
+    public static final Money MONEY_5000_WON = Money.from(BigDecimal.valueOf(5000));
+    public static final Money MONEY_10000_WON = Money.from(BigDecimal.valueOf(10000));
+    public static final Money MONEY_15000_WON = Money.from(BigDecimal.valueOf(15000));
+    public static final Money MONEY_20000_WON = Money.from(BigDecimal.valueOf(20000));
+
     OrderValidator orderValidator = new OrderValidator();
 
-    private Member createAssociateMember() {
-        Member member = Member.createGuestMember(OAUTH_ID);
+    private Member createAssociateMember(Long id) {
+        Member member = createGuestMember(OAUTH_ID);
         member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
         member.completeUnivEmailVerification(UNIV_EMAIL);
         member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
         member.verifyBevy();
         member.advanceToAssociate();
+        ReflectionTestUtils.setField(member, "id", id);
         return member;
     }
 
@@ -39,5 +53,226 @@ class OrderValidatorTest {
 
     private Membership createMembership(Member member, Recruitment recruitment) {
         return Membership.createMembership(member, recruitment);
+    }
+
+    private IssuedCoupon createAndIssue(Money money, Member member) {
+        Coupon coupon = Coupon.createCoupon("테스트쿠폰", money);
+        return IssuedCoupon.issue(coupon, member);
+    }
+
+    @Test
+    void 멤버십_대상_멤버와_현재_로그인한_멤버_다르면_주문생성에_실패한다() {
+        // given
+        Member currentMember = createAssociateMember(1L);
+
+        Recruitment recruitment = createRecruitment(
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(1),
+                2024,
+                SemesterType.FIRST,
+                MONEY_20000_WON);
+
+        Member anotherMember = createAssociateMember(2L);
+        Membership membership = createMembership(anotherMember, recruitment);
+
+        IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
+
+        // when & then
+        MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+        assertThatThrownBy(() ->
+                        orderValidator.validatePendingOrderCreate(membership, issuedCoupon, moneyInfo, currentMember))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ORDER_MEMBERSHIP_MEMBER_MISMATCH.getMessage());
+    }
+
+    @Test
+    void 멤버십_회비납부상태_이미_충족되었으면_주문생성에_실패한다() {
+        // given
+        Member currentMember = createAssociateMember(1L);
+
+        Recruitment recruitment = createRecruitment(
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(1),
+                2024,
+                SemesterType.FIRST,
+                MONEY_20000_WON);
+
+        Membership membership = createMembership(currentMember, recruitment);
+        membership.verifyPaymentStatus();
+
+        IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
+
+        // when & then
+        MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+        assertThatThrownBy(() ->
+                        orderValidator.validatePendingOrderCreate(membership, issuedCoupon, moneyInfo, currentMember))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ORDER_MEMBERSHIP_ALREADY_PAID.getMessage());
+    }
+
+    @Test
+    void 리크루팅_모집기간이_아니면_주문생성에_실패한다() {
+        // given
+        Member currentMember = createAssociateMember(1L);
+
+        LocalDateTime invalidStartDate = LocalDateTime.now().minusDays(2);
+        LocalDateTime invalidaEndDate = LocalDateTime.now().minusDays(1);
+        Recruitment recruitment =
+                createRecruitment(invalidStartDate, invalidaEndDate, 2024, SemesterType.FIRST, MONEY_20000_WON);
+
+        Membership membership = createMembership(currentMember, recruitment);
+
+        IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
+
+        // when & then
+        MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+        assertThatThrownBy(() ->
+                        orderValidator.validatePendingOrderCreate(membership, issuedCoupon, moneyInfo, currentMember))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ORDER_RECRUITMENT_PERIOD_INVALID.getMessage());
+    }
+
+    @Test
+    void 쿠폰_발급대상_멤버와_현재_로그인한_멤버_다르면_주문생성에_실패한다() {
+        // given
+        Member currentMember = createAssociateMember(1L);
+
+        Recruitment recruitment = createRecruitment(
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(1),
+                2024,
+                SemesterType.FIRST,
+                MONEY_20000_WON);
+
+        Membership membership = createMembership(currentMember, recruitment);
+
+        Member anotherMember = createAssociateMember(2L);
+        IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, anotherMember);
+
+        // when & then
+        MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+        assertThatThrownBy(() ->
+                        orderValidator.validatePendingOrderCreate(membership, issuedCoupon, moneyInfo, currentMember))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ORDER_ISSUED_COUPON_MEMBER_MISMATCH.getMessage());
+    }
+
+    @Test
+    void 회수된_발급쿠폰이면_주문생성에_실패한다() {
+        // given
+        Member currentMember = createAssociateMember(1L);
+
+        Recruitment recruitment = createRecruitment(
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(1),
+                2024,
+                SemesterType.FIRST,
+                MONEY_20000_WON);
+
+        Membership membership = createMembership(currentMember, recruitment);
+
+        IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
+        issuedCoupon.revoke();
+
+        // when & then
+        MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+        assertThatThrownBy(() ->
+                        orderValidator.validatePendingOrderCreate(membership, issuedCoupon, moneyInfo, currentMember))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(COUPON_NOT_USABLE_REVOKED.getMessage());
+    }
+
+    @Test
+    void 사용한_발급쿠폰이면_주문생성에_실패한다() {
+        // given
+        Member currentMember = createAssociateMember(1L);
+
+        Recruitment recruitment = createRecruitment(
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(1),
+                2024,
+                SemesterType.FIRST,
+                MONEY_20000_WON);
+
+        Membership membership = createMembership(currentMember, recruitment);
+
+        IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
+        issuedCoupon.use();
+
+        // when & then
+        MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+        assertThatThrownBy(() ->
+                        orderValidator.validatePendingOrderCreate(membership, issuedCoupon, moneyInfo, currentMember))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(COUPON_NOT_USABLE_ALREADY_USED.getMessage());
+    }
+
+    @Test
+    void 주문총액이_리크루팅_회비와_다르면_주문생성에_실패한다() {
+        // given
+        Member currentMember = createAssociateMember(1L);
+
+        Recruitment recruitment = createRecruitment(
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(1),
+                2024,
+                SemesterType.FIRST,
+                MONEY_15000_WON);
+
+        Membership membership = createMembership(currentMember, recruitment);
+
+        IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
+
+        // when & then
+        MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+        assertThatThrownBy(() ->
+                        orderValidator.validatePendingOrderCreate(membership, issuedCoupon, moneyInfo, currentMember))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ORDER_TOTAL_AMOUNT_MISMATCH.getMessage());
+    }
+
+    @Test
+    void 쿠폰_미사용시_할인금액이_0이_아니면_주문생성에_실패한다() {
+        // given
+        Member currentMember = createAssociateMember(1L);
+
+        Recruitment recruitment = createRecruitment(
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(1),
+                2024,
+                SemesterType.FIRST,
+                MONEY_20000_WON);
+
+        Membership membership = createMembership(currentMember, recruitment);
+
+        // when & then
+        MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+        assertThatThrownBy(() -> orderValidator.validatePendingOrderCreate(membership, null, moneyInfo, currentMember))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ORDER_DISCOUNT_AMOUNT_NOT_ZERO.getMessage());
+    }
+
+    @Test
+    void 쿠폰_사용시_할인금액이_쿠폰의_할인금액과_다르면_주문생성에_실패한다() {
+        // given
+        Member currentMember = createAssociateMember(1L);
+
+        Recruitment recruitment = createRecruitment(
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(1),
+                2024,
+                SemesterType.FIRST,
+                MONEY_20000_WON);
+
+        Membership membership = createMembership(currentMember, recruitment);
+
+        IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
+
+        // when & then
+        MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_10000_WON, MONEY_10000_WON);
+        assertThatThrownBy(() ->
+                        orderValidator.validatePendingOrderCreate(membership, issuedCoupon, moneyInfo, currentMember))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ORDER_DISCOUNT_AMOUNT_MISMATCH.getMessage());
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
@@ -116,9 +116,9 @@ class OrderValidatorTest {
         Member currentMember = createAssociateMember(1L);
 
         LocalDateTime invalidStartDate = LocalDateTime.now().minusDays(2);
-        LocalDateTime invalidaEndDate = LocalDateTime.now().minusDays(1);
+        LocalDateTime invalidEndDate = LocalDateTime.now().minusDays(1);
         Recruitment recruitment =
-                createRecruitment(invalidStartDate, invalidaEndDate, 2024, SemesterType.FIRST, MONEY_20000_WON);
+                createRecruitment(invalidStartDate, invalidEndDate, 2024, SemesterType.FIRST, MONEY_20000_WON);
 
         Membership membership = createMembership(currentMember, recruitment);
 

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -5,6 +5,10 @@ import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 
 import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.coupon.dao.CouponRepository;
+import com.gdschongik.gdsc.domain.coupon.dao.IssuedCouponRepository;
+import com.gdschongik.gdsc.domain.coupon.domain.Coupon;
+import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
@@ -39,6 +43,12 @@ public abstract class IntegrationTest {
 
     @Autowired
     protected MembershipRepository membershipRepository;
+
+    @Autowired
+    protected CouponRepository couponRepository;
+
+    @Autowired
+    protected IssuedCouponRepository issuedCouponRepository;
 
     @MockBean
     protected OnboardingRecruitmentService onboardingRecruitmentService;
@@ -82,5 +92,12 @@ public abstract class IntegrationTest {
     protected Membership createMembership(Member member, Recruitment recruitment) {
         Membership membership = Membership.createMembership(member, recruitment);
         return membershipRepository.save(membership);
+    }
+
+    protected IssuedCoupon createAndIssue(Money money, Member member) {
+        Coupon coupon = Coupon.createCoupon("테스트쿠폰", money);
+        couponRepository.save(coupon);
+        IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
+        return issuedCouponRepository.save(issuedCoupon);
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -4,13 +4,17 @@ import static com.gdschongik.gdsc.domain.member.domain.Department.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.domain.membership.dao.MembershipRepository;
+import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.recruitment.application.OnboardingRecruitmentService;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.global.security.PrincipalDetails;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -32,6 +36,9 @@ public abstract class IntegrationTest {
 
     @Autowired
     protected RecruitmentRepository recruitmentRepository;
+
+    @Autowired
+    protected MembershipRepository membershipRepository;
 
     @MockBean
     protected OnboardingRecruitmentService onboardingRecruitmentService;
@@ -64,5 +71,16 @@ public abstract class IntegrationTest {
         Recruitment recruitment = Recruitment.createRecruitment(
                 NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
         return recruitmentRepository.save(recruitment);
+    }
+
+    protected Recruitment createRecruitment(LocalDateTime startDate, LocalDateTime endDate, Money fee) {
+        Recruitment recruitment =
+                Recruitment.createRecruitment(NAME, startDate, endDate, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, fee);
+        return recruitmentRepository.save(recruitment);
+    }
+
+    protected Membership createMembership(Member member, Recruitment recruitment) {
+        Membership membership = Membership.createMembership(member, recruitment);
+        return membershipRepository.save(membership);
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: "test"
 
   datasource:
-    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL;NON_KEYWORDS=YEAR
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL;NON_KEYWORDS=YEAR,ORDER
 
 discord:
   enabled: false


### PR DESCRIPTION
## 🌱 관련 이슈
- close #343

## 📌 작업 내용 및 특이사항
### 결제 플로우에 대한 간단한 설명
- 클라이언트는 결제를 요청하기 전에 임시 주문 생성
- 이런저런 절차 거쳐서 결제 성공하면 서버로 결제 성공 요청을 보냄
- 그러면 서버는 토스페이먼츠 서버로 결제 승인 요청을 보내고, 아까 전에 만들어둔 임시 주문을 성공 처리함

### 주문 엔티티 구현
- 일단 주문에 사용되는 연관 엔티티의 ID 정보 및 금액정보만 저장 -> 추후 토스페이먼츠 측에서 전달하는 정보 저장할 예정
- 발급쿠폰의 경우 사용할 수도, 사용하지 않을 수도 있음
- 금액정보의 경우 `MoneyInfo` VO로 관리 -> `주문총액 - 쿠폰할인금액 = 최종결제금액` 불변식 지키기 위함 (테스트 참고)

### 임시 주문 발급 로직 설명
- 요청으로는 1) 주문 nano id 2) 회비납입상태를 갱신하고자 하는 멤버십 id 3) (있는 경우) 사용하려는 발급쿠폰 id 4) 클라이언트에서 사용자에게 디스플레이한 금액 정보를 받는다
- 발급쿠폰 id가 요청 바디에 담겼다면 조회, 아니라면 null
- 관련 엔티티를 조회하고, VO를 생성한 다음, 도메인 서비스에 해당하는 `OrderValidator` 에게 결제 유효성 검증 요청

### 도메인 서비스 `OrderValidator`
- 주문 검증기는 아래와 같은 도메인 규칙을 검증함
    1. 멤버십의 대상 멤버가 현재 로그인한 멤버와 일치하는가?
    2. 멤버십의 정회원 승급조건 중 회비납입상태를 아직 충족하지 못했는가?
    3. 멤버십이 참조하는 리쿠르팅이, 현재 지원 가능한 리쿠르팅인가?
    4. (발급쿠폰이 있다면) 발급쿠폰의 소유자가 현재 로그인한 멤버와 일치하는가?
    5. (발급쿠폰이 있다면) 발급쿠폰이 사용 가능한가? (== 회수되지 않았고, 사용되지 않았는가?)
    6. 주문총액이 현재 멤버십의 리쿠르팅의 회비와 일치하는가?
    7. (발급쿠폰이 없다면) 쿠폰할인금액은 0인가?
    8. (발급쿠폰이 있다면) 쿠폰할인금액은 쿠폰의 할인금액과 일치하는가?
- 멤버가 준회원인지 검증 안하는 이유 -> 멤버십 생성하려면 준회원이어야 하기 때문에 필요없음 

## 📝 참고사항
- `OrderValidator` 는 도메인 서비스에 해당하며, 추후 `@Component` 대신 wrapping된 별도 어노테이션으로 변경할 예정
- 어드민도 멤버십 신청 / 회비 납입이 가능하게 해야 하는가? -> 장기적으로는 멤버십 테이블에 기록되면 활동내역이 증빙되므로, 가능하게 하는 게 좋을 것 같음.
- 검증기의 경우 예외 상황에 대한 테스트를 주로 수행하고, 통합 테스트에서는 임시 주문이 정상 생성되는지만 테스트했음

## 📚 기타
-
