### PR TITLE
refactor: 디스코드 연동 로직에 도메인 서비스 적용

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
@@ -19,9 +19,11 @@ import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.security.SecureRandom;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OnboardingDiscordService {
@@ -72,6 +74,8 @@ public class OnboardingDiscordService {
         currentMember.verifyDiscord(request.discordUsername(), request.nickname());
 
         updateDiscordId(request.discordUsername(), currentMember);
+
+        log.info("[OnboardingDiscordService] 디스코드 연동: memberId={}", currentMember.getId());
     }
 
     private void updateDiscordId(String discordUsername, Member currentMember) {

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/domain/DiscordValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/domain/DiscordValidator.java
@@ -13,14 +13,17 @@ public class DiscordValidator {
             DiscordVerificationCode discordVerificationCode,
             boolean isDiscordUsernameDuplicate,
             boolean isNicknameDuplicate) {
+        // 입력받은 코드가 일치하는지 검증
         if (!discordVerificationCode.matchesCode(code)) {
             throw new CustomException(DISCORD_CODE_MISMATCH);
         }
 
+        // 디스코드 유저네임이 중복되는지 검증
         if (isDiscordUsernameDuplicate) {
             throw new CustomException(MEMBER_DISCORD_USERNAME_DUPLICATE);
         }
 
+        // 닉네임이 중복되는지 검증
         if (isNicknameDuplicate) {
             throw new CustomException(MEMBER_NICKNAME_DUPLICATE);
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/domain/DiscordValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/domain/DiscordValidator.java
@@ -1,0 +1,28 @@
+package com.gdschongik.gdsc.domain.discord.domain;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.global.annotation.DomainService;
+import com.gdschongik.gdsc.global.exception.CustomException;
+
+@DomainService
+public class DiscordValidator {
+
+    public void validateVerifyDiscordCode(
+            Integer code,
+            DiscordVerificationCode discordVerificationCode,
+            boolean isDiscordUsernameDuplicate,
+            boolean isNicknameDuplicate) {
+        if (!discordVerificationCode.matchesCode(code)) {
+            throw new CustomException(DISCORD_CODE_MISMATCH);
+        }
+
+        if (isDiscordUsernameDuplicate) {
+            throw new CustomException(MEMBER_DISCORD_USERNAME_DUPLICATE);
+        }
+
+        if (isNicknameDuplicate) {
+            throw new CustomException(MEMBER_NICKNAME_DUPLICATE);
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/domain/DiscordValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/domain/DiscordValidator.java
@@ -9,12 +9,12 @@ import com.gdschongik.gdsc.global.exception.CustomException;
 public class DiscordValidator {
 
     public void validateVerifyDiscordCode(
-            Integer code,
+            Integer requestedCode,
             DiscordVerificationCode discordVerificationCode,
             boolean isDiscordUsernameDuplicate,
             boolean isNicknameDuplicate) {
         // 입력받은 코드가 일치하는지 검증
-        if (!discordVerificationCode.matchesCode(code)) {
+        if (!discordVerificationCode.matchesCode(requestedCode)) {
             throw new CustomException(DISCORD_CODE_MISMATCH);
         }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/discord/DiscordValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/discord/DiscordValidatorTest.java
@@ -1,0 +1,59 @@
+package com.gdschongik.gdsc.domain.discord;
+
+import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.discord.domain.DiscordValidator;
+import com.gdschongik.gdsc.domain.discord.domain.DiscordVerificationCode;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class DiscordValidatorTest {
+
+    DiscordValidator discordValidator = new DiscordValidator();
+
+    @Nested
+    class 디스코드_연동시 {
+
+        @Test
+        void 인증코드가_일치하지_않는다면_실패한다() {
+            // given
+            DiscordVerificationCode discordVerificationCode =
+                    DiscordVerificationCode.create(DISCORD_USERNAME, DISCORD_CODE, DISCORD_CODE_TTL);
+
+            // when & then
+            assertThatThrownBy(() ->
+                            discordValidator.validateVerifyDiscordCode(1235, discordVerificationCode, false, false))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(DISCORD_CODE_MISMATCH.getMessage());
+        }
+
+        @Test
+        void 이미_존재하는_디스코드_유저네임이라면_실패한다() {
+            // given
+            DiscordVerificationCode discordVerificationCode =
+                    DiscordVerificationCode.create(DISCORD_USERNAME, DISCORD_CODE, DISCORD_CODE_TTL);
+
+            // when & then
+            assertThatThrownBy(() -> discordValidator.validateVerifyDiscordCode(
+                            DISCORD_CODE, discordVerificationCode, true, false))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(MEMBER_DISCORD_USERNAME_DUPLICATE.getMessage());
+        }
+
+        @Test
+        void 이미_존재하는_닉네임이라면_실패한다() {
+            // given
+            DiscordVerificationCode discordVerificationCode =
+                    DiscordVerificationCode.create(DISCORD_USERNAME, DISCORD_CODE, DISCORD_CODE_TTL);
+
+            // when & then
+            assertThatThrownBy(() -> discordValidator.validateVerifyDiscordCode(
+                            DISCORD_CODE, discordVerificationCode, false, true))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(MEMBER_NICKNAME_DUPLICATE.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/DiscordConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/DiscordConstant.java
@@ -1,0 +1,9 @@
+package com.gdschongik.gdsc.global.common.constant;
+
+public class DiscordConstant {
+    private DiscordConstant() {}
+
+    public static final String DISCORD_USERNAME = "유저네임";
+    public static final Integer DISCORD_CODE = 1234;
+    public static final Long DISCORD_CODE_TTL = 300L;
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #483

## 📌 작업 내용 및 특이사항
- 아래의 3가지에 대한 검증을 `OnboardingDiscordService`에서 `DiscordValidator`로 옮겼습니다.
  - 인증코드 일치여부
  - 유저네임 중복여부
  - 닉네임 중복여부

## 📝 참고사항
-

## 📚 기타
- 수정하는 김에 로그도 한 줄 추가했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- Discord 사용자 검증을 위한 `DiscordValidator` 클래스 추가, 중복 사용자 이름 및 별명 검증 기능 포함.
	- Discord 코드 검증의 효율성을 높이기 위한 통합 검증 로직 개선.

- **버그 수정**
	- Discord 계정 링크 시 발생할 수 있는 오류 로깅 기능 추가.

- **문서화**
	- Discord 관련 상수를 관리하기 위한 `DiscordConstant` 클래스 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->