### PR TITLE
refactor: StudyHistory 엔티티 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.study.domain;
 
-import com.gdschongik.gdsc.domain.common.model.BaseSemesterEntity;
+import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class StudyHistory extends BaseSemesterEntity {
+public class StudyHistory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -26,7 +26,7 @@ public class StudyHistory extends BaseSemesterEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
-    private Member mentor;
+    private Member mentee;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "study_id")


### PR DESCRIPTION
## 🌱 관련 이슈
- close #450

## 📌 작업 내용 및 특이사항
- StudyHistory에 들어가는 Member는 멘토가 아닌 수강자이므로 `mentee`로 수정했습니다.
- Study에 학년도와 학기 정보가 있고, StudyHistory에서는 이 정보들을 쓸 일이 많지 않을 것 같아서 BaseSemesterEntity를 BaseEntity로 변경했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- `StudyHistory` 클래스에서 `mentor` 필드를 `mentee`로 변경하여 정확한 역할을 반영합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->