### PR TITLE
fix: QueryOption 패턴 제약 제거

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/dto/request/IssuedCouponQueryOption.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/dto/request/IssuedCouponQueryOption.java
@@ -1,14 +1,11 @@
 package com.gdschongik.gdsc.domain.coupon.dto.request;
 
-import static com.gdschongik.gdsc.global.common.constant.RegexConstant.PHONE_WITHOUT_HYPHEN;
-import static com.gdschongik.gdsc.global.common.constant.RegexConstant.STUDENT_ID;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record IssuedCouponQueryOption(
-        @Schema(description = "학번", pattern = STUDENT_ID) String studentId,
+        @Schema(description = "학번") String studentId,
         @Schema(description = "이름") String memberName,
-        @Schema(description = "전화번호", pattern = PHONE_WITHOUT_HYPHEN) String phone,
+        @Schema(description = "전화번호") String phone,
         @Schema(description = "쿠폰 이름") String couponName,
         @Schema(description = "쿠폰 사용 여부") Boolean hasUsed,
         @Schema(description = "쿠폰 회수 여부") Boolean hasRevoked) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberQueryOption.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberQueryOption.java
@@ -1,17 +1,15 @@
 package com.gdschongik.gdsc.domain.member.dto.request;
 
-import static com.gdschongik.gdsc.global.common.constant.RegexConstant.*;
-
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public record MemberQueryOption(
-        @Schema(description = "학번", pattern = STUDENT_ID) String studentId,
+        @Schema(description = "학번") String studentId,
         @Schema(description = "이름") String name,
-        @Schema(description = "전화번호", pattern = PHONE_WITHOUT_HYPHEN) String phone,
+        @Schema(description = "전화번호") String phone,
         @Schema(description = "학과") String department,
         @Schema(description = "이메일") String email,
         @Schema(description = "디스코드 유저네임") String discordUsername,
-        @Schema(description = "커뮤니티 닉네임", pattern = NICKNAME) String nickname,
+        @Schema(description = "커뮤니티 닉네임") String nickname,
         @Schema(description = "멤버 권한") List<MemberRole> roles) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #500

## 📌 작업 내용 및 특이사항
- 키워드 기반 검색을 위해 QueryOption 패턴 제약을 제거했습니다.
- `MemberQueryOption` 수정하는 김에 `IssuedCouponQueryOption`도 같이 수정했습니다.

## 📝 참고사항
-

## 📚 기타
-
