### PR TITLE
fix: 진행중인 모집회차가 없을 경우 `CustomException` 발생하도록 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/OnboardingRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/OnboardingRecruitmentService.java
@@ -2,6 +2,8 @@ package com.gdschongik.gdsc.domain.recruitment.application;
 
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +20,6 @@ public class OnboardingRecruitmentService {
         return recruitmentRoundRepository.findAll().stream()
                 .filter(RecruitmentRound::isOpen) // isOpen -> isDisplayable
                 .findFirst()
-                .orElseThrow();
+                .orElseThrow(() -> new CustomException(ErrorCode.OPEN_RECRUITMENT_ROUND_NOT_FOUND));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/OnboardingRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/OnboardingRecruitmentService.java
@@ -20,6 +20,6 @@ public class OnboardingRecruitmentService {
         return recruitmentRoundRepository.findAll().stream()
                 .filter(RecruitmentRound::isOpen) // isOpen -> isDisplayable
                 .findFirst()
-                .orElseThrow(() -> new CustomException(ErrorCode.OPEN_RECRUITMENT_ROUND_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_ROUND_OPEN_NOT_FOUND));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -86,6 +86,7 @@ public enum ErrorCode {
     RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일이 학기 시작일로부터 2주 이내에 있지 않습니다."),
     RECRUITMENT_ROUND_TYPE_OVERLAP(HttpStatus.BAD_REQUEST, "모집 차수가 중복됩니다."),
     RECRUITMENT_ROUND_STARTDATE_ALREADY_PASSED(HttpStatus.BAD_REQUEST, "이미 모집 시작일이 지난 리크루팅 회차입니다."),
+    OPEN_RECRUITMENT_ROUND_NOT_FOUND(HttpStatus.NOT_FOUND, "진행중인 모집회차가 존재하지 않습니다."),
 
     // Coupon
     COUPON_DISCOUNT_AMOUNT_NOT_POSITIVE(HttpStatus.CONFLICT, "쿠폰의 할인 금액은 0보다 커야 합니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -86,7 +86,7 @@ public enum ErrorCode {
     RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일이 학기 시작일로부터 2주 이내에 있지 않습니다."),
     RECRUITMENT_ROUND_TYPE_OVERLAP(HttpStatus.BAD_REQUEST, "모집 차수가 중복됩니다."),
     RECRUITMENT_ROUND_STARTDATE_ALREADY_PASSED(HttpStatus.BAD_REQUEST, "이미 모집 시작일이 지난 리크루팅 회차입니다."),
-    OPEN_RECRUITMENT_ROUND_NOT_FOUND(HttpStatus.NOT_FOUND, "진행중인 모집회차가 존재하지 않습니다."),
+    RECRUITMENT_ROUND_OPEN_NOT_FOUND(HttpStatus.NOT_FOUND, "진행중인 모집회차가 존재하지 않습니다."),
 
     // Coupon
     COUPON_DISCOUNT_AMOUNT_NOT_POSITIVE(HttpStatus.CONFLICT, "쿠폰의 할인 금액은 0보다 커야 합니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #459

## 📌 작업 내용 및 특이사항
- Service에서 예외를 지정하지 않아, 500번 에러가 발생하고 있었습니다. 
새로운 ErrorCode를 만들어 지정했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 모집 회차가 없을 경우 사용자에게 적절한 오류 메시지(`진행중인 모집회차가 존재하지 않습니다.`)를 제공.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->