### PR TITLE
refactor: 디스코드 ID 배치시 역할 검증 로직을 도메인 서비스로 이동

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/CommonDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/CommonDiscordService.java
@@ -3,9 +3,9 @@ package com.gdschongik.gdsc.domain.discord.application;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.model.RequirementStatus;
+import com.gdschongik.gdsc.domain.discord.domain.DiscordValidator;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.DiscordUtil;
 import java.util.List;
@@ -19,6 +19,7 @@ public class CommonDiscordService {
 
     private final MemberRepository memberRepository;
     private final DiscordUtil discordUtil;
+    private final DiscordValidator discordValidator;
 
     public String getNicknameByDiscordUsername(String discordUsername) {
         return memberRepository
@@ -28,7 +29,13 @@ public class CommonDiscordService {
     }
 
     @Transactional
-    public void batchDiscordId(RequirementStatus discordStatus) {
+    public void batchDiscordId(String currentDiscordUsername, RequirementStatus discordStatus) {
+        Member currentMember = memberRepository
+                .findByDiscordUsername(currentDiscordUsername)
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+        discordValidator.validatePermissionForCommand(currentMember);
+
         List<Member> discordSatisfiedMembers = memberRepository.findAllByDiscordStatus(discordStatus);
 
         discordSatisfiedMembers.forEach(member -> {
@@ -36,15 +43,5 @@ public class CommonDiscordService {
             String discordId = discordUtil.getMemberIdByUsername(discordUsername);
             member.updateDiscordId(discordId);
         });
-    }
-
-    public void checkPermissionForCommand(String discordUsername) {
-        Member member = memberRepository
-                .findByDiscordUsername(discordUsername)
-                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
-
-        if (!member.getRole().equals(MemberRole.ADMIN)) {
-            throw new CustomException(INVALID_ROLE);
-        }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/DiscordIdBatchCommandHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/DiscordIdBatchCommandHandler.java
@@ -21,8 +21,7 @@ public class DiscordIdBatchCommandHandler implements DiscordEventHandler {
         event.deferReply(true).setContent(DEFER_MESSAGE_BATCH_DISCORD_ID).queue();
 
         String discordUsername = event.getUser().getName();
-        commonDiscordService.checkPermissionForCommand(discordUsername);
-        commonDiscordService.batchDiscordId(SATISFIED);
+        commonDiscordService.batchDiscordId(discordUsername, SATISFIED);
 
         event.getHook()
                 .sendMessage(REPLY_MESSAGE_BATCH_DISCORD_ID)

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/domain/DiscordValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/domain/DiscordValidator.java
@@ -2,6 +2,8 @@ package com.gdschongik.gdsc.domain.discord.domain;
 
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
 
@@ -26,6 +28,12 @@ public class DiscordValidator {
         // 닉네임이 중복되는지 검증
         if (isNicknameDuplicate) {
             throw new CustomException(MEMBER_NICKNAME_DUPLICATE);
+        }
+    }
+
+    public void validatePermissionForCommand(Member currentMember) {
+        if (!currentMember.getRole().equals(MemberRole.ADMIN)) {
+            throw new CustomException(INVALID_ROLE);
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #506

## 📌 작업 내용 및 특이사항
- 디스코드 id 배치 명령은 어드민만 사용 가능합니다. 기존에는 이를 검증하기 위해 `DiscordIdBatchCommandHandler`에서 service를 두 번 호출했습니다. 
```java
   commonDiscordService.checkPermissionForCommand(discordUsername);
   commonDiscordService.batchDiscordId(SATISFIED);
```
이걸 batchDiscordId() 메서드 하나로 합치고 내부에서 검증 로직을 Validator 통해서 호출하도록 수정했습니다.
```java
   commonDiscordService.batchDiscordId(discordUsername, SATISFIED);
```

## 📝 참고사항
-

## 📚 기타
-
