### PR TITLE
refactor: 메일 발송 요청 로직에 도메인 서비스 적용

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/email/application/UnivEmailVerificationLinkSendService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/email/application/UnivEmailVerificationLinkSendService.java
@@ -4,8 +4,6 @@ import static com.gdschongik.gdsc.global.common.constant.EmailConstant.VERIFICAT
 
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import com.gdschongik.gdsc.global.util.email.EmailVerificationTokenUtil;
 import com.gdschongik.gdsc.global.util.email.HongikUnivEmailValidator;
@@ -14,6 +12,7 @@ import com.gdschongik.gdsc.global.util.email.VerificationLinkUtil;
 import java.time.Duration;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +29,7 @@ public class UnivEmailVerificationLinkSendService {
     private final EmailVerificationTokenUtil emailVerificationTokenUtil;
     private final VerificationLinkUtil verificationLinkUtil;
     private final MemberUtil memberUtil;
+
     public static final Duration VERIFICATION_TOKEN_TIME_TO_LIVE = Duration.ofMinutes(30);
 
     private static final String NOTIFICATION_MESSAGE =
@@ -45,14 +45,14 @@ public class UnivEmailVerificationLinkSendService {
 """;
 
     public void send(String univEmail) {
-        hongikUnivEmailValidator.validate(univEmail);
-        validateUnivEmailNotSatisfied(univEmail);
+        Optional<Member> member = memberRepository.findByUnivEmail(univEmail);
+
+        hongikUnivEmailValidator.validate(univEmail, member);
 
         String verificationToken = generateVerificationToken(univEmail);
         String verificationLink = verificationLinkUtil.createLink(verificationToken);
         String mailContent = writeMailContentWithVerificationLink(verificationLink);
         mailSender.send(univEmail, VERIFICATION_EMAIL_SUBJECT, mailContent);
-    }
 
         log.info("[UnivEmailVerificationLinkSendService] 학생 인증 메일 발송: univEmail={}", univEmail);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/email/application/UnivEmailVerificationLinkSendService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/email/application/UnivEmailVerificationLinkSendService.java
@@ -47,7 +47,7 @@ public class UnivEmailVerificationLinkSendService {
     public void send(String univEmail) {
         Optional<Member> member = memberRepository.findByUnivEmail(univEmail);
 
-        hongikUnivEmailValidator.validate(univEmail, member);
+        hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(univEmail, member);
 
         String verificationToken = generateVerificationToken(univEmail);
         String verificationLink = verificationLinkUtil.createLink(verificationToken);

--- a/src/main/java/com/gdschongik/gdsc/domain/email/application/UnivEmailVerificationLinkSendService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/email/application/UnivEmailVerificationLinkSendService.java
@@ -2,11 +2,11 @@ package com.gdschongik.gdsc.domain.email.application;
 
 import static com.gdschongik.gdsc.global.common.constant.EmailConstant.VERIFICATION_EMAIL_SUBJECT;
 
+import com.gdschongik.gdsc.domain.email.domain.HongikUnivEmailValidator;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import com.gdschongik.gdsc.global.util.email.EmailVerificationTokenUtil;
-import com.gdschongik.gdsc.global.util.email.HongikUnivEmailValidator;
 import com.gdschongik.gdsc.global.util.email.MailSender;
 import com.gdschongik.gdsc.global.util.email.VerificationLinkUtil;
 import java.time.Duration;

--- a/src/main/java/com/gdschongik/gdsc/domain/email/application/UnivEmailVerificationLinkSendService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/email/application/UnivEmailVerificationLinkSendService.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -53,11 +54,7 @@ public class UnivEmailVerificationLinkSendService {
         mailSender.send(univEmail, VERIFICATION_EMAIL_SUBJECT, mailContent);
     }
 
-    private void validateUnivEmailNotSatisfied(String univEmail) {
-        Optional<Member> member = memberRepository.findByUnivEmail(univEmail);
-        if (member.isPresent()) {
-            throw new CustomException(ErrorCode.UNIV_EMAIL_ALREADY_SATISFIED);
-        }
+        log.info("[UnivEmailVerificationLinkSendService] 학생 인증 메일 발송: univEmail={}", univEmail);
     }
 
     private String generateVerificationToken(String univEmail) {

--- a/src/main/java/com/gdschongik/gdsc/domain/email/application/UnivEmailVerificationLinkSendService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/email/application/UnivEmailVerificationLinkSendService.java
@@ -4,13 +4,11 @@ import static com.gdschongik.gdsc.global.common.constant.EmailConstant.VERIFICAT
 
 import com.gdschongik.gdsc.domain.email.domain.HongikUnivEmailValidator;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
-import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import com.gdschongik.gdsc.global.util.email.EmailVerificationTokenUtil;
 import com.gdschongik.gdsc.global.util.email.MailSender;
 import com.gdschongik.gdsc.global.util.email.VerificationLinkUtil;
 import java.time.Duration;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -45,9 +43,9 @@ public class UnivEmailVerificationLinkSendService {
 """;
 
     public void send(String univEmail) {
-        Optional<Member> member = memberRepository.findByUnivEmail(univEmail);
+        boolean isUnivEmailDuplicate = memberRepository.existsByUnivEmail(univEmail);
 
-        hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(univEmail, member);
+        hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(univEmail, isUnivEmailDuplicate);
 
         String verificationToken = generateVerificationToken(univEmail);
         String verificationLink = verificationLinkUtil.createLink(verificationToken);

--- a/src/main/java/com/gdschongik/gdsc/domain/email/domain/HongikUnivEmailValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/email/domain/HongikUnivEmailValidator.java
@@ -1,4 +1,4 @@
-package com.gdschongik.gdsc.global.util.email;
+package com.gdschongik.gdsc.domain.email.domain;
 
 import static com.gdschongik.gdsc.global.common.constant.EmailConstant.HONGIK_UNIV_MAIL_DOMAIN;
 import static com.gdschongik.gdsc.global.common.constant.RegexConstant.HONGIK_EMAIL;

--- a/src/main/java/com/gdschongik/gdsc/domain/email/domain/HongikUnivEmailValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/email/domain/HongikUnivEmailValidator.java
@@ -4,15 +4,13 @@ import static com.gdschongik.gdsc.global.common.constant.EmailConstant.HONGIK_UN
 import static com.gdschongik.gdsc.global.common.constant.RegexConstant.HONGIK_EMAIL;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
-import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
-import java.util.Optional;
 
 @DomainService
 public class HongikUnivEmailValidator {
 
-    public void validateSendUnivEmailVerificationLink(String email, Optional<Member> optionalMember) {
+    public void validateSendUnivEmailVerificationLink(String email, boolean isUnivEmailDuplicate) {
         if (!email.contains(HONGIK_UNIV_MAIL_DOMAIN)) {
             throw new CustomException(UNIV_EMAIL_DOMAIN_MISMATCH);
         }
@@ -21,7 +19,7 @@ public class HongikUnivEmailValidator {
             throw new CustomException(UNIV_EMAIL_FORMAT_MISMATCH);
         }
 
-        if (optionalMember.isPresent()) {
+        if (isUnivEmailDuplicate) {
             throw new CustomException(UNIV_EMAIL_ALREADY_SATISFIED);
         }
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
@@ -9,9 +9,9 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberCus
 
     boolean existsByNickname(String nickname);
 
-    Optional<Member> findByDiscordUsername(String discordUsername);
+    boolean existsByUnivEmail(String univEmail);
 
-    Optional<Member> findByUnivEmail(String univEmail);
+    Optional<Member> findByDiscordUsername(String discordUsername);
 
     Optional<Member> findByOauthId(String oauthId);
 }

--- a/src/main/java/com/gdschongik/gdsc/global/util/email/HongikUnivEmailValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/email/HongikUnivEmailValidator.java
@@ -3,13 +3,13 @@ package com.gdschongik.gdsc.global.util.email;
 import static com.gdschongik.gdsc.global.common.constant.EmailConstant.HONGIK_UNIV_MAIL_DOMAIN;
 import static com.gdschongik.gdsc.global.common.constant.RegexConstant.HONGIK_EMAIL;
 
+import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-@Component
-@RequiredArgsConstructor
+@DomainService
 public class HongikUnivEmailValidator {
 
     public void validate(String email) {

--- a/src/main/java/com/gdschongik/gdsc/global/util/email/HongikUnivEmailValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/email/HongikUnivEmailValidator.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 @DomainService
 public class HongikUnivEmailValidator {
 
-    public void validate(String email, Optional<Member> optionalMember) {
+    public void validateSendUnivEmailVerificationLink(String email, Optional<Member> optionalMember) {
         if (!email.contains(HONGIK_UNIV_MAIL_DOMAIN)) {
             throw new CustomException(UNIV_EMAIL_DOMAIN_MISMATCH);
         }

--- a/src/main/java/com/gdschongik/gdsc/global/util/email/HongikUnivEmailValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/email/HongikUnivEmailValidator.java
@@ -2,19 +2,19 @@ package com.gdschongik.gdsc.global.util.email;
 
 import static com.gdschongik.gdsc.global.common.constant.EmailConstant.HONGIK_UNIV_MAIL_DOMAIN;
 import static com.gdschongik.gdsc.global.common.constant.RegexConstant.HONGIK_EMAIL;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
+import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.global.exception.ErrorCode;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
+import java.util.Optional;
 
 @DomainService
 public class HongikUnivEmailValidator {
 
     public void validate(String email, Optional<Member> optionalMember) {
         if (!email.contains(HONGIK_UNIV_MAIL_DOMAIN)) {
-            throw new CustomException(ErrorCode.UNIV_EMAIL_DOMAIN_MISMATCH);
+            throw new CustomException(UNIV_EMAIL_DOMAIN_MISMATCH);
         }
 
         if (!email.matches(HONGIK_EMAIL)) {

--- a/src/main/java/com/gdschongik/gdsc/global/util/email/HongikUnivEmailValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/email/HongikUnivEmailValidator.java
@@ -12,13 +12,17 @@ import org.springframework.stereotype.Component;
 @DomainService
 public class HongikUnivEmailValidator {
 
-    public void validate(String email) {
+    public void validate(String email, Optional<Member> optionalMember) {
         if (!email.contains(HONGIK_UNIV_MAIL_DOMAIN)) {
             throw new CustomException(ErrorCode.UNIV_EMAIL_DOMAIN_MISMATCH);
         }
 
         if (!email.matches(HONGIK_EMAIL)) {
-            throw new CustomException(ErrorCode.UNIV_EMAIL_FORMAT_MISMATCH);
+            throw new CustomException(UNIV_EMAIL_FORMAT_MISMATCH);
+        }
+
+        if (optionalMember.isPresent()) {
+            throw new CustomException(UNIV_EMAIL_ALREADY_SATISFIED);
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/email/domain/HongikUnivEmailValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/email/domain/HongikUnivEmailValidatorTest.java
@@ -26,7 +26,8 @@ class HongikUnivEmailValidatorTest {
         Optional<Member> optionalMember = Optional.empty();
 
         // when & then
-        assertThatCode(() -> hongikUnivEmailValidator.validate(hongikDomainEmail, optionalMember))
+        assertThatCode(() -> hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(
+                        hongikDomainEmail, optionalMember))
                 .doesNotThrowAnyException();
     }
 
@@ -38,7 +39,7 @@ class HongikUnivEmailValidatorTest {
         Optional<Member> optionalMember = Optional.empty();
 
         // when & then
-        assertThatThrownBy(() -> hongikUnivEmailValidator.validate(email, optionalMember))
+        assertThatThrownBy(() -> hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(email, optionalMember))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.UNIV_EMAIL_DOMAIN_MISMATCH.getMessage());
     }
@@ -50,7 +51,7 @@ class HongikUnivEmailValidatorTest {
         String email = "t.e.s.t@g.hongik.ac.kr";
         Optional<Member> optionalMember = Optional.empty();
 
-        assertThatCode(() -> hongikUnivEmailValidator.validate(email, optionalMember))
+        assertThatCode(() -> hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(email, optionalMember))
                 .doesNotThrowAnyException();
     }
 
@@ -72,7 +73,7 @@ class HongikUnivEmailValidatorTest {
         Optional<Member> optionalMember = Optional.empty();
 
         // when & then
-        assertThatThrownBy(() -> hongikUnivEmailValidator.validate(email, optionalMember))
+        assertThatThrownBy(() -> hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(email, optionalMember))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.UNIV_EMAIL_FORMAT_MISMATCH.getMessage());
     }
@@ -85,7 +86,7 @@ class HongikUnivEmailValidatorTest {
         Optional<Member> optionalMember = Optional.empty();
 
         // when & then
-        assertThatThrownBy(() -> hongikUnivEmailValidator.validate(email, optionalMember))
+        assertThatThrownBy(() -> hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(email, optionalMember))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.UNIV_EMAIL_FORMAT_MISMATCH.getMessage());
     }
@@ -99,7 +100,8 @@ class HongikUnivEmailValidatorTest {
         Optional<Member> optionalMember = Optional.of(member);
 
         // when & then
-        assertThatThrownBy(() -> hongikUnivEmailValidator.validate(hongikDomainEmail, optionalMember))
+        assertThatThrownBy(() -> hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(
+                        hongikDomainEmail, optionalMember))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(UNIV_EMAIL_ALREADY_SATISFIED.getMessage());
     }

--- a/src/test/java/com/gdschongik/gdsc/domain/email/domain/HongikUnivEmailValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/email/domain/HongikUnivEmailValidatorTest.java
@@ -1,32 +1,32 @@
-package com.gdschongik.gdsc.domain.email;
+package com.gdschongik.gdsc.domain.email.domain;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.global.common.constant.MemberConstant;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.global.util.email.HongikUnivEmailValidator;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
-@ActiveProfiles("test")
 class HongikUnivEmailValidatorTest {
 
-    @Autowired
-    private HongikUnivEmailValidator hongikUnivEmailValidator;
+    HongikUnivEmailValidator hongikUnivEmailValidator = new HongikUnivEmailValidator();
 
     @Test
     @DisplayName("'g.hongik.ac.kr' 도메인을 가진 이메일을 검증할 수 있다.")
     void validateEmailDomainTest() {
+        // given
         String hongikDomainEmail = "test@g.hongik.ac.kr";
+        Optional<Member> optionalMember = Optional.empty();
 
-        assertThatCode(() -> hongikUnivEmailValidator.validate(hongikDomainEmail))
+        // when & then
+        assertThatCode(() -> hongikUnivEmailValidator.validate(hongikDomainEmail, optionalMember))
                 .doesNotThrowAnyException();
     }
 
@@ -34,7 +34,11 @@ class HongikUnivEmailValidatorTest {
     @ValueSource(strings = {"test@naver.com", "test@mail.hongik.ac.kr", "test@gmail.com", "test@gg.hongik.ac.kr"})
     @DisplayName("'g.hongik.ac.kr'가 아닌 도메인을 가진 이메일을 입력하면 예외를 발생시킨다.")
     void validateEmailDomainMismatchTest(String email) {
-        assertThatThrownBy(() -> hongikUnivEmailValidator.validate(email))
+        // given
+        Optional<Member> optionalMember = Optional.empty();
+
+        // when & then
+        assertThatThrownBy(() -> hongikUnivEmailValidator.validate(email, optionalMember))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.UNIV_EMAIL_DOMAIN_MISMATCH.getMessage());
     }
@@ -42,9 +46,12 @@ class HongikUnivEmailValidatorTest {
     @Test
     @DisplayName("Email의 '@' 앞 부분에는 연속되지 않은 점이 포함될 수 있다.")
     void validateEmailFormatWithDotsTest() {
+        // given
         String email = "t.e.s.t@g.hongik.ac.kr";
+        Optional<Member> optionalMember = Optional.empty();
 
-        assertThatCode(() -> hongikUnivEmailValidator.validate(email)).doesNotThrowAnyException();
+        assertThatCode(() -> hongikUnivEmailValidator.validate(email, optionalMember))
+                .doesNotThrowAnyException();
     }
 
     @ParameterizedTest
@@ -61,7 +68,11 @@ class HongikUnivEmailValidatorTest {
             })
     @DisplayName("Email의 '@' 앞 부분에 '&', '=', ''', '-', '+', ',', '<', '>'가 포함되는 경우 예외를 발생시킨다.")
     void validateEmailFormatMismatchTest(String email) {
-        assertThatThrownBy(() -> hongikUnivEmailValidator.validate(email))
+        // given
+        Optional<Member> optionalMember = Optional.empty();
+
+        // when & then
+        assertThatThrownBy(() -> hongikUnivEmailValidator.validate(email, optionalMember))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.UNIV_EMAIL_FORMAT_MISMATCH.getMessage());
     }
@@ -69,9 +80,27 @@ class HongikUnivEmailValidatorTest {
     @Test
     @DisplayName("Email의 '@' 앞 부분에 '.'이 2개 연속 오는 경우 예외를 발생시킨다.")
     void validateEmailFormatMismatchWithDotsTest() {
+        // given
         String email = "te..st@g.hongik.ac.kr";
-        assertThatThrownBy(() -> hongikUnivEmailValidator.validate(email))
+        Optional<Member> optionalMember = Optional.empty();
+
+        // when & then
+        assertThatThrownBy(() -> hongikUnivEmailValidator.validate(email, optionalMember))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.UNIV_EMAIL_FORMAT_MISMATCH.getMessage());
+    }
+
+    @Test
+    void 이미_가입된_재학생_메일이라면_실패한다() {
+        // given
+        String hongikDomainEmail = "test@g.hongik.ac.kr";
+
+        Member member = Member.createGuestMember(MemberConstant.OAUTH_ID);
+        Optional<Member> optionalMember = Optional.of(member);
+
+        // when & then
+        assertThatThrownBy(() -> hongikUnivEmailValidator.validate(hongikDomainEmail, optionalMember))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(UNIV_EMAIL_ALREADY_SATISFIED.getMessage());
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/email/domain/HongikUnivEmailValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/email/domain/HongikUnivEmailValidatorTest.java
@@ -3,11 +3,8 @@ package com.gdschongik.gdsc.domain.email.domain;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
-import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.global.common.constant.MemberConstant;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -22,11 +19,9 @@ class HongikUnivEmailValidatorTest {
     void validateEmailDomainTest() {
         // given
         String hongikDomainEmail = "test@g.hongik.ac.kr";
-        Optional<Member> optionalMember = Optional.empty();
 
         // when & then
-        assertThatCode(() -> hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(
-                        hongikDomainEmail, optionalMember))
+        assertThatCode(() -> hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(hongikDomainEmail, false))
                 .doesNotThrowAnyException();
     }
 
@@ -34,11 +29,8 @@ class HongikUnivEmailValidatorTest {
     @ValueSource(strings = {"test@naver.com", "test@mail.hongik.ac.kr", "test@gmail.com", "test@gg.hongik.ac.kr"})
     @DisplayName("'g.hongik.ac.kr'가 아닌 도메인을 가진 이메일을 입력하면 예외를 발생시킨다.")
     void validateEmailDomainMismatchTest(String email) {
-        // given
-        Optional<Member> optionalMember = Optional.empty();
-
         // when & then
-        assertThatThrownBy(() -> hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(email, optionalMember))
+        assertThatThrownBy(() -> hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(email, false))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.UNIV_EMAIL_DOMAIN_MISMATCH.getMessage());
     }
@@ -48,9 +40,9 @@ class HongikUnivEmailValidatorTest {
     void validateEmailFormatWithDotsTest() {
         // given
         String email = "t.e.s.t@g.hongik.ac.kr";
-        Optional<Member> optionalMember = Optional.empty();
 
-        assertThatCode(() -> hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(email, optionalMember))
+        // when & then
+        assertThatCode(() -> hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(email, false))
                 .doesNotThrowAnyException();
     }
 
@@ -68,11 +60,8 @@ class HongikUnivEmailValidatorTest {
             })
     @DisplayName("Email의 '@' 앞 부분에 '&', '=', ''', '-', '+', ',', '<', '>'가 포함되는 경우 예외를 발생시킨다.")
     void validateEmailFormatMismatchTest(String email) {
-        // given
-        Optional<Member> optionalMember = Optional.empty();
-
         // when & then
-        assertThatThrownBy(() -> hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(email, optionalMember))
+        assertThatThrownBy(() -> hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(email, false))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.UNIV_EMAIL_FORMAT_MISMATCH.getMessage());
     }
@@ -82,10 +71,9 @@ class HongikUnivEmailValidatorTest {
     void validateEmailFormatMismatchWithDotsTest() {
         // given
         String email = "te..st@g.hongik.ac.kr";
-        Optional<Member> optionalMember = Optional.empty();
 
         // when & then
-        assertThatThrownBy(() -> hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(email, optionalMember))
+        assertThatThrownBy(() -> hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(email, false))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.UNIV_EMAIL_FORMAT_MISMATCH.getMessage());
     }
@@ -95,12 +83,9 @@ class HongikUnivEmailValidatorTest {
         // given
         String hongikDomainEmail = "test@g.hongik.ac.kr";
 
-        Member member = Member.createGuestMember(MemberConstant.OAUTH_ID);
-        Optional<Member> optionalMember = Optional.of(member);
-
         // when & then
-        assertThatThrownBy(() -> hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(
-                        hongikDomainEmail, optionalMember))
+        assertThatThrownBy(
+                        () -> hongikUnivEmailValidator.validateSendUnivEmailVerificationLink(hongikDomainEmail, true))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(UNIV_EMAIL_ALREADY_SATISFIED.getMessage());
     }

--- a/src/test/java/com/gdschongik/gdsc/domain/email/domain/HongikUnivEmailValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/email/domain/HongikUnivEmailValidatorTest.java
@@ -7,7 +7,6 @@ import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.global.common.constant.MemberConstant;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
-import com.gdschongik.gdsc.global.util.email.HongikUnivEmailValidator;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #486

## 📌 작업 내용 및 특이사항
- 원래 있던 `HongikUnivEmailValidator`에 `@DomainService`를 달았습니다.
- 이미 재학생 인증에 사용된 메일인지를 검증하는 로직을 `HongikUnivEmailValidator`에 추가했습니다.

## 📝 참고사항
- 기존 test에 given, when, then 구분이 없길래 추가했습니다.
- log도 같이 추가했습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 대학 이메일 검증 프로세스를 개선하여 회원 데이터 확인 및 유효성 검사를 통합했습니다.
	- 이메일 검증 시 기존 회원의 존재 여부를 고려하는 새로운 검증 규칙을 도입했습니다.

- **버그 수정**
	- 이메일 발송 및 검증 과정에서 로깅 기능이 추가되어 문제 추적이 용이해졌습니다.

- **테스트**
	- 이메일 검증 로직을 반영하여 테스트 케이스를 업데이트하고, 회원 데이터 검사 기능을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->