### PR TITLE
refactor: 준회원으로 일괄 강등 로직에 도메인 서비스 적용

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -5,11 +5,13 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.domain.member.domain.MemberValidator;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberDemoteRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryOption;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberUpdateRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.AdminMemberResponse;
-import com.gdschongik.gdsc.domain.recruitment.application.AdminRecruitmentService;
+import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.global.util.ExcelUtil;
@@ -30,7 +32,8 @@ public class AdminMemberService {
 
     private final MemberRepository memberRepository;
     private final ExcelUtil excelUtil;
-    private final AdminRecruitmentService adminRecruitmentService;
+    private final RecruitmentRoundRepository recruitmentRoundRepository;
+    private final MemberValidator memberValidator;
 
     public Page<AdminMemberResponse> searchMembers(MemberQueryOption queryOption, Pageable pageable) {
         Page<Member> members = memberRepository.searchMembers(queryOption, pageable);
@@ -63,7 +66,11 @@ public class AdminMemberService {
 
     @Transactional
     public void demoteAllRegularMembersToAssociate(MemberDemoteRequest request) {
-        adminRecruitmentService.validateRecruitmentNotStarted(request.academicYear(), request.semesterType());
+        List<RecruitmentRound> recruitmentRounds = recruitmentRoundRepository.findAllByAcademicYearAndSemesterType(
+                request.academicYear(), request.semesterType());
+
+        memberValidator.validateMemberDemote(recruitmentRounds);
+
         List<Member> regularMembers = memberRepository.findAllByRole(MemberRole.REGULAR);
 
         regularMembers.forEach(Member::demoteToAssociate);

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberValidator.java
@@ -1,0 +1,23 @@
+package com.gdschongik.gdsc.domain.member.domain;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
+import com.gdschongik.gdsc.global.annotation.DomainService;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import java.util.List;
+
+@DomainService
+public class MemberValidator {
+
+    public void validateMemberDemote(List<RecruitmentRound> recruitmentRounds) {
+
+        // 해당 학기에 모집회차가 존재하는지 검증
+        if (recruitmentRounds.isEmpty()) {
+            throw new CustomException(RECRUITMENT_ROUND_NOT_FOUND);
+        }
+
+        // 해당 학기의 모든 모집회차가 아직 시작되지 않았는지 검증
+        recruitmentRounds.forEach(RecruitmentRound::validatePeriodNotStarted);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -2,7 +2,6 @@ package com.gdschongik.gdsc.domain.recruitment.application;
 
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
-import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
@@ -106,20 +105,5 @@ public class AdminRecruitmentService {
                 request.name(), Period.createPeriod(request.startDate(), request.endDate()), request.roundType());
 
         log.info("[AdminRecruitmentService] 모집회차 수정: recruitmentRoundId={}", recruitmentRoundId);
-    }
-
-    /*
-     1. 해당 학기에 리쿠르팅이 존재해야 함.
-     2. 해당 학기의 모든 리쿠르팅이 아직 시작되지 않았어야 함.
-    */
-    public void validateRecruitmentNotStarted(Integer academicYear, SemesterType semesterType) {
-        List<RecruitmentRound> recruitmentRounds =
-                recruitmentRoundRepository.findAllByAcademicYearAndSemesterType(academicYear, semesterType);
-
-        if (recruitmentRounds.isEmpty()) {
-            throw new CustomException(RECRUITMENT_ROUND_NOT_FOUND);
-        }
-
-        recruitmentRounds.forEach(RecruitmentRound::validatePeriodNotStarted);
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
@@ -1,19 +1,15 @@
 package com.gdschongik.gdsc.domain.member.application;
 
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
-import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Department;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.member.dto.request.MemberDemoteRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberUpdateRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.helper.IntegrationTest;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -38,32 +34,5 @@ class AdminMemberServiceTest extends IntegrationTest {
         assertThatThrownBy(() -> adminMemberService.updateMember(member.getId(), requestBody))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
-    }
-
-    @Nested
-    class 준회원으로_일괄_강등시 {
-        @Test
-        void 해당_학기에_이미_시작된_모집기간이_있다면_실패한다() {
-            // given
-            createRecruitmentRound(
-                    RECRUITMENT_NAME, START_DATE, END_DATE, ACADEMIC_YEAR, SEMESTER_TYPE, ROUND_TYPE, FEE);
-            MemberDemoteRequest request = new MemberDemoteRequest(ACADEMIC_YEAR, SEMESTER_TYPE);
-
-            // when & then
-            assertThatThrownBy(() -> adminMemberService.demoteAllRegularMembersToAssociate(request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_ROUND_STARTDATE_ALREADY_PASSED.getMessage());
-        }
-
-        @Test
-        void 해당_학기에_리쿠르팅이_존재하지_않는다면_실패한다() {
-            // given
-            MemberDemoteRequest request = new MemberDemoteRequest(ACADEMIC_YEAR, SEMESTER_TYPE);
-
-            // when & then
-            assertThatThrownBy(() -> adminMemberService.demoteAllRegularMembersToAssociate(request))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_ROUND_NOT_FOUND.getMessage());
-        }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
@@ -1,0 +1,53 @@
+package com.gdschongik.gdsc.domain.member.domain;
+
+import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class MemberValidatorTest {
+
+    MemberValidator memberValidator = new MemberValidator();
+
+    @Nested
+    class 준회원으로_일괄_강등시 {
+
+        @Test
+        void 해당_학기에_이미_시작된_모집기간이_있다면_실패한다() {
+            // given
+            Recruitment recruitment = Recruitment.createRecruitment(
+                    ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, Period.createPeriod(START_DATE, END_DATE));
+            RecruitmentRound recruitmentRound = RecruitmentRound.create(
+                    RECRUITMENT_NAME,
+                    LocalDateTime.now().minusDays(1),
+                    LocalDateTime.now().plusDays(1),
+                    recruitment,
+                    ROUND_TYPE);
+            List<RecruitmentRound> recruitmentRounds = List.of(recruitmentRound);
+
+            // when & then
+            assertThatThrownBy(() -> memberValidator.validateMemberDemote(recruitmentRounds))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(RECRUITMENT_ROUND_STARTDATE_ALREADY_PASSED.getMessage());
+        }
+
+        @Test
+        void 해당_학기에_모집회차가_존재하지_않는다면_실패한다() {
+            // given
+            List<RecruitmentRound> recruitmentRounds = List.of();
+
+            // when & then
+            assertThatThrownBy(() -> memberValidator.validateMemberDemote(recruitmentRounds))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(RECRUITMENT_ROUND_NOT_FOUND.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
@@ -26,7 +26,7 @@ public class MemberValidatorTest {
             Recruitment recruitment = Recruitment.createRecruitment(
                     ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, Period.createPeriod(START_DATE, END_DATE));
             RecruitmentRound recruitmentRound = RecruitmentRound.create(
-                    RECRUITMENT_NAME,
+                    RECRUITMENT_ROUND_NAME,
                     LocalDateTime.now().minusDays(1),
                     LocalDateTime.now().plusDays(1),
                     recruitment,


### PR DESCRIPTION
## 🌱 관련 이슈
- close #502

## 📌 작업 내용 및 특이사항
- `AdminRecruitmentService`에 있던 검증 로직을 `MemberValidator`로 옮겼습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit



- **New Features**
	- 멤버 강등 요청을 검증하는 `MemberValidator` 클래스 추가.
	- 강등 과정에서 모집 회차 정보를 직접 활용하는 새로운 로직 구현.

- **Bug Fixes**
	- 특정 조건에서 발생할 수 있는 예외 처리 로직 개선 및 검증 강화.

- **Tests**
	- `MemberValidator` 클래스의 검증 로직에 대한 새로운 단위 테스트 추가.
	- `AdminMemberServiceTest`에서 일부 테스트 케이스 제거.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->