### PR TITLE
feat: Feign ErrorDecoder 관련 예외처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ dependencies {
 
     // OpenFeign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'io.github.openfeign:feign-jackson'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorResponse.java
@@ -8,4 +8,8 @@ public record ErrorResponse(String errorCodeName, String errorMessage) {
     public static ErrorResponse of(ErrorCode errorCode, String errorMessage) {
         return new ErrorResponse(errorCode.name(), errorMessage);
     }
+
+    public static ErrorResponse of(String errorCodeName, String errorMessage) {
+        return new ErrorResponse(errorCodeName, errorMessage);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.global.exception;
 
+import com.gdschongik.gdsc.infra.feign.payment.error.CustomPaymentException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
@@ -18,6 +19,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
         log.error("CustomException : {}", e.getMessage(), e);
         return ResponseEntity.status(e.getErrorCode().getStatus()).body(ErrorResponse.of(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(CustomPaymentException.class)
+    public ResponseEntity<ErrorResponse> handleCustomPaymentException(CustomPaymentException e) {
+        log.error("CustomPaymentException : {}, {}", e.getCode(), e.getMessage());
+        return ResponseEntity.status(e.getStatus()).body(ErrorResponse.of(e.getCode(), e.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/gdschongik/gdsc/infra/feign/global/config/FeignConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/feign/global/config/FeignConfig.java
@@ -1,4 +1,4 @@
-package com.gdschongik.gdsc.global.config;
+package com.gdschongik.gdsc.infra.feign.global.config;
 
 import feign.Logger;
 import org.springframework.cloud.openfeign.EnableFeignClients;

--- a/src/main/java/com/gdschongik/gdsc/infra/feign/global/config/FeignConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/feign/global/config/FeignConfig.java
@@ -1,6 +1,10 @@
 package com.gdschongik.gdsc.infra.feign.global.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.Logger;
+import feign.codec.Decoder;
+import feign.jackson.JacksonDecoder;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignFormatterRegistrar;
 import org.springframework.context.annotation.Bean;
@@ -10,6 +14,17 @@ import org.springframework.format.datetime.standard.DateTimeFormatterRegistrar;
 @Configuration
 @EnableFeignClients("com.gdschongik.gdsc.infra")
 public class FeignConfig {
+
+    @Bean
+    public Decoder feignDecoder() {
+        return new JacksonDecoder(customObjectMapper());
+    }
+
+    public ObjectMapper customObjectMapper() {
+        return new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
+    }
 
     @Bean
     Logger.Level feignLoggerLevel() {

--- a/src/main/java/com/gdschongik/gdsc/infra/feign/payment/client/PaymentClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/feign/payment/client/PaymentClient.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.infra.feign.payment.client;
 
-import com.gdschongik.gdsc.infra.feign.payment.config.BasicAuthConfig;
+import com.gdschongik.gdsc.infra.feign.payment.config.PaymentClientConfig;
 import com.gdschongik.gdsc.infra.feign.payment.dto.request.PaymentConfirmRequest;
 import com.gdschongik.gdsc.infra.feign.payment.dto.response.PaymentResponse;
 import jakarta.validation.Valid;
@@ -8,10 +8,8 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@FeignClient(name = "paymentClient", url = "https://api.tosspayments.com", configuration = BasicAuthConfig.class)
+@FeignClient(name = "paymentClient", url = "https://api.tosspayments.com", configuration = PaymentClientConfig.class)
 public interface PaymentClient {
-
-    // TODO: Feign 예외 처리 구현
 
     @PostMapping("/v1/payments/confirm")
     PaymentResponse confirm(@Valid @RequestBody PaymentConfirmRequest request);

--- a/src/main/java/com/gdschongik/gdsc/infra/feign/payment/config/PaymentClientConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/feign/payment/config/PaymentClientConfig.java
@@ -1,0 +1,14 @@
+package com.gdschongik.gdsc.infra.feign.payment.config;
+
+import com.gdschongik.gdsc.infra.feign.payment.error.PaymentErrorDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+@Import({BasicAuthConfig.class, PaymentErrorDecoder.class})
+public class PaymentClientConfig {
+
+    @Bean
+    public PaymentErrorDecoder paymentErrorDecoder() {
+        return new PaymentErrorDecoder();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/infra/feign/payment/error/CustomPaymentException.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/feign/payment/error/CustomPaymentException.java
@@ -1,0 +1,12 @@
+package com.gdschongik.gdsc.infra.feign.payment.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomPaymentException extends RuntimeException {
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/gdschongik/gdsc/infra/feign/payment/error/PaymentErrorDecoder.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/feign/payment/error/PaymentErrorDecoder.java
@@ -1,0 +1,22 @@
+package com.gdschongik.gdsc.infra.feign.payment.error;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import java.io.IOException;
+
+public class PaymentErrorDecoder implements ErrorDecoder {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ErrorDecoder defaultErrorDecoder = new Default();
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        try {
+            var paymentErrorDto = objectMapper.readValue(response.body().asInputStream(), PaymentErrorDto.class);
+            return new CustomPaymentException(response.status(), paymentErrorDto.code(), paymentErrorDto.message());
+        } catch (IOException e) {
+            return defaultErrorDecoder.decode(methodKey, response);
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/infra/feign/payment/error/PaymentErrorDto.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/feign/payment/error/PaymentErrorDto.java
@@ -1,0 +1,3 @@
+package com.gdschongik.gdsc.infra.feign.payment.error;
+
+public record PaymentErrorDto(String code, String message) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #479

## 📌 작업 내용 및 특이사항
### FeignConfig 위치 변경
- infra 패키지에서 config 설정까지 관리하는 게 맞을 것 같아 옮겼습니다.

### Decoder 관련
- Feign의 기본 설정값인 SpringDecoder의 경우 프로덕션에서 성능 문제가 있어, JacksonDecoder를 사용하도록 설정했습니다.
> feign client에서 jackson 메시지 변환기를 사용하려면 JacksonDecoder를 사용하세요. SpringDecoder는 프로덕션 환경에서 feignclient 호출의 평균 지연 시간을 증가시킵니다. (...)
> 제 인상으로는 크게 개선되었습니다. 프로덕션에서 8k QPS의 경우 평균 10ms가 개선되었습니다.[(레퍼런스)](https://stackoverflow.com/questions/35853908/how-to-set-custom-jackson-objectmapper-with-spring-cloud-netflix-feign)
- 토스페이먼츠 측에서 enum 추가, 에러코드 변경 등의 건은 신규 버전 릴리즈 없이 즉시 반영되기 때문에, 1) 추가 응답 필드가 들어오는 경우 무시 2) 사전에 설정하지 않은 enum 값이 들어오는 경우 null로 변환하도록 했습니다. (ObjectMapper 관련 코드 체크)
> API 응답이나 웹훅 이벤트 본문에 새로운 필드가 추가와 같이 [하위 호환을 지원하는 변경 사항](https://docs.tosspayments.com/reference/versioning#%ED%95%98%EC%9C%84-%ED%98%B8%ED%99%98%EC%9D%84-%EC%A7%80%EC%9B%90%ED%95%98%EB%8A%94-%EB%B3%80%EA%B2%BD-%EC%82%AC%ED%95%AD)은 버전 릴리즈 없이 기존 API에 반영됩니다. 클라이언트 코드는 이러한 변경에 유연하게 대응할 수 있도록 작성해 주세요. 추가된 새로운 필드를 무시하거나 기본값을 설정하는 방식으로 JSON 파싱 로직을 구성해 주세요. 
> 예를 들어 Java에서는 ObjectMapper를 사용해서 JSON 응답을 처리할 때 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false) 옵션을 설정하면 새로운 필드가 추가되어도 오류가 발생하지 않을 수 있습니다. [(레퍼런스)](https://docs.tosspayments.com/reference/using-api/req-res#%EC%9C%A0%EC%9D%98%EC%82%AC%ED%95%AD)
### 예외 처리 관련
- PaymentErrorDecoder는 토스페이먼츠 API 호출 시 내려주는 응답을 역직렬화하여 PaymentErrorDto로 매핑합니다. 그리고 이를 CustomPaymentException으로 변환하여 반환합니다.
- 이렇게 반환된 예외는 GlobalExceptionHandler의 관련 로직에 의해 캐치하여 처리됩니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 사용자 지정 결제 예외(`CustomPaymentException`) 및 에러 디코더(`PaymentErrorDecoder`) 추가로 결제 관련 오류 처리 기능 향상
- **버그 수정**
  - 전역 예외 처리기(`GlobalExceptionHandler`)에 새로운 예외 처리 메서드 추가로 에러 응답 개선
- **개선**
  - `PaymentClient` 인터페이스에 새로운 설정 클래스(`PaymentClientConfig`) 적용하여 구성 관리 간소화
  - `ErrorResponse` 클래스에 새로운 정적 메서드 추가로 에러 응답 생성 유연성 증가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->