### PR TITLE
refactor: 멤버십 가입 신청 접수 API 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/membership/api/MembershipController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/api/MembershipController.java
@@ -18,7 +18,6 @@ public class MembershipController {
 
     private final MembershipService membershipService;
 
-    // todo: 서비스 복구 필요
     @Operation(summary = "멤버십 가입 신청 접수", description = "정회원 가입을 위해 멤버십 가입 신청을 접수합니다. 별도의 정회원 가입 조건을 만족해야 가입이 완료됩니다.")
     @PostMapping
     public ResponseEntity<Void> submitMembership(@RequestParam(name = "recruitmentRoundId") Long recruitmentRoundId) {

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -5,6 +5,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.dao.MembershipRepository;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
+import com.gdschongik.gdsc.domain.membership.domain.MembershipValidator;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.exception.CustomException;
@@ -21,6 +22,7 @@ public class MembershipService {
     private final MembershipRepository membershipRepository;
     private final RecruitmentRoundRepository recruitmentRoundRepository;
     private final MemberUtil memberUtil;
+    private final MembershipValidator membershipValidator;
 
     @Transactional
     public void verifyPaymentStatus(Long membershipId) {
@@ -32,26 +34,17 @@ public class MembershipService {
     }
 
     @Transactional
-    public void submitMembership(Long recruitmentRoundId) {}
+    public void submitMembership(Long recruitmentRoundId) {
+        Member currentMember = memberUtil.getCurrentMember();
+        RecruitmentRound recruitmentRound = recruitmentRoundRepository
+                .findById(recruitmentRoundId)
+                .orElseThrow(() -> new CustomException(RECRUITMENT_ROUND_NOT_FOUND));
 
-    // private void validateRecruitmentRoundOpen(RecruitmentRound recruitmentRound) {
-    //     if (!recruitmentRound.isOpen()) {
-    //         throw new CustomException(RECRUITMENT_ROUND_NOT_OPEN);
-    //     }
-    // }
-    //
-    // private void validateMembershipDuplicate(Member currentMember, Recruitment recruitment) {
-    //     membershipRepository
-    //             .findByMember(currentMember)
-    //             .filter(membership ->
-    //                     membership.getRecruitmentRound().getRecruitment().equals(recruitment))
-    //             .ifPresent(membership -> {
-    //                 if (membership.isRegularRequirementAllSatisfied()) {
-    //                     throw new CustomException(MEMBERSHIP_ALREADY_SATISFIED);
-    //                 }
-    //                 throw new CustomException(MEMBERSHIP_ALREADY_APPLIED);
-    //             });
-    // }
+        // membershipValidator.validateMembershipSubmit(currentMember, recruitmentRound);
+
+        Membership membership = Membership.createMembership(currentMember, recruitmentRound);
+        membershipRepository.save(membership);
+    }
 
     public Optional<Membership> findMyMembership(Member member, RecruitmentRound recruitmentRound) {
         return membershipRepository.findByMemberAndRecruitmentRound(member, recruitmentRound);

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -7,7 +7,6 @@ import com.gdschongik.gdsc.domain.membership.dao.MembershipRepository;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.membership.domain.MembershipValidator;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
@@ -39,12 +38,16 @@ public class MembershipService {
     @Transactional
     public void submitMembership(Long recruitmentRoundId) {
         Member currentMember = memberUtil.getCurrentMember();
+
         RecruitmentRound recruitmentRound = recruitmentRoundRepository
                 .findById(recruitmentRoundId)
                 .orElseThrow(() -> new CustomException(RECRUITMENT_ROUND_NOT_FOUND));
 
-        validateMembershipDuplicate(currentMember, recruitmentRound.getRecruitment());
-        membershipValidator.validateMembershipSubmit(recruitmentRound);
+        Optional<Membership> existingMembership = membershipRepository.findAllByMember(currentMember).stream()
+                .filter(m -> m.getRecruitmentRound().getRecruitment().equals(recruitmentRound.getRecruitment()))
+                .findFirst();
+
+        membershipValidator.validateMembershipSubmit(recruitmentRound, existingMembership);
 
         Membership membership = Membership.createMembership(currentMember, recruitmentRound);
         membershipRepository.save(membership);
@@ -54,18 +57,5 @@ public class MembershipService {
 
     public Optional<Membership> findMyMembership(Member member, RecruitmentRound recruitmentRound) {
         return membershipRepository.findByMemberAndRecruitmentRound(member, recruitmentRound);
-    }
-
-    private void validateMembershipDuplicate(Member currentMember, Recruitment recruitment) {
-        Optional<Membership> membership = membershipRepository.findAllByMember(currentMember).stream()
-                .filter(m -> m.getRecruitmentRound().getRecruitment().equals(recruitment))
-                .findFirst();
-
-        if (membership.isPresent()) {
-            if (membership.get().isRegularRequirementAllSatisfied()) {
-                throw new CustomException(MEMBERSHIP_ALREADY_SATISFIED);
-            }
-            throw new CustomException(MEMBERSHIP_ALREADY_SUBMITTED);
-        }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -12,9 +12,12 @@ import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -44,6 +47,8 @@ public class MembershipService {
 
         Membership membership = Membership.createMembership(currentMember, recruitmentRound);
         membershipRepository.save(membership);
+
+        log.info("[MembershipService] 멤버십 가입 신청 접수: membershipId = {}", membership.getId());
     }
 
     public Optional<Membership> findMyMembership(Member member, RecruitmentRound recruitmentRound) {

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -40,7 +40,7 @@ public class MembershipService {
                 .findById(recruitmentRoundId)
                 .orElseThrow(() -> new CustomException(RECRUITMENT_ROUND_NOT_FOUND));
 
-        // membershipValidator.validateMembershipSubmit(currentMember, recruitmentRound);
+        membershipValidator.validateMembershipSubmit(currentMember, recruitmentRound);
 
         Membership membership = Membership.createMembership(currentMember, recruitmentRound);
         membershipRepository.save(membership);

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -46,7 +46,7 @@ public class MembershipService {
         boolean isMembershipAlreadySubmitted =
                 membershipRepository.existsByMemberAndRecruitment(currentMember, recruitmentRound.getRecruitment());
 
-        membershipValidator.validateMembershipSubmit(recruitmentRound, isMembershipAlreadySubmitted);
+        membershipValidator.validateMembershipSubmit(currentMember, recruitmentRound, isMembershipAlreadySubmitted);
 
         Membership membership = Membership.createMembership(currentMember, recruitmentRound);
         membershipRepository.save(membership);

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -43,10 +43,6 @@ public class MembershipService {
                 .findById(recruitmentRoundId)
                 .orElseThrow(() -> new CustomException(RECRUITMENT_ROUND_NOT_FOUND));
 
-        Optional<Membership> existingMembership = membershipRepository.findAllByMember(currentMember).stream()
-                .filter(m -> m.getRecruitmentRound().getRecruitment().equals(recruitmentRound.getRecruitment()))
-                .findFirst();
-
         boolean isMembershipAlreadySubmitted =
                 membershipRepository.existsByMemberAndRecruitment(currentMember, recruitmentRound.getRecruitment());
 

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -47,7 +47,10 @@ public class MembershipService {
                 .filter(m -> m.getRecruitmentRound().getRecruitment().equals(recruitmentRound.getRecruitment()))
                 .findFirst();
 
-        membershipValidator.validateMembershipSubmit(recruitmentRound, existingMembership);
+        boolean isMembershipAlreadySubmitted =
+                membershipRepository.existsByMemberAndRecruitment(currentMember, recruitmentRound.getRecruitment());
+
+        membershipValidator.validateMembershipSubmit(recruitmentRound, isMembershipAlreadySubmitted);
 
         Membership membership = Membership.createMembership(currentMember, recruitmentRound);
         membershipRepository.save(membership);

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipCustomRepository.java
@@ -1,0 +1,9 @@
+package com.gdschongik.gdsc.domain.membership.dao;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+
+public interface MembershipCustomRepository {
+
+    boolean existsByMemberAndRecruitment(Member member, Recruitment recruitment);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipCustomRepositoryImpl.java
@@ -4,6 +4,7 @@ import static com.gdschongik.gdsc.domain.membership.domain.QMembership.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
@@ -17,9 +18,17 @@ public class MembershipCustomRepositoryImpl implements MembershipCustomRepositor
         Integer fetchOne = queryFactory
                 .selectOne()
                 .from(membership)
-                .where(membership.member.eq(member), membership.recruitmentRound.recruitment.eq(recruitment))
+                .where(eqMember(member), eqRecruitment(recruitment))
                 .fetchFirst();
 
         return fetchOne != null;
+    }
+
+    private BooleanExpression eqMember(Member member) {
+        return member != null ? membership.member.eq(member) : null;
+    }
+
+    private BooleanExpression eqRecruitment(Recruitment recruitment) {
+        return recruitment != null ? membership.recruitmentRound.recruitment.eq(recruitment) : null;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipCustomRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.gdschongik.gdsc.domain.membership.dao;
+
+import static com.gdschongik.gdsc.domain.membership.domain.QMembership.*;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MembershipCustomRepositoryImpl implements MembershipCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean existsByMemberAndRecruitment(Member member, Recruitment recruitment) {
+        Integer fetchOne = queryFactory
+                .selectOne()
+                .from(membership)
+                .where(membership.member.eq(member), membership.recruitmentRound.recruitment.eq(recruitment))
+                .fetchFirst();
+
+        return fetchOne != null;
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipRepository.java
@@ -3,12 +3,13 @@ package com.gdschongik.gdsc.domain.membership.dao;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MembershipRepository extends JpaRepository<Membership, Long> {
 
-    Optional<Membership> findByMember(Member member);
+    List<Membership> findAllByMember(Member member);
 
     Optional<Membership> findByMemberAndRecruitmentRound(Member member, RecruitmentRound recruitmentRound);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MembershipRepository extends JpaRepository<Membership, Long> {
 
-    // Optional<Membership> findByMember(Member member);
+    Optional<Membership> findByMember(Member member);
 
     Optional<Membership> findByMemberAndRecruitmentRound(Member member, RecruitmentRound recruitmentRound);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MembershipRepository extends JpaRepository<Membership, Long> {
+public interface MembershipRepository extends JpaRepository<Membership, Long>, MembershipCustomRepository {
 
     List<Membership> findAllByMember(Member member);
 

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipRepository.java
@@ -3,13 +3,10 @@ package com.gdschongik.gdsc.domain.membership.dao;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MembershipRepository extends JpaRepository<Membership, Long>, MembershipCustomRepository {
-
-    List<Membership> findAllByMember(Member member);
 
     Optional<Membership> findByMemberAndRecruitmentRound(Member member, RecruitmentRound recruitmentRound);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
@@ -6,7 +6,6 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRegularEvent;
-import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.Column;
@@ -52,8 +51,6 @@ public class Membership extends BaseEntity {
     }
 
     public static Membership createMembership(Member member, RecruitmentRound recruitmentRound) {
-        validateMembershipApplicable(member);
-
         return Membership.builder()
                 .member(member)
                 .recruitmentRound(recruitmentRound)
@@ -62,16 +59,6 @@ public class Membership extends BaseEntity {
     }
 
     // 검증 로직
-
-    // TODO validateRegularRequirement처럼 로직 변경
-    // TODO: 어드민인 경우 리쿠르팅 지원 및 결제에 대한 정책 검토 필요. 현재는 불가능하도록 설정
-    private static void validateMembershipApplicable(Member member) {
-        if (member.getRole().equals(MemberRole.ASSOCIATE)) {
-            return;
-        }
-
-        throw new CustomException(MEMBERSHIP_NOT_APPLICABLE);
-    }
 
     public void validateRegularRequirement() {
         if (isRegularRequirementAllSatisfied()) {

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidator.java
@@ -1,0 +1,42 @@
+package com.gdschongik.gdsc.domain.membership.domain;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.membership.dao.MembershipRepository;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
+import com.gdschongik.gdsc.global.annotation.DomainService;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class MembershipValidator {
+
+    private final MembershipRepository membershipRepository;
+
+    public void validateMembershipSubmit(Member currentMember, RecruitmentRound recruitmentRound) {
+        validateMembershipDuplicate(currentMember, recruitmentRound.getRecruitment());
+        validateRecruitmentRoundOpen(recruitmentRound);
+    }
+
+    private void validateMembershipDuplicate(Member currentMember, Recruitment recruitment) {
+        membershipRepository
+                .findByMember(currentMember)
+                .filter(membership ->
+                        membership.getRecruitmentRound().getRecruitment().equals(recruitment))
+                .ifPresent(membership -> {
+                    if (membership.isRegularRequirementAllSatisfied()) {
+                        throw new CustomException(MEMBERSHIP_ALREADY_SATISFIED);
+                    }
+                    throw new CustomException(MEMBERSHIP_ALREADY_SUBMITTED);
+                });
+    }
+
+    private void validateRecruitmentRoundOpen(RecruitmentRound recruitmentRound) {
+        if (!recruitmentRound.isOpen()) {
+            throw new CustomException(RECRUITMENT_ROUND_NOT_OPEN);
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidator.java
@@ -19,7 +19,7 @@ public class MembershipValidator {
 
         // 모집 회차가 열려있는지 검증
         if (!recruitmentRound.isOpen()) {
-            throw new CustomException(RECRUITMENT_ROUND_NOT_OPEN);
+            throw new CustomException(MEMBERSHIP_RECRUITMENT_ROUND_NOT_OPEN);
         }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidator.java
@@ -5,19 +5,15 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @DomainService
 @RequiredArgsConstructor
 public class MembershipValidator {
 
-    public void validateMembershipSubmit(RecruitmentRound recruitmentRound, Optional<Membership> membership) {
+    public void validateMembershipSubmit(RecruitmentRound recruitmentRound, boolean isMembershipAlreadySubmitted) {
         // 이미 접수한 멤버십이 있는지 검증
-        if (membership.isPresent()) {
-            if (membership.get().isRegularRequirementAllSatisfied()) {
-                throw new CustomException(MEMBERSHIP_ALREADY_SATISFIED);
-            }
+        if (isMembershipAlreadySubmitted) {
             throw new CustomException(MEMBERSHIP_ALREADY_SUBMITTED);
         }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidator.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.domain.membership.domain;
 
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
+import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
@@ -11,7 +12,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MembershipValidator {
 
-    public void validateMembershipSubmit(RecruitmentRound recruitmentRound, boolean isMembershipAlreadySubmitted) {
+    public void validateMembershipSubmit(
+            Member currentMember, RecruitmentRound recruitmentRound, boolean isMembershipAlreadySubmitted) {
+        // 준회원인지 검증
+        // TODO: 어드민인 경우 리쿠르팅 지원 및 결제에 대한 정책 검토 필요. 현재는 불가능하도록 설정
+        if (!currentMember.isAssociate()) {
+            throw new CustomException(MEMBERSHIP_NOT_APPLICABLE);
+        }
+
         // 이미 접수한 멤버십이 있는지 검증
         if (isMembershipAlreadySubmitted) {
             throw new CustomException(MEMBERSHIP_ALREADY_SUBMITTED);

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidator.java
@@ -2,9 +2,6 @@ package com.gdschongik.gdsc.domain.membership.domain;
 
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
-import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.membership.dao.MembershipRepository;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
@@ -14,27 +11,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MembershipValidator {
 
-    private final MembershipRepository membershipRepository;
-
-    public void validateMembershipSubmit(Member currentMember, RecruitmentRound recruitmentRound) {
-        validateMembershipDuplicate(currentMember, recruitmentRound.getRecruitment());
-        validateRecruitmentRoundOpen(recruitmentRound);
-    }
-
-    private void validateMembershipDuplicate(Member currentMember, Recruitment recruitment) {
-        membershipRepository
-                .findByMember(currentMember)
-                .filter(membership ->
-                        membership.getRecruitmentRound().getRecruitment().equals(recruitment))
-                .ifPresent(membership -> {
-                    if (membership.isRegularRequirementAllSatisfied()) {
-                        throw new CustomException(MEMBERSHIP_ALREADY_SATISFIED);
-                    }
-                    throw new CustomException(MEMBERSHIP_ALREADY_SUBMITTED);
-                });
-    }
-
-    private void validateRecruitmentRoundOpen(RecruitmentRound recruitmentRound) {
+    public void validateMembershipSubmit(RecruitmentRound recruitmentRound) {
+        // 모집 회차가 열려있는지 검증
         if (!recruitmentRound.isOpen()) {
             throw new CustomException(RECRUITMENT_ROUND_NOT_OPEN);
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidator.java
@@ -5,13 +5,22 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @DomainService
 @RequiredArgsConstructor
 public class MembershipValidator {
 
-    public void validateMembershipSubmit(RecruitmentRound recruitmentRound) {
+    public void validateMembershipSubmit(RecruitmentRound recruitmentRound, Optional<Membership> membership) {
+        // 이미 접수한 멤버십이 있는지 검증
+        if (membership.isPresent()) {
+            if (membership.get().isRegularRequirementAllSatisfied()) {
+                throw new CustomException(MEMBERSHIP_ALREADY_SATISFIED);
+            }
+            throw new CustomException(MEMBERSHIP_ALREADY_SUBMITTED);
+        }
+
         // 모집 회차가 열려있는지 검증
         if (!recruitmentRound.isOpen()) {
             throw new CustomException(RECRUITMENT_ROUND_NOT_OPEN);

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -74,11 +74,11 @@ public enum ErrorCode {
     MEMBERSHIP_ALREADY_SUBMITTED(HttpStatus.CONFLICT, "이미 이번 학기에 멤버십 가입을 신청한 회원입니다."),
     MEMBERSHIP_ALREADY_SATISFIED(HttpStatus.CONFLICT, "이미 이번 학기에 정회원 승급을 완료한 회원입니다."),
     MEMBERSHIP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 멤버십이 존재하지 않습니다."),
+    MEMBERSHIP_RECRUITMENT_ROUND_NOT_OPEN(HttpStatus.CONFLICT, "리크루팅 회차 모집기간이 아닙니다."),
 
     // Recruitment
     DATE_PRECEDENCE_INVALID(HttpStatus.BAD_REQUEST, "종료일이 시작일과 같거나 앞설 수 없습니다."),
     RECRUITMENT_OVERLAP(HttpStatus.BAD_REQUEST, "해당 학기에 이미 리크루팅이 존재합니다."),
-    RECRUITMENT_ROUND_NOT_OPEN(HttpStatus.CONFLICT, "리크루팅 회차 모집기간이 아닙니다."),
     RECRUITMENT_ROUND_NOT_FOUND(HttpStatus.NOT_FOUND, "리크루팅 회차가 존재하지 않습니다."),
     RECRUITMENT_PERIOD_MISMATCH_ACADEMIC_YEAR(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 연도가 학년도와 일치하지 않습니다."),
     RECRUITMENT_PERIOD_MISMATCH_SEMESTER_TYPE(HttpStatus.BAD_REQUEST, "모집 시작일과 종료일의 입력된 학기가 일치하지 않습니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -71,7 +71,7 @@ public enum ErrorCode {
     // Membership
     PAYMENT_NOT_SATISFIED(HttpStatus.CONFLICT, "회비 납부가 완료되지 않았습니다."),
     MEMBERSHIP_NOT_APPLICABLE(HttpStatus.CONFLICT, "멤버십 가입을 신청할 수 없는 회원입니다."),
-    MEMBERSHIP_ALREADY_APPLIED(HttpStatus.CONFLICT, "이미 이번 학기에 멤버십 가입을 신청한 회원입니다."),
+    MEMBERSHIP_ALREADY_SUBMITTED(HttpStatus.CONFLICT, "이미 이번 학기에 멤버십 가입을 신청한 회원입니다."),
     MEMBERSHIP_ALREADY_SATISFIED(HttpStatus.CONFLICT, "이미 이번 학기에 정회원 승급을 완료한 회원입니다."),
     MEMBERSHIP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 멤버십이 존재하지 않습니다."),
 

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -37,6 +37,38 @@ public class MembershipServiceTest extends IntegrationTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessage(RECRUITMENT_ROUND_NOT_FOUND.getMessage());
         }
+
+        @Test
+        void 해당_학기에_이미_Membership을_발급받았다면_실패한다() {
+            // given
+            Member member = createMember();
+            logoutAndReloginAs(1L, ASSOCIATE);
+            RecruitmentRound recruitmentRound = createRecruitmentRound();
+            Membership membership = createMembership(member, recruitmentRound);
+
+            // when
+            membership.verifyPaymentStatus();
+            membershipRepository.save(membership);
+
+            // then
+            assertThatThrownBy(() -> membershipService.submitMembership(recruitmentRound.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MEMBERSHIP_ALREADY_SATISFIED.getMessage());
+        }
+
+        @Test
+        void 해당_학기에_이미_Membership을_생성한_적이_있다면_실패한다() {
+            // given
+            Member member = createMember();
+            logoutAndReloginAs(1L, ASSOCIATE);
+            RecruitmentRound recruitmentRound = createRecruitmentRound();
+            createMembership(member, recruitmentRound);
+
+            // when & then
+            assertThatThrownBy(() -> membershipService.submitMembership(recruitmentRound.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MEMBERSHIP_ALREADY_SUBMITTED.getMessage());
+        }
     }
 
     @Test

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -23,67 +23,66 @@ public class MembershipServiceTest extends IntegrationTest {
     @Autowired
     private MembershipRepository membershipRepository;
 
-    // todo: test 원복
-    // @Nested
-    // class 멤버십_가입신청시 {
-    //     @Test
-    //     void RecruitmentRound가_없다면_실패한다() {
-    //         // given
-    //         createMember();
-    //         logoutAndReloginAs(1L, ASSOCIATE);
-    //         Long recruitmentId = 1L;
-    //
-    //         // when & then
-    //         assertThatThrownBy(() -> membershipService.submitMembership(recruitmentId))
-    //                 .isInstanceOf(CustomException.class)
-    //                 .hasMessage(RECRUITMENT_ROUND_NOT_FOUND.getMessage());
-    //     }
-    //
-    //     @Test
-    //     void 해당_학기에_이미_Membership을_발급받았다면_실패한다() {
-    //         // given
-    //         Member member = createMember();
-    //         logoutAndReloginAs(1L, ASSOCIATE);
-    //         RecruitmentRound recruitmentRound = createRecruitmentRound();
-    //         Membership membership = createMembership(member, recruitmentRound);
-    //
-    //         // when
-    //         membership.verifyPaymentStatus();
-    //         membershipRepository.save(membership);
-    //
-    //         // then
-    //         assertThatThrownBy(() -> membershipService.submitMembership(recruitmentRound.getId()))
-    //                 .isInstanceOf(CustomException.class)
-    //                 .hasMessage(MEMBERSHIP_ALREADY_SATISFIED.getMessage());
-    //     }
-    //
-    //     @Test
-    //     void 해당_Recruitment에_대해_Membership을_생성한_적이_있다면_실패한다() {
-    //         // given
-    //         Member member = createMember();
-    //         logoutAndReloginAs(1L, ASSOCIATE);
-    //         RecruitmentRound recruitmentRound = createRecruitmentRound();
-    //         createMembership(member, recruitmentRound);
-    //
-    //         // when & then
-    //         assertThatThrownBy(() -> membershipService.submitMembership(recruitmentRound.getId()))
-    //                 .isInstanceOf(CustomException.class)
-    //                 .hasMessage(MEMBERSHIP_ALREADY_APPLIED.getMessage());
-    //     }
-    //
-    //     @Test
-    //     void 해당_RecruitmentRound의_모집기간이_아니라면_실패한다() {
-    //         // given
-    //         createMember();
-    //         logoutAndReloginAs(1L, ASSOCIATE);
-    //         RecruitmentRound recruitmentRound = createRecruitmentRound();
-    //
-    //         // when & then
-    //         assertThatThrownBy(() -> membershipService.submitMembership(recruitmentRound.getId()))
-    //                 .isInstanceOf(CustomException.class)
-    //                 .hasMessage(RECRUITMENT_ROUND_NOT_OPEN.getMessage());
-    //     }
-    // }
+    @Nested
+    class 멤버십_가입신청시 {
+        @Test
+        void RecruitmentRound가_없다면_실패한다() {
+            // given
+            createMember();
+            logoutAndReloginAs(1L, ASSOCIATE);
+            Long recruitmentId = 1L;
+
+            // when & then
+            assertThatThrownBy(() -> membershipService.submitMembership(recruitmentId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(RECRUITMENT_ROUND_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 해당_학기에_이미_Membership을_발급받았다면_실패한다() {
+            // given
+            Member member = createMember();
+            logoutAndReloginAs(1L, ASSOCIATE);
+            RecruitmentRound recruitmentRound = createRecruitmentRound();
+            Membership membership = createMembership(member, recruitmentRound);
+
+            // when
+            membership.verifyPaymentStatus();
+            membershipRepository.save(membership);
+
+            // then
+            assertThatThrownBy(() -> membershipService.submitMembership(recruitmentRound.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MEMBERSHIP_ALREADY_SATISFIED.getMessage());
+        }
+
+        @Test
+        void 해당_Recruitment에_대해_Membership을_생성한_적이_있다면_실패한다() {
+            // given
+            Member member = createMember();
+            logoutAndReloginAs(1L, ASSOCIATE);
+            RecruitmentRound recruitmentRound = createRecruitmentRound();
+            createMembership(member, recruitmentRound);
+
+            // when & then
+            assertThatThrownBy(() -> membershipService.submitMembership(recruitmentRound.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MEMBERSHIP_ALREADY_SUBMITTED.getMessage());
+        }
+
+        @Test
+        void 해당_RecruitmentRound의_모집기간이_아니라면_실패한다() {
+            // given
+            createMember();
+            logoutAndReloginAs(1L, ASSOCIATE);
+            RecruitmentRound recruitmentRound = createRecruitmentRound();
+
+            // when & then
+            assertThatThrownBy(() -> membershipService.submitMembership(recruitmentRound.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(RECRUITMENT_ROUND_NOT_OPEN.getMessage());
+        }
+    }
 
     @Test
     void 멤버십_회비납부시_이미_회비납부_했다면_회비납부_실패한다() {

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -37,51 +37,6 @@ public class MembershipServiceTest extends IntegrationTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessage(RECRUITMENT_ROUND_NOT_FOUND.getMessage());
         }
-
-        @Test
-        void 해당_학기에_이미_Membership을_발급받았다면_실패한다() {
-            // given
-            Member member = createMember();
-            logoutAndReloginAs(1L, ASSOCIATE);
-            RecruitmentRound recruitmentRound = createRecruitmentRound();
-            Membership membership = createMembership(member, recruitmentRound);
-
-            // when
-            membership.verifyPaymentStatus();
-            membershipRepository.save(membership);
-
-            // then
-            assertThatThrownBy(() -> membershipService.submitMembership(recruitmentRound.getId()))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(MEMBERSHIP_ALREADY_SATISFIED.getMessage());
-        }
-
-        @Test
-        void 해당_Recruitment에_대해_Membership을_생성한_적이_있다면_실패한다() {
-            // given
-            Member member = createMember();
-            logoutAndReloginAs(1L, ASSOCIATE);
-            RecruitmentRound recruitmentRound = createRecruitmentRound();
-            createMembership(member, recruitmentRound);
-
-            // when & then
-            assertThatThrownBy(() -> membershipService.submitMembership(recruitmentRound.getId()))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(MEMBERSHIP_ALREADY_SUBMITTED.getMessage());
-        }
-
-        @Test
-        void 해당_RecruitmentRound의_모집기간이_아니라면_실패한다() {
-            // given
-            createMember();
-            logoutAndReloginAs(1L, ASSOCIATE);
-            RecruitmentRound recruitmentRound = createRecruitmentRound();
-
-            // when & then
-            assertThatThrownBy(() -> membershipService.submitMembership(recruitmentRound.getId()))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_ROUND_NOT_OPEN.getMessage());
-        }
     }
 
     @Test

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -30,10 +30,10 @@ public class MembershipServiceTest extends IntegrationTest {
             // given
             createMember();
             logoutAndReloginAs(1L, ASSOCIATE);
-            Long recruitmentId = 1L;
+            Long recruitmentRoundId = 1L;
 
             // when & then
-            assertThatThrownBy(() -> membershipService.submitMembership(recruitmentId))
+            assertThatThrownBy(() -> membershipService.submitMembership(recruitmentRoundId))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(RECRUITMENT_ROUND_NOT_FOUND.getMessage());
         }

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -37,38 +37,6 @@ public class MembershipServiceTest extends IntegrationTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessage(RECRUITMENT_ROUND_NOT_FOUND.getMessage());
         }
-
-        @Test
-        void 해당_학기에_이미_Membership을_발급받았다면_실패한다() {
-            // given
-            Member member = createMember();
-            logoutAndReloginAs(1L, ASSOCIATE);
-            RecruitmentRound recruitmentRound = createRecruitmentRound();
-            Membership membership = createMembership(member, recruitmentRound);
-
-            // when
-            membership.verifyPaymentStatus();
-            membershipRepository.save(membership);
-
-            // then
-            assertThatThrownBy(() -> membershipService.submitMembership(recruitmentRound.getId()))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(MEMBERSHIP_ALREADY_SATISFIED.getMessage());
-        }
-
-        @Test
-        void 해당_학기에_이미_Membership을_생성한_적이_있다면_실패한다() {
-            // given
-            Member member = createMember();
-            logoutAndReloginAs(1L, ASSOCIATE);
-            RecruitmentRound recruitmentRound = createRecruitmentRound();
-            createMembership(member, recruitmentRound);
-
-            // when & then
-            assertThatThrownBy(() -> membershipService.submitMembership(recruitmentRound.getId()))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(MEMBERSHIP_ALREADY_SUBMITTED.getMessage());
-        }
     }
 
     @Test

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
@@ -1,16 +1,16 @@
 package com.gdschongik.gdsc.domain.membership.domain;
 
+import static com.gdschongik.gdsc.domain.member.domain.Department.*;
+import static com.gdschongik.gdsc.domain.member.domain.Member.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.SemesterConstant.*;
-import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
-import com.gdschongik.gdsc.global.exception.CustomException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -18,19 +18,27 @@ class MembershipTest {
 
     @Nested
     class 멤버십_가입신청시 {
+
         @Test
-        void 역할이_GUEST라면_멤버십_가입신청에_실패한다() {
+        void 성공한다() {
             // given
-            Member guestMember = Member.createGuestMember(OAUTH_ID);
+            Member member = createGuestMember(OAUTH_ID);
+            member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
+            member.completeUnivEmailVerification(UNIV_EMAIL);
+            member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
+            member.verifyBevy();
+            member.advanceToAssociate();
+
             Recruitment recruitment = Recruitment.createRecruitment(
                     ACADEMIC_YEAR, SEMESTER_TYPE, FEE, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
             RecruitmentRound recruitmentRound =
                     RecruitmentRound.create(RECRUITMENT_NAME, START_DATE, END_DATE, recruitment, ROUND_TYPE);
 
-            // when & then
-            assertThatThrownBy(() -> Membership.createMembership(guestMember, recruitmentRound))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(MEMBERSHIP_NOT_APPLICABLE.getMessage());
+            // when
+            Membership membership = Membership.createMembership(member, recruitmentRound);
+
+            // then
+            assertThat(membership).isNotNull();
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
@@ -48,14 +48,31 @@ class MembershipValidatorTest {
 
     @Nested
     class 멤버십_가입신청시 {
+
         @Test
-        void 해당_리쿠르팅회차의_모집기간이_아니라면_실패한다() {
+        void 역할이_GUEST라면_멤버십_가입신청에_실패한다() {
             // given
+            Member member = createGuestMember(OAUTH_ID);
+
             RecruitmentRound recruitmentRound =
                     createRecruitmentRound(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, START_DATE, END_DATE);
 
             // when & then
-            assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(recruitmentRound, false))
+            assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(member, recruitmentRound, false))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MEMBERSHIP_NOT_APPLICABLE.getMessage());
+        }
+
+        @Test
+        void 해당_리쿠르팅회차의_모집기간이_아니라면_실패한다() {
+            // given
+            Member member = createAssociateMember(1L);
+
+            RecruitmentRound recruitmentRound =
+                    createRecruitmentRound(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, START_DATE, END_DATE);
+
+            // when & then
+            assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(member, recruitmentRound, false))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(MEMBERSHIP_RECRUITMENT_ROUND_NOT_OPEN.getMessage());
         }
@@ -71,7 +88,7 @@ class MembershipValidatorTest {
             Membership membership = Membership.createMembership(member, recruitmentRound);
 
             // when & then
-            assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(recruitmentRound, true))
+            assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(member, recruitmentRound, true))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(MEMBERSHIP_ALREADY_SUBMITTED.getMessage());
         }

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
@@ -1,79 +1,33 @@
 package com.gdschongik.gdsc.domain.membership.domain;
 
-import static com.gdschongik.gdsc.domain.member.domain.MemberRole.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.SemesterConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
-import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.membership.dao.MembershipRepository;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.helper.IntegrationTest;
-import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-class MembershipValidatorTest extends IntegrationTest {
+class MembershipValidatorTest {
 
-    private MembershipValidator membershipValidator;
-    private MembershipRepository membershipRepository;
-
-    @BeforeEach
-    public void setUp() {
-        membershipRepository = Mockito.mock(MembershipRepository.class);
-        membershipValidator = new MembershipValidator(membershipRepository);
-    }
+    MembershipValidator membershipValidator = new MembershipValidator();
 
     @Nested
     class 멤버십_가입신청시 {
         @Test
-        void 해당_학기에_이미_Membership을_발급받았다면_실패한다() {
-            // given
-            Member member = createMember();
-            logoutAndReloginAs(1L, ASSOCIATE);
-            RecruitmentRound recruitmentRound = createRecruitmentRound();
-            Membership membership = createMembership(member, recruitmentRound);
-
-            when(membershipRepository.findByMember(member)).thenReturn(Optional.of(membership));
-
-            // when
-            membership.verifyPaymentStatus();
-
-            // when & then
-            assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(member, recruitmentRound))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(MEMBERSHIP_ALREADY_SATISFIED.getMessage());
-        }
-
-        @Test
-        void 해당_Recruitment에_대해_Membership을_생성한_적이_있다면_실패한다() {
-            // given
-            Member member = createMember();
-            logoutAndReloginAs(1L, ASSOCIATE);
-            RecruitmentRound recruitmentRound = createRecruitmentRound();
-            Membership membership = createMembership(member, recruitmentRound);
-
-            when(membershipRepository.findByMember(member)).thenReturn(Optional.of(membership));
-
-            // when & then
-            assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(member, recruitmentRound))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(MEMBERSHIP_ALREADY_SUBMITTED.getMessage());
-        }
-
-        @Test
         void 해당_RecruitmentRound의_모집기간이_아니라면_실패한다() {
             // given
-            Member member = createMember();
-            logoutAndReloginAs(1L, ASSOCIATE);
-            RecruitmentRound recruitmentRound = createRecruitmentRound();
+            Recruitment recruitment = Recruitment.createRecruitment(
+                    ACADEMIC_YEAR, SEMESTER_TYPE, FEE, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
+            RecruitmentRound recruitmentRound =
+                    RecruitmentRound.create(RECRUITMENT_NAME, START_DATE, END_DATE, recruitment, ROUND_TYPE);
 
             // when & then
-            assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(member, recruitmentRound))
+            assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(recruitmentRound))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(RECRUITMENT_ROUND_NOT_OPEN.getMessage());
         }

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
@@ -1,0 +1,81 @@
+package com.gdschongik.gdsc.domain.membership.domain;
+
+import static com.gdschongik.gdsc.domain.member.domain.MemberRole.*;
+import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.membership.dao.MembershipRepository;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.helper.IntegrationTest;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class MembershipValidatorTest extends IntegrationTest {
+
+    private MembershipValidator membershipValidator;
+    private MembershipRepository membershipRepository;
+
+    @BeforeEach
+    public void setUp() {
+        membershipRepository = Mockito.mock(MembershipRepository.class);
+        membershipValidator = new MembershipValidator(membershipRepository);
+    }
+
+    @Nested
+    class 멤버십_가입신청시 {
+        @Test
+        void 해당_학기에_이미_Membership을_발급받았다면_실패한다() {
+            // given
+            Member member = createMember();
+            logoutAndReloginAs(1L, ASSOCIATE);
+            RecruitmentRound recruitmentRound = createRecruitmentRound();
+            Membership membership = createMembership(member, recruitmentRound);
+
+            when(membershipRepository.findByMember(member)).thenReturn(Optional.of(membership));
+
+            // when
+            membership.verifyPaymentStatus();
+
+            // when & then
+            assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(member, recruitmentRound))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MEMBERSHIP_ALREADY_SATISFIED.getMessage());
+        }
+
+        @Test
+        void 해당_Recruitment에_대해_Membership을_생성한_적이_있다면_실패한다() {
+            // given
+            Member member = createMember();
+            logoutAndReloginAs(1L, ASSOCIATE);
+            RecruitmentRound recruitmentRound = createRecruitmentRound();
+            Membership membership = createMembership(member, recruitmentRound);
+
+            when(membershipRepository.findByMember(member)).thenReturn(Optional.of(membership));
+
+            // when & then
+            assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(member, recruitmentRound))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MEMBERSHIP_ALREADY_SUBMITTED.getMessage());
+        }
+
+        @Test
+        void 해당_RecruitmentRound의_모집기간이_아니라면_실패한다() {
+            // given
+            Member member = createMember();
+            logoutAndReloginAs(1L, ASSOCIATE);
+            RecruitmentRound recruitmentRound = createRecruitmentRound();
+
+            // when & then
+            assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(member, recruitmentRound))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(RECRUITMENT_ROUND_NOT_OPEN.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
@@ -78,7 +78,7 @@ class MembershipValidatorTest {
         }
 
         @Test
-        void 해당_학기에_이미_Membership을_생성한_적이_있다면_실패한다() {
+        void 해당_학기에_이미_멤버십을_생성한_적이_있다면_실패한다() {
             // given
             Member member = createAssociateMember(1L);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
@@ -49,7 +49,7 @@ class MembershipValidatorTest {
     @Nested
     class 멤버십_가입신청시 {
         @Test
-        void 해당_RecruitmentRound의_모집기간이_아니라면_실패한다() {
+        void 해당_리쿠르팅회차의_모집기간이_아니라면_실패한다() {
             // given
             RecruitmentRound recruitmentRound =
                     createRecruitmentRound(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, START_DATE, END_DATE);

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
@@ -57,7 +57,7 @@ class MembershipValidatorTest {
             // when & then
             assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(recruitmentRound, false))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_ROUND_NOT_OPEN.getMessage());
+                    .hasMessage(MEMBERSHIP_RECRUITMENT_ROUND_NOT_OPEN.getMessage());
         }
 
         @Test

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
@@ -1,34 +1,59 @@
 package com.gdschongik.gdsc.domain.membership.domain;
 
 import static com.gdschongik.gdsc.domain.member.domain.Department.*;
+import static com.gdschongik.gdsc.domain.member.domain.Member.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.SemesterConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 class MembershipValidatorTest {
 
     MembershipValidator membershipValidator = new MembershipValidator();
+
+    private Member createAssociateMember(Long id) {
+        Member member = createGuestMember(OAUTH_ID);
+        member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
+        member.completeUnivEmailVerification(UNIV_EMAIL);
+        member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
+        member.verifyBevy();
+        member.advanceToAssociate();
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+
+    private RecruitmentRound createRecruitmentRound(
+            Integer academicYear,
+            SemesterType semesterType,
+            Money fee,
+            LocalDateTime startDate,
+            LocalDateTime endDate) {
+        Recruitment recruitment = Recruitment.createRecruitment(
+                academicYear, semesterType, fee, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
+        return RecruitmentRound.create(RECRUITMENT_NAME, startDate, endDate, recruitment, ROUND_TYPE);
+    }
 
     @Nested
     class 멤버십_가입신청시 {
         @Test
         void 해당_RecruitmentRound의_모집기간이_아니라면_실패한다() {
             // given
-            Recruitment recruitment = Recruitment.createRecruitment(
-                    ACADEMIC_YEAR, SEMESTER_TYPE, FEE, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
             RecruitmentRound recruitmentRound =
-                    RecruitmentRound.create(RECRUITMENT_NAME, START_DATE, END_DATE, recruitment, ROUND_TYPE);
+                    createRecruitmentRound(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, START_DATE, END_DATE);
 
             // when & then
             assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(recruitmentRound, Optional.empty()))
@@ -39,18 +64,10 @@ class MembershipValidatorTest {
         @Test
         void 해당_학기에_이미_Membership을_발급받았다면_실패한다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
-            member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
-            member.completeUnivEmailVerification(UNIV_EMAIL);
-            member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
-            member.verifyBevy();
-            member.advanceToAssociate();
-
-            Recruitment recruitment = Recruitment.createRecruitment(
-                    ACADEMIC_YEAR, SEMESTER_TYPE, FEE, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
+            Member member = createAssociateMember(1L);
 
             RecruitmentRound recruitmentRound =
-                    RecruitmentRound.create(RECRUITMENT_NAME, START_DATE, END_DATE, recruitment, ROUND_TYPE);
+                    createRecruitmentRound(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, START_DATE, END_DATE);
 
             Membership membership = Membership.createMembership(member, recruitmentRound);
 
@@ -67,18 +84,10 @@ class MembershipValidatorTest {
         @Test
         void 해당_학기에_이미_Membership을_생성한_적이_있다면_실패한다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
-            member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
-            member.completeUnivEmailVerification(UNIV_EMAIL);
-            member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
-            member.verifyBevy();
-            member.advanceToAssociate();
-
-            Recruitment recruitment = Recruitment.createRecruitment(
-                    ACADEMIC_YEAR, SEMESTER_TYPE, FEE, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
+            Member member = createAssociateMember(1L);
 
             RecruitmentRound recruitmentRound =
-                    RecruitmentRound.create(RECRUITMENT_NAME, START_DATE, END_DATE, recruitment, ROUND_TYPE);
+                    createRecruitmentRound(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, START_DATE, END_DATE);
 
             Membership membership = Membership.createMembership(member, recruitmentRound);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
@@ -16,7 +16,6 @@ import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import java.time.LocalDateTime;
-import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -56,29 +55,9 @@ class MembershipValidatorTest {
                     createRecruitmentRound(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, START_DATE, END_DATE);
 
             // when & then
-            assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(recruitmentRound, Optional.empty()))
+            assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(recruitmentRound, false))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(RECRUITMENT_ROUND_NOT_OPEN.getMessage());
-        }
-
-        @Test
-        void 해당_학기에_이미_Membership을_발급받았다면_실패한다() {
-            // given
-            Member member = createAssociateMember(1L);
-
-            RecruitmentRound recruitmentRound =
-                    createRecruitmentRound(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, START_DATE, END_DATE);
-
-            Membership membership = Membership.createMembership(member, recruitmentRound);
-
-            // when
-            membership.verifyPaymentStatus();
-
-            // then
-            assertThatThrownBy(() ->
-                            membershipValidator.validateMembershipSubmit(recruitmentRound, Optional.of(membership)))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(MEMBERSHIP_ALREADY_SATISFIED.getMessage());
         }
 
         @Test
@@ -92,8 +71,7 @@ class MembershipValidatorTest {
             Membership membership = Membership.createMembership(member, recruitmentRound);
 
             // when & then
-            assertThatThrownBy(() ->
-                            membershipValidator.validateMembershipSubmit(recruitmentRound, Optional.of(membership)))
+            assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(recruitmentRound, true))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(MEMBERSHIP_ALREADY_SUBMITTED.getMessage());
         }

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
@@ -1,14 +1,18 @@
 package com.gdschongik.gdsc.domain.membership.domain;
 
+import static com.gdschongik.gdsc.domain.member.domain.Department.*;
+import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.SemesterConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -27,9 +31,62 @@ class MembershipValidatorTest {
                     RecruitmentRound.create(RECRUITMENT_NAME, START_DATE, END_DATE, recruitment, ROUND_TYPE);
 
             // when & then
-            assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(recruitmentRound))
+            assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(recruitmentRound, Optional.empty()))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(RECRUITMENT_ROUND_NOT_OPEN.getMessage());
+        }
+
+        @Test
+        void 해당_학기에_이미_Membership을_발급받았다면_실패한다() {
+            // given
+            Member member = Member.createGuestMember(OAUTH_ID);
+            member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
+            member.completeUnivEmailVerification(UNIV_EMAIL);
+            member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
+            member.verifyBevy();
+            member.advanceToAssociate();
+
+            Recruitment recruitment = Recruitment.createRecruitment(
+                    ACADEMIC_YEAR, SEMESTER_TYPE, FEE, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
+
+            RecruitmentRound recruitmentRound =
+                    RecruitmentRound.create(RECRUITMENT_NAME, START_DATE, END_DATE, recruitment, ROUND_TYPE);
+
+            Membership membership = Membership.createMembership(member, recruitmentRound);
+
+            // when
+            membership.verifyPaymentStatus();
+
+            // then
+            assertThatThrownBy(() ->
+                            membershipValidator.validateMembershipSubmit(recruitmentRound, Optional.of(membership)))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MEMBERSHIP_ALREADY_SATISFIED.getMessage());
+        }
+
+        @Test
+        void 해당_학기에_이미_Membership을_생성한_적이_있다면_실패한다() {
+            // given
+            Member member = Member.createGuestMember(OAUTH_ID);
+            member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
+            member.completeUnivEmailVerification(UNIV_EMAIL);
+            member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
+            member.verifyBevy();
+            member.advanceToAssociate();
+
+            Recruitment recruitment = Recruitment.createRecruitment(
+                    ACADEMIC_YEAR, SEMESTER_TYPE, FEE, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
+
+            RecruitmentRound recruitmentRound =
+                    RecruitmentRound.create(RECRUITMENT_NAME, START_DATE, END_DATE, recruitment, ROUND_TYPE);
+
+            Membership membership = Membership.createMembership(member, recruitmentRound);
+
+            // when & then
+            assertThatThrownBy(() ->
+                            membershipValidator.validateMembershipSubmit(recruitmentRound, Optional.of(membership)))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(MEMBERSHIP_ALREADY_SUBMITTED.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #461

## 📌 작업 내용 및 특이사항
- 리쿠르팅 정규화 과정에서 service가 null을 반환하게 했었던 멤버십 가입 신청 접수 api를 복구했습니다.

## 📝 참고사항
- 가입 신청 접수를 submit membership이라고 부르고 있으므로, 
`MEMBERSHIP_ALREADY_APPLIED`를 `MEMBERSHIP_ALREADY_SUBMITTED`로 수정했습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 멤버십 제출 시 중복 멤버십 검증 및 요구 사항 충족 여부를 확인하는 `MembershipValidator` 추가

- **버그 수정**
  - 기존 `MEMBERSHIP_ALREADY_APPLIED` 오류 코드를 `MEMBERSHIP_ALREADY_SUBMITTED`로 이름 변경
  - 새로운 오류 코드 `MEMBERSHIP_RECRUITMENT_ROUND_NOT_OPEN` 추가

- **테스트**
  - `MembershipServiceTest`와 `MembershipValidatorTest`에 새로운 검증 시나리오 테스트 추가
  - `MembershipTest`에서 멤버 역할 검증 로직 수정 및 추가 검증 로직 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->