### PR TITLE
feat: 주문 목록 조회하기 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberQueryOption.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberQueryOption.java
@@ -14,4 +14,6 @@ public record MemberQueryOption(
         @Schema(description = "이메일") String email,
         @Schema(description = "디스코드 유저네임") String discordUsername,
         @Schema(description = "커뮤니티 닉네임", pattern = NICKNAME) String nickname,
-        @Schema(description = "멤버 권한") List<MemberRole> roles) {}
+        @Schema(description = "멤버 권한") List<MemberRole> roles) {
+    // TODO: 키워드 기반 검색 고려하여 pattern 제약조건 제거
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/api/AdminOrderController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/api/AdminOrderController.java
@@ -1,0 +1,34 @@
+package com.gdschongik.gdsc.domain.order.api;
+
+import com.gdschongik.gdsc.domain.order.application.OrderService;
+import com.gdschongik.gdsc.domain.order.dto.request.OrderQueryOption;
+import com.gdschongik.gdsc.domain.order.dto.response.OrderAdminResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Admin Order", description = "주문 어드민 API입니다.")
+@RestController
+@RequestMapping("/admin/orders")
+@RequiredArgsConstructor
+public class AdminOrderController {
+
+    private final OrderService orderService;
+
+    @Operation(summary = "주문 목록 조회하기", description = "주문 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<Page<OrderAdminResponse>> getOrders(
+            @ParameterObject @Valid OrderQueryOption queryOption, @ParameterObject Pageable pageable) {
+        var response = orderService.searchOrders(queryOption, pageable);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/api/AdminOrderController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/api/AdminOrderController.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
@@ -14,6 +14,8 @@ import com.gdschongik.gdsc.domain.order.domain.Order;
 import com.gdschongik.gdsc.domain.order.domain.OrderValidator;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCompleteRequest;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCreateRequest;
+import com.gdschongik.gdsc.domain.order.dto.request.OrderQueryOption;
+import com.gdschongik.gdsc.domain.order.dto.response.OrderAdminResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import com.gdschongik.gdsc.infra.feign.payment.client.PaymentClient;
@@ -22,6 +24,8 @@ import com.gdschongik.gdsc.infra.feign.payment.dto.response.PaymentResponse;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -91,5 +95,10 @@ public class OrderService {
         orderRepository.save(order);
 
         log.info("[OrderService] 주문 완료: orderId={}", order.getId());
+    }
+
+    @Transactional(readOnly = true)
+    public Page<OrderAdminResponse> searchOrders(OrderQueryOption queryOption, Pageable pageable) {
+        return orderRepository.searchOrders(queryOption, pageable);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
@@ -18,6 +18,7 @@ import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import com.gdschongik.gdsc.infra.feign.payment.client.PaymentClient;
 import com.gdschongik.gdsc.infra.feign.payment.dto.request.PaymentConfirmRequest;
+import com.gdschongik.gdsc.infra.feign.payment.dto.response.PaymentResponse;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -82,9 +83,9 @@ public class OrderService {
         orderValidator.validateCompleteOrder(order, issuedCoupon, currentMember, requestedAmount);
 
         var paymentRequest = new PaymentConfirmRequest(request.paymentKey(), order.getNanoId(), request.amount());
-        paymentClient.confirm(paymentRequest);
+        PaymentResponse response = paymentClient.confirm(paymentRequest);
 
-        order.complete(request.paymentKey());
+        order.complete(request.paymentKey(), response.approvedAt());
         issuedCoupon.ifPresent(IssuedCoupon::use);
 
         orderRepository.save(order);

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderCustomRepository.java
@@ -1,0 +1,10 @@
+package com.gdschongik.gdsc.domain.order.dao;
+
+import com.gdschongik.gdsc.domain.order.dto.request.OrderQueryOption;
+import com.gdschongik.gdsc.domain.order.dto.response.OrderAdminResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface OrderCustomRepository {
+    Page<OrderAdminResponse> searchOrders(OrderQueryOption queryOption, Pageable pageable);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderCustomRepositoryImpl.java
@@ -1,0 +1,73 @@
+package com.gdschongik.gdsc.domain.order.dao;
+
+import static com.gdschongik.gdsc.domain.member.domain.QMember.*;
+import static com.gdschongik.gdsc.domain.order.domain.QOrder.*;
+import static com.gdschongik.gdsc.domain.recruitment.domain.QRecruitmentRound.*;
+
+import com.gdschongik.gdsc.domain.order.dto.request.OrderQueryOption;
+import com.gdschongik.gdsc.domain.order.dto.response.OrderAdminResponse;
+import com.gdschongik.gdsc.domain.order.dto.response.QOrderAdminResponse;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.annotation.Nullable;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+@RequiredArgsConstructor
+public class OrderCustomRepositoryImpl implements OrderCustomRepository, OrderQueryMethod {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<OrderAdminResponse> searchOrders(OrderQueryOption queryOption, Pageable pageable) {
+
+        List<Long> ids = getIdsByQueryOption(queryOption, null, order.createdAt.desc());
+
+        List<OrderAdminResponse> fetch = queryFactory
+                .select(getOrderAdminResponse())
+                .from(order)
+                .join(member)
+                .on(eqMember())
+                .join(recruitmentRound)
+                .on(eqRecruitmentRound())
+                .where(order.id.in(ids))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return PageableExecutionUtils.getPage(fetch, pageable, ids::size);
+    }
+
+    private QOrderAdminResponse getOrderAdminResponse() {
+        return new QOrderAdminResponse(
+                order.id,
+                recruitmentRound.academicYear,
+                recruitmentRound.semesterType,
+                member.name,
+                order.status,
+                member.studentId,
+                order.nanoId,
+                order.paymentKey,
+                order.moneyInfo.totalAmount,
+                order.moneyInfo.discountAmount,
+                order.moneyInfo.finalPaymentAmount,
+                order.approvedAt);
+    }
+
+    private List<Long> getIdsByQueryOption(
+            OrderQueryOption queryOption,
+            @Nullable Predicate predicate,
+            @NonNull OrderSpecifier<?>... orderSpecifiers) {
+        return queryFactory
+                .select(order.id)
+                .from(order)
+                .where(matchesOrderQueryOption(queryOption), predicate)
+                .orderBy(orderSpecifiers)
+                .fetch();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderQueryMethod.java
@@ -35,7 +35,7 @@ public interface OrderQueryMethod {
         return paymentKey != null ? order.paymentKey.contains(paymentKey) : null;
     }
 
-    default BooleanExpression eqApprovedAt(LocalDateTime approvedAt) {
+    default BooleanExpression eqApprovedAt(ZonedDateTime approvedAt) {
         return approvedAt != null ? order.approvedAt.eq(approvedAt) : null;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderQueryMethod.java
@@ -1,0 +1,41 @@
+package com.gdschongik.gdsc.domain.order.dao;
+
+import static com.gdschongik.gdsc.domain.member.domain.QMember.*;
+import static com.gdschongik.gdsc.domain.order.domain.QOrder.*;
+import static com.gdschongik.gdsc.domain.recruitment.domain.QRecruitment.*;
+
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import java.time.LocalDateTime;
+
+public interface OrderQueryMethod {
+
+    // TODO: MemberQueryMethod가 interface로 변경된 경우 해당 메서드 제거 및 대체
+    default BooleanExpression eqName(String name) {
+        return name != null ? member.name.contains(name) : null;
+    }
+
+    default BooleanExpression eqAcademicYear(Integer academicYear) {
+        return academicYear != null ? recruitment.academicYear.eq(academicYear) : null;
+    }
+
+    default BooleanExpression eqSemesterType(SemesterType semesterType) {
+        return semesterType != null ? recruitment.semesterType.eq(semesterType) : null;
+    }
+
+    default BooleanExpression eqStudentId(String studentId) {
+        return studentId != null ? member.studentId.containsIgnoreCase(studentId) : null;
+    }
+
+    default BooleanExpression eqNanoId(String nanoId) {
+        return nanoId != null ? order.nanoId.contains(nanoId) : null;
+    }
+
+    default BooleanExpression eqPaymentKey(String paymentKey) {
+        return paymentKey != null ? order.paymentKey.contains(paymentKey) : null;
+    }
+
+    default BooleanExpression eqApprovedAt(LocalDateTime approvedAt) {
+        return approvedAt != null ? order.approvedAt.eq(approvedAt) : null;
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderQueryMethod.java
@@ -5,10 +5,31 @@ import static com.gdschongik.gdsc.domain.order.domain.QOrder.*;
 import static com.gdschongik.gdsc.domain.recruitment.domain.QRecruitment.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.order.dto.request.OrderQueryOption;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 public interface OrderQueryMethod {
+
+    default BooleanBuilder matchesOrderQueryOption(OrderQueryOption queryOption) {
+        return new BooleanBuilder()
+                .and(eqName(queryOption.name()))
+                .and(eqAcademicYear(queryOption.academicYear()))
+                .and(eqSemesterType(queryOption.semesterType()))
+                .and(eqStudentId(queryOption.studentId()))
+                .and(eqNanoId(queryOption.nanoId()))
+                .and(eqPaymentKey(queryOption.paymentKey()))
+                .and(eqApprovedAt(queryOption.approvedAt()));
+    }
+
+    default BooleanExpression eqMember() {
+        return order.memberId.eq(member.id);
+    }
+
+    default BooleanExpression eqRecruitmentRound() {
+        return order.recruitmentRoundId.eq(recruitment.id);
+    }
 
     // TODO: MemberQueryMethod가 interface로 변경된 경우 해당 메서드 제거 및 대체
     default BooleanExpression eqName(String name) {

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderRepository.java
@@ -4,6 +4,6 @@ import com.gdschongik.gdsc.domain.order.domain.Order;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OrderRepository extends JpaRepository<Order, Long> {
+public interface OrderRepository extends JpaRepository<Order, Long>, OrderCustomRepository {
     Optional<Order> findByNanoId(String nanoId);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
@@ -45,8 +45,8 @@ public class Order extends BaseEntity {
     @Comment("주문 대상 멤버십 ID")
     private Long membershipId;
 
-    @Comment("신청하려는 리쿠르팅 ID")
-    private Long recruitmentId;
+    @Comment("신청하려는 모집회차 ID")
+    private Long recruitmentRoundId;
 
     @Comment("사용하려는 발급쿠폰 ID")
     private Long issuedCouponId;
@@ -64,14 +64,14 @@ public class Order extends BaseEntity {
             String nanoId,
             Long memberId,
             Long membershipId,
-            Long recruitmentId,
+            Long recruitmentRoundId,
             Long issuedCouponId,
             MoneyInfo moneyInfo) {
         this.status = status;
         this.nanoId = nanoId;
         this.memberId = memberId;
         this.membershipId = membershipId;
-        this.recruitmentId = recruitmentId;
+        this.recruitmentRoundId = recruitmentRoundId;
         this.issuedCouponId = issuedCouponId;
         this.moneyInfo = moneyInfo;
     }
@@ -87,7 +87,7 @@ public class Order extends BaseEntity {
                 .nanoId(nanoId)
                 .memberId(membership.getMember().getId())
                 .membershipId(membership.getId())
-                .recruitmentId(membership.getRecruitmentRound().getRecruitment().getId())
+                .recruitmentRoundId(membership.getRecruitmentRound().getId())
                 .issuedCouponId(issuedCoupon != null ? issuedCoupon.getId() : null)
                 .moneyInfo(moneyInfo)
                 .build();

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.ZonedDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -54,6 +55,8 @@ public class Order extends BaseEntity {
     private MoneyInfo moneyInfo;
 
     private String paymentKey;
+
+    private ZonedDateTime approvedAt;
 
     @Builder(access = AccessLevel.PRIVATE)
     private Order(
@@ -98,9 +101,10 @@ public class Order extends BaseEntity {
      * 이는 결제 승인 API 호출 후 완료 처리 과정에서 예외가 발생하는 것을 방지하기 위함입니다.
      * 실제 완료 처리 유효성에 대한 검증은 {@link OrderValidator#validateCompleteOrder}에서 수행합니다.
      */
-    public void complete(String paymentKey) {
+    public void complete(String paymentKey, ZonedDateTime approvedAt) {
         this.status = OrderStatus.COMPLETED;
         this.paymentKey = paymentKey;
+        this.approvedAt = approvedAt;
 
         registerEvent(new OrderCompletedEvent(id));
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dto/request/OrderQueryOption.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dto/request/OrderQueryOption.java
@@ -3,7 +3,7 @@ package com.gdschongik.gdsc.domain.order.dto.request;
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.order.domain.OrderStatus;
 import jakarta.validation.constraints.Min;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 public record OrderQueryOption(
         String name,
@@ -13,4 +13,4 @@ public record OrderQueryOption(
         OrderStatus status,
         String nanoId,
         String paymentKey,
-        LocalDateTime approvedAt) {}
+        ZonedDateTime approvedAt) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dto/request/OrderQueryOption.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dto/request/OrderQueryOption.java
@@ -1,0 +1,16 @@
+package com.gdschongik.gdsc.domain.order.dto.request;
+
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.order.domain.OrderStatus;
+import jakarta.validation.constraints.Min;
+import java.time.LocalDateTime;
+
+public record OrderQueryOption(
+        String name,
+        @Min(2023) Integer academicYear,
+        SemesterType semesterType,
+        String studentId,
+        OrderStatus status,
+        String nanoId,
+        String paymentKey,
+        LocalDateTime approvedAt) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dto/response/OrderAdminResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dto/response/OrderAdminResponse.java
@@ -1,0 +1,39 @@
+package com.gdschongik.gdsc.domain.order.dto.response;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.order.domain.MoneyInfo;
+import com.gdschongik.gdsc.domain.order.domain.Order;
+import com.gdschongik.gdsc.domain.order.domain.OrderStatus;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.global.util.formatter.MoneyFormatter;
+import com.gdschongik.gdsc.global.util.formatter.SemesterFormatter;
+import java.time.LocalDateTime;
+
+public record OrderAdminResponse(
+        Long orderId,
+        String semester,
+        String memberName,
+        OrderStatus status,
+        String studentId,
+        String nanoId,
+        String paymentKey,
+        String totalAmount,
+        String discountAmount,
+        String finalPaymentAmount,
+        LocalDateTime updatedAt) {
+    public static OrderAdminResponse from(Order order, Recruitment recruitment, Member member) {
+        MoneyInfo moneyInfo = order.getMoneyInfo();
+        return new OrderAdminResponse(
+                order.getId(),
+                SemesterFormatter.format(recruitment),
+                member.getName(),
+                order.getStatus(),
+                member.getStudentId(),
+                order.getNanoId(),
+                order.getPaymentKey(),
+                MoneyFormatter.format(moneyInfo.getTotalAmount()),
+                MoneyFormatter.format(moneyInfo.getDiscountAmount()),
+                MoneyFormatter.format(moneyInfo.getFinalPaymentAmount()),
+                order.getUpdatedAt());
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dto/response/OrderAdminResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dto/response/OrderAdminResponse.java
@@ -2,11 +2,7 @@ package com.gdschongik.gdsc.domain.order.dto.response;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
-import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.order.domain.MoneyInfo;
-import com.gdschongik.gdsc.domain.order.domain.Order;
 import com.gdschongik.gdsc.domain.order.domain.OrderStatus;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.global.util.formatter.MoneyFormatter;
 import com.gdschongik.gdsc.global.util.formatter.SemesterFormatter;
 import com.querydsl.core.annotations.QueryProjection;
@@ -51,21 +47,5 @@ public record OrderAdminResponse(
                 MoneyFormatter.format(discountAmount),
                 MoneyFormatter.format(finalPaymentAmount),
                 approvedAt);
-    }
-
-    public static OrderAdminResponse from(Order order, Recruitment recruitment, Member member) {
-        MoneyInfo moneyInfo = order.getMoneyInfo();
-        return new OrderAdminResponse(
-                order.getId(),
-                SemesterFormatter.format(recruitment),
-                member.getName(),
-                order.getStatus(),
-                member.getStudentId(),
-                order.getNanoId(),
-                order.getPaymentKey(),
-                MoneyFormatter.format(moneyInfo.getTotalAmount()),
-                MoneyFormatter.format(moneyInfo.getDiscountAmount()),
-                MoneyFormatter.format(moneyInfo.getFinalPaymentAmount()),
-                order.getApprovedAt());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dto/response/OrderAdminResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dto/response/OrderAdminResponse.java
@@ -20,7 +20,7 @@ public record OrderAdminResponse(
         String totalAmount,
         String discountAmount,
         String finalPaymentAmount,
-        LocalDateTime updatedAt) {
+        ZonedDateTime approvedAt) {
     public static OrderAdminResponse from(Order order, Recruitment recruitment, Member member) {
         MoneyInfo moneyInfo = order.getMoneyInfo();
         return new OrderAdminResponse(

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dto/response/OrderAdminResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dto/response/OrderAdminResponse.java
@@ -1,5 +1,7 @@
 package com.gdschongik.gdsc.domain.order.dto.response;
 
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.order.domain.MoneyInfo;
 import com.gdschongik.gdsc.domain.order.domain.Order;
@@ -7,7 +9,8 @@ import com.gdschongik.gdsc.domain.order.domain.OrderStatus;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.global.util.formatter.MoneyFormatter;
 import com.gdschongik.gdsc.global.util.formatter.SemesterFormatter;
-import java.time.LocalDateTime;
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.ZonedDateTime;
 
 public record OrderAdminResponse(
         Long orderId,
@@ -21,6 +24,35 @@ public record OrderAdminResponse(
         String discountAmount,
         String finalPaymentAmount,
         ZonedDateTime approvedAt) {
+
+    @QueryProjection
+    public OrderAdminResponse(
+            Long orderId,
+            Integer academicYear,
+            SemesterType semesterType,
+            String memberName,
+            OrderStatus status,
+            String studentId,
+            String nanoId,
+            String paymentKey,
+            Money totalAmount,
+            Money discountAmount,
+            Money finalPaymentAmount,
+            ZonedDateTime approvedAt) {
+        this(
+                orderId,
+                SemesterFormatter.format(academicYear, semesterType),
+                memberName,
+                status,
+                studentId,
+                nanoId,
+                paymentKey,
+                MoneyFormatter.format(totalAmount),
+                MoneyFormatter.format(discountAmount),
+                MoneyFormatter.format(finalPaymentAmount),
+                approvedAt);
+    }
+
     public static OrderAdminResponse from(Order order, Recruitment recruitment, Member member) {
         MoneyInfo moneyInfo = order.getMoneyInfo();
         return new OrderAdminResponse(
@@ -34,6 +66,6 @@ public record OrderAdminResponse(
                 MoneyFormatter.format(moneyInfo.getTotalAmount()),
                 MoneyFormatter.format(moneyInfo.getDiscountAmount()),
                 MoneyFormatter.format(moneyInfo.getFinalPaymentAmount()),
-                order.getUpdatedAt());
+                order.getApprovedAt());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/util/formatter/SemesterFormatter.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/formatter/SemesterFormatter.java
@@ -1,14 +1,18 @@
 package com.gdschongik.gdsc.global.util.formatter;
 
 import com.gdschongik.gdsc.domain.common.model.BaseSemesterEntity;
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SemesterFormatter {
     public static String format(BaseSemesterEntity semesterEntity) {
-        return semesterEntity.getAcademicYear() + "-"
-                + semesterEntity.getSemesterType().getValue();
+        return format(semesterEntity.getAcademicYear(), semesterEntity.getSemesterType());
+    }
+
+    public static String format(Integer academicYear, SemesterType semesterType) {
+        return academicYear + "-" + semesterType.getValue();
     }
 
     public static String formatType(BaseSemesterEntity semesterEntity) {

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -17,8 +17,10 @@ import com.gdschongik.gdsc.domain.order.dto.request.OrderCreateRequest;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.helper.IntegrationTest;
 import com.gdschongik.gdsc.infra.feign.payment.dto.request.PaymentConfirmRequest;
+import com.gdschongik.gdsc.infra.feign.payment.dto.response.PaymentResponse;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -102,7 +104,11 @@ class OrderServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(15000)));
 
             String paymentKey = "testPaymentKey";
-            when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(null);
+
+            ZonedDateTime approvedAt = ZonedDateTime.now();
+            PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
+            when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
+            when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
 
             // when
             var request = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
@@ -20,6 +20,7 @@ import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -314,7 +315,7 @@ class OrderValidatorTest {
 
             Order completedOrder = Order.createPending(
                     "nanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, MONEY_0_WON, MONEY_20000_WON));
-            completedOrder.complete("paymentKey");
+            completedOrder.complete("paymentKey", ZonedDateTime.now());
 
             Optional<IssuedCoupon> emptyIssuedCoupon = Optional.empty();
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #491

## 📌 작업 내용 및 특이사항
- 결제 완료처리시 페이먼츠 응답으로부터 승인시간을 저장하도록 했습니다. 어드민 뷰에서 승인시간을 보여주고 있는데 리스트 뷰에서 매번 페이먼츠 조회 API를 쏘는 건 별로인 것 같아서 디비에 저장하기로 했습니다.
- 주문 조회 API를 구현했습니다. 피그마 상 주문 검색 옵션 / 페이지네이션 적용되어 있습니다.
- 엔티티 참조관계가 없기 때문에 fetchjoin이 불가능합니다. DTO Projection으로 해결했습니다. 
- `@QueryProjection` 달 때 Money의 경우 포맷터 적용해야 하므로 별도 생성자 만들어서 내부에서 포맷터 호출해주도록 했습니다.
- `PaymentClient` 의 경우 외부 의존성이기 때문에 테스트할 때 기본적으로 모킹 / 스터빙이 필요합니다. 기존에는 stubbing 응답이 null이었는데 이번에 approvedAt 저장하는 로직이 추가되면서 `PaymentResponse` 목 객체에서 해당 getter만 stubbing 해주는 방식으로 해결했습니다 (응답 객체 자체를 직접 만들어도 되지만 너무 사이즈가 커질 것 같아서 그냥 모킹으로 처리...)



## 📝 참고사항
- MemberQueryOption에 PATTERN 졔약조건 걸려있는 것들 있던데 요렇게 하면 키워드 검색 하려고 해도 패턴에 걸려서 불가능할 것 같은데... 한번 확인 부탁드립니다 @Sangwook02 
- `OrderQueryMethod` 의 경우 주문 엔티티가 아닌 멤버 엔티티 관련 키워드 검색 조건을 포함하는 유틸 메서드가 존재하는데, 추후 #494 에서 해결되면 적용할 수 있도록 관련 투두 하나 달아놨습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- 관리자를 위한 주문 관리 기능 추가.
	- 주문 검색을 위한 새로운 쿼리 옵션 및 페이징 기능 구현.
	- 주문 응답을 위한 DTO 생성.
	- 결제 확인 시 타임스탬프를 포함한 로직 개선.

- **Bug Fixes**
	- 주문 완료 메서드에 타임스탬프 추가로 주문 상태 추적 개선.

- **Documentation**
	- 코드에 향후 개선 사항에 대한 TODO 주석 추가. 

- **Style**
	- 코드 리팩토링으로 가독성 및 유지보수성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->