### PR TITLE
feat: 주문 취소하기 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/order/api/AdminOrderController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/api/AdminOrderController.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.order.api;
 
 import com.gdschongik.gdsc.domain.order.application.OrderService;
+import com.gdschongik.gdsc.domain.order.dto.request.OrderCancelRequest;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderQueryOption;
 import com.gdschongik.gdsc.domain.order.dto.response.OrderAdminResponse;
 import com.gdschongik.gdsc.infra.feign.payment.dto.response.PaymentResponse;
@@ -14,6 +15,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -40,5 +43,13 @@ public class AdminOrderController {
     public ResponseEntity<PaymentResponse> getCompletedOrderPayment(@PathVariable Long orderId) {
         var response = orderService.getCompletedOrderPayment(orderId);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "주문 결제 취소하기", description = "주문 상태를 취소로 변경하고 결제를 취소합니다.")
+    @PostMapping("/{orderId}/cancel")
+    public ResponseEntity<Void> cancelOrder(
+            @PathVariable Long orderId, @Valid @RequestBody OrderCancelRequest request) {
+        orderService.cancelOrder(orderId, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
@@ -132,6 +132,7 @@ public class OrderService {
     }
 
     private ZonedDateTime getCanceledAt(PaymentResponse response) {
+        // TODO: 예외 발생하는 경우 대개 응답 DTO 매핑 오류이며, 결제 취소는 완료되었으나 DB 주문 취소는 실패한 것이므로 별도 처리 필요
         return Optional.ofNullable(response.cancels())
                 .flatMap(this::findLatestCancelDate)
                 .orElseThrow(() -> new CustomException(ORDER_CANCEL_RESPONSE_NOT_FOUND));

--- a/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
@@ -24,6 +24,7 @@ import com.gdschongik.gdsc.infra.feign.payment.dto.request.PaymentCancelRequest;
 import com.gdschongik.gdsc.infra.feign.payment.dto.request.PaymentConfirmRequest;
 import com.gdschongik.gdsc.infra.feign.payment.dto.response.PaymentResponse;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -131,12 +132,12 @@ public class OrderService {
     }
 
     private ZonedDateTime getCanceledAt(PaymentResponse response) {
-        var cancels = Optional.ofNullable(response.cancels())
+        return Optional.ofNullable(response.cancels())
+                .flatMap(this::findLatestCancelDate)
                 .orElseThrow(() -> new CustomException(ORDER_CANCEL_RESPONSE_NOT_FOUND));
+    }
 
-        return cancels.stream()
-                .findFirst()
-                .map(PaymentResponse.CancelDto::canceledAt)
-                .orElseThrow(() -> new CustomException(ORDER_CANCEL_RESPONSE_NOT_FOUND));
+    private Optional<ZonedDateTime> findLatestCancelDate(List<PaymentResponse.CancelDto> cancels) {
+        return cancels.stream().map(PaymentResponse.CancelDto::canceledAt).max(ZonedDateTime::compareTo);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
@@ -1,8 +1,11 @@
 package com.gdschongik.gdsc.domain.order.domain;
 
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
 import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
+import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -58,6 +61,8 @@ public class Order extends BaseEntity {
 
     private ZonedDateTime approvedAt;
 
+    private ZonedDateTime canceledAt;
+
     @Builder(access = AccessLevel.PRIVATE)
     private Order(
             OrderStatus status,
@@ -107,6 +112,22 @@ public class Order extends BaseEntity {
         this.approvedAt = approvedAt;
 
         registerEvent(new OrderCompletedEvent(id));
+    }
+
+    /**
+     * 주문을 취소 처리합니다.
+     * 상태 변경 및 취소 시각을 저장하며, 예외를 발생시키지 않도록 외부 취소 요청 전에 validateCancelable을 호출합니다.
+     */
+    public void cancel(ZonedDateTime canceledAt) {
+        validateCancelable();
+        this.status = OrderStatus.CANCELED;
+        this.canceledAt = canceledAt;
+    }
+
+    public void validateCancelable() {
+        if (status != OrderStatus.COMPLETED) {
+            throw new CustomException(ORDER_CANCEL_NOT_COMPLETED);
+        }
     }
 
     // 데이터 조회 로직

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dto/request/OrderCancelRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dto/request/OrderCancelRequest.java
@@ -1,0 +1,5 @@
+package com.gdschongik.gdsc.domain.order.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record OrderCancelRequest(@NotBlank String cancelReason) {}

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -118,6 +118,9 @@ public enum ErrorCode {
     ORDER_COMPLETE_AMOUNT_MISMATCH(HttpStatus.CONFLICT, "주문 최종결제금액이 주문완료요청의 결제금액과 일치하지 않습니다."),
     ORDER_COMPLETE_MEMBER_MISMATCH(HttpStatus.CONFLICT, "주문자와 현재 로그인한 멤버가 일치하지 않습니다."),
     ORDER_COMPLETED_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 주문이거나, 완료되지 않은 주문입니다."),
+    ORDER_CANCEL_NOT_COMPLETED(HttpStatus.CONFLICT, "완료되지 않은 주문은 취소할 수 없습니다."),
+    ORDER_CANCEL_RESPONSE_NOT_FOUND(
+            HttpStatus.INTERNAL_SERVER_ERROR, "주문 결제가 취소되었지만, 응답에 취소 정보가 존재하지 않습니다. 관리자에게 문의 바랍니다."),
 
     // Order - MoneyInfo
     ORDER_FINAL_PAYMENT_AMOUNT_MISMATCH(HttpStatus.CONFLICT, "주문 최종결제금액은 주문총액에서 할인금액을 뺀 값이어야 합니다."),

--- a/src/main/java/com/gdschongik/gdsc/infra/feign/payment/client/PaymentClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/feign/payment/client/PaymentClient.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.infra.feign.payment.client;
 
 import com.gdschongik.gdsc.infra.feign.payment.config.PaymentClientConfig;
+import com.gdschongik.gdsc.infra.feign.payment.dto.request.PaymentCancelRequest;
 import com.gdschongik.gdsc.infra.feign.payment.dto.request.PaymentConfirmRequest;
 import com.gdschongik.gdsc.infra.feign.payment.dto.response.PaymentResponse;
 import jakarta.validation.Valid;
@@ -18,4 +19,7 @@ public interface PaymentClient {
 
     @GetMapping("/v1/payments/{paymentKey}")
     PaymentResponse getPayment(@PathVariable String paymentKey);
+
+    @PostMapping("/v1/payments/{paymentKey}/cancel")
+    PaymentResponse cancelPayment(@PathVariable String paymentKey, @Valid @RequestBody PaymentCancelRequest request);
 }

--- a/src/main/java/com/gdschongik/gdsc/infra/feign/payment/dto/request/PaymentCancelRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/feign/payment/dto/request/PaymentCancelRequest.java
@@ -1,0 +1,5 @@
+package com.gdschongik.gdsc.infra.feign.payment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PaymentCancelRequest(@NotBlank String cancelReason) {}

--- a/src/main/java/com/gdschongik/gdsc/infra/feign/payment/dto/response/PaymentResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/feign/payment/dto/response/PaymentResponse.java
@@ -25,7 +25,7 @@ public record PaymentResponse(
         Boolean cultureExpense,
         Long taxFreeAmount,
         Long taxExemtionAmount,
-        @Nullable List<PaymentCancelDto> cancels,
+        @Nullable List<CancelDto> cancels,
         Boolean isPartialCancelable,
         @Nullable CardDto card,
         @Nullable TransferDto transfer,
@@ -37,7 +37,7 @@ public record PaymentResponse(
         @Nullable CashReceiptDto cashReceipt,
         @Nullable List<CashReceiptsDto> cashReceipts) {
     // TODO: enum 관련 매핑 여부 검토
-    public record PaymentCancelDto(
+    public record CancelDto(
             Long cancelAmount,
             String cancelReason,
             Long taxFreeAmount,

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.order.application;
 
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -12,15 +13,19 @@ import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.order.dao.OrderRepository;
 import com.gdschongik.gdsc.domain.order.domain.Order;
 import com.gdschongik.gdsc.domain.order.domain.OrderStatus;
+import com.gdschongik.gdsc.domain.order.dto.request.OrderCancelRequest;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCompleteRequest;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCreateRequest;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
+import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.IntegrationTest;
+import com.gdschongik.gdsc.infra.feign.payment.dto.request.PaymentCancelRequest;
 import com.gdschongik.gdsc.infra.feign.payment.dto.request.PaymentConfirmRequest;
 import com.gdschongik.gdsc.infra.feign.payment.dto.response.PaymentResponse;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -124,6 +129,108 @@ class OrderServiceTest extends IntegrationTest {
             assertThat(usedCoupon.hasUsed()).isTrue();
 
             verify(paymentClient).confirm(any(PaymentConfirmRequest.class));
+        }
+    }
+
+    @Nested
+    class 주문_취소할때 {
+
+        @Test
+        void 성공한다() {
+            // given
+            Member member = createMember();
+            logoutAndReloginAs(1L, MemberRole.ASSOCIATE);
+            RecruitmentRound recruitmentRound = createRecruitmentRound(
+                    RECRUITMENT_ROUND_NAME,
+                    LocalDateTime.now().minusDays(1),
+                    LocalDateTime.now().plusDays(1),
+                    ACADEMIC_YEAR,
+                    SEMESTER_TYPE,
+                    ROUND_TYPE,
+                    MONEY_20000_WON);
+
+            Membership membership = createMembership(member, recruitmentRound);
+            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
+
+            String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
+            orderService.createPendingOrder(new OrderCreateRequest(
+                    orderNanoId,
+                    membership.getId(),
+                    issuedCoupon.getId(),
+                    BigDecimal.valueOf(20000),
+                    BigDecimal.valueOf(5000),
+                    BigDecimal.valueOf(15000)));
+
+            String paymentKey = "testPaymentKey";
+
+            ZonedDateTime approvedAt = ZonedDateTime.now();
+            PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
+            when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
+            when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
+
+            var completeRequest = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);
+            orderService.completeOrder(completeRequest);
+
+            Order completedOrder = orderRepository.findByNanoId(orderNanoId).orElseThrow();
+
+            ZonedDateTime canceledAt = ZonedDateTime.now();
+            PaymentResponse mockCancelResponse = mock(PaymentResponse.class);
+            PaymentResponse.CancelDto mockCancelDto = mock(PaymentResponse.CancelDto.class);
+
+            when(mockCancelResponse.cancels()).thenReturn(List.of(mockCancelDto));
+            when(mockCancelDto.canceledAt()).thenReturn(canceledAt);
+            when(paymentClient.cancelPayment(eq(paymentKey), any(PaymentCancelRequest.class)))
+                    .thenReturn(mockCancelResponse);
+
+            // when
+            var cancelRequest = new OrderCancelRequest("테스트 취소 사유");
+            orderService.cancelOrder(completedOrder.getId(), cancelRequest);
+
+            // then
+            Order canceledOrder =
+                    orderRepository.findById(completedOrder.getId()).orElseThrow();
+            assertThat(canceledOrder.getStatus()).isEqualTo(OrderStatus.CANCELED);
+            assertThat(canceledOrder.getCanceledAt()).isNotNull();
+
+            verify(paymentClient).cancelPayment(eq(paymentKey), any(PaymentCancelRequest.class));
+        }
+
+        @Test
+        void 주문상태가_PENDING이면_실패한다() {
+            // given
+            Member member = createMember();
+            logoutAndReloginAs(1L, MemberRole.ASSOCIATE);
+            RecruitmentRound recruitmentRound = createRecruitmentRound(
+                    RECRUITMENT_ROUND_NAME,
+                    LocalDateTime.now().minusDays(1),
+                    LocalDateTime.now().plusDays(1),
+                    ACADEMIC_YEAR,
+                    SEMESTER_TYPE,
+                    ROUND_TYPE,
+                    MONEY_20000_WON);
+
+            Membership membership = createMembership(member, recruitmentRound);
+
+            String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
+            orderService.createPendingOrder(new OrderCreateRequest(
+                    orderNanoId,
+                    membership.getId(),
+                    null,
+                    BigDecimal.valueOf(20000),
+                    BigDecimal.valueOf(0),
+                    BigDecimal.valueOf(20000)));
+
+            Order pendingOrder = orderRepository.findByNanoId(orderNanoId).orElseThrow();
+            Long id = pendingOrder.getId();
+
+            OrderCancelRequest request = new OrderCancelRequest("테스트 취소 사유");
+
+            // when & then
+            assertThatThrownBy(() -> orderService.cancelOrder(id, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ORDER_CANCEL_NOT_COMPLETED.getMessage());
+
+            verify(paymentClient, never()).cancelPayment(any(), any());
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderTest.java
@@ -1,0 +1,117 @@
+package com.gdschongik.gdsc.domain.order.domain;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.membership.domain.Membership;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.helper.FixtureHelper;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.Test;
+
+class OrderTest {
+
+    public static final Money MONEY_0_WON = Money.from(0L);
+    public static final Money MONEY_5000_WON = Money.from(5000L);
+    public static final Money MONEY_10000_WON = Money.from(10000L);
+    public static final Money MONEY_15000_WON = Money.from(15000L);
+    public static final Money MONEY_20000_WON = Money.from(20000L);
+
+    FixtureHelper fixtureHelper = new FixtureHelper();
+
+    public Member createAssociateMember(Long id) {
+        return fixtureHelper.createAssociateMember(id);
+    }
+
+    private RecruitmentRound createRecruitmentRound(
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            Integer academicYear,
+            SemesterType semesterType,
+            Money fee) {
+        return fixtureHelper.createRecruitmentRound(startDate, endDate, academicYear, semesterType, fee);
+    }
+
+    private Membership createMembership(Member member, RecruitmentRound recruitmentRound) {
+        return fixtureHelper.createMembership(member, recruitmentRound);
+    }
+
+    @Test
+    void 대기상태이면_주문취소에_실패한다() {
+        // given
+        Member currentMember = createAssociateMember(1L);
+        RecruitmentRound recruitmentRound = createRecruitmentRound(
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(1),
+                2021,
+                SemesterType.FIRST,
+                MONEY_10000_WON);
+        Membership membership = createMembership(currentMember, recruitmentRound);
+
+        Order order = Order.createPending(
+                "testNanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+
+        ZonedDateTime canceledAt = ZonedDateTime.now();
+
+        // when
+        assertThatThrownBy(() -> order.cancel(canceledAt))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ORDER_CANCEL_NOT_COMPLETED.getMessage());
+    }
+
+    @Test
+    void 취소상태이면_주문취소에_실패한다() {
+        // given
+        Member currentMember = createAssociateMember(1L);
+        RecruitmentRound recruitmentRound = createRecruitmentRound(
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(1),
+                2021,
+                SemesterType.FIRST,
+                MONEY_10000_WON);
+        Membership membership = createMembership(currentMember, recruitmentRound);
+
+        Order order = Order.createPending(
+                "testNanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+        order.complete("testPaymentKey", ZonedDateTime.now());
+        order.cancel(ZonedDateTime.now());
+
+        ZonedDateTime canceledAt = ZonedDateTime.now();
+
+        // when & then
+        assertThatThrownBy(() -> order.cancel(canceledAt))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ORDER_CANCEL_NOT_COMPLETED.getMessage());
+    }
+
+    @Test
+    void 완료상태이면_주문취소에_성공한다() {
+        // given
+        Member currentMember = createAssociateMember(1L);
+        RecruitmentRound recruitmentRound = createRecruitmentRound(
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(1),
+                2021,
+                SemesterType.FIRST,
+                MONEY_10000_WON);
+        Membership membership = createMembership(currentMember, recruitmentRound);
+
+        Order order = Order.createPending(
+                "testNanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+        order.complete("testPaymentKey", ZonedDateTime.now());
+
+        ZonedDateTime canceledAt = ZonedDateTime.now();
+
+        // when
+        order.cancel(canceledAt);
+
+        // then
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELED);
+        assertThat(order.getCanceledAt()).isEqualTo(canceledAt);
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
@@ -10,21 +10,17 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
-import com.gdschongik.gdsc.domain.coupon.domain.Coupon;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
-import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.helper.FixtureHelper;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
 
 class OrderValidatorTest {
 
@@ -34,17 +30,11 @@ class OrderValidatorTest {
     public static final Money MONEY_15000_WON = Money.from(15000L);
     public static final Money MONEY_20000_WON = Money.from(20000L);
 
+    FixtureHelper fixtureHelper = new FixtureHelper();
     OrderValidator orderValidator = new OrderValidator();
 
-    private Member createAssociateMember(Long id) {
-        Member member = createGuestMember(OAUTH_ID);
-        member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
-        member.completeUnivEmailVerification(UNIV_EMAIL);
-        member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
-        member.verifyBevy();
-        member.advanceToAssociate();
-        ReflectionTestUtils.setField(member, "id", id);
-        return member;
+    public Member createAssociateMember(Long id) {
+        return fixtureHelper.createAssociateMember(id);
     }
 
     private RecruitmentRound createRecruitmentRound(
@@ -53,19 +43,15 @@ class OrderValidatorTest {
             Integer academicYear,
             SemesterType semesterType,
             Money fee) {
-        Recruitment recruitment = Recruitment.createRecruitment(
-                academicYear, semesterType, fee, FEE_NAME, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
-
-        return RecruitmentRound.create(RECRUITMENT_ROUND_NAME, startDate, endDate, recruitment, RoundType.FIRST);
+        return fixtureHelper.createRecruitmentRound(startDate, endDate, academicYear, semesterType, fee);
     }
 
     private Membership createMembership(Member member, RecruitmentRound recruitmentRound) {
-        return Membership.createMembership(member, recruitmentRound);
+        return fixtureHelper.createMembership(member, recruitmentRound);
     }
 
     private IssuedCoupon createAndIssue(Money money, Member member) {
-        Coupon coupon = Coupon.createCoupon("테스트쿠폰", money);
-        return IssuedCoupon.issue(coupon, member);
+        return fixtureHelper.createAndIssue(money, member);
     }
 
     @Nested

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -1,0 +1,55 @@
+package com.gdschongik.gdsc.helper;
+
+import static com.gdschongik.gdsc.domain.member.domain.Department.*;
+import static com.gdschongik.gdsc.domain.member.domain.Member.*;
+import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.SemesterConstant.*;
+
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.coupon.domain.Coupon;
+import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.membership.domain.Membership;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
+import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import java.time.LocalDateTime;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class FixtureHelper {
+
+    public Member createAssociateMember(Long id) {
+        Member member = createGuestMember(OAUTH_ID);
+        member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
+        member.completeUnivEmailVerification(UNIV_EMAIL);
+        member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
+        member.verifyBevy();
+        member.advanceToAssociate();
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+
+    public RecruitmentRound createRecruitmentRound(
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            Integer academicYear,
+            SemesterType semesterType,
+            Money fee) {
+        Recruitment recruitment = Recruitment.createRecruitment(
+                academicYear, semesterType, fee, FEE_NAME, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
+
+        return RecruitmentRound.create(RECRUITMENT_ROUND_NAME, startDate, endDate, recruitment, RoundType.FIRST);
+    }
+
+    public Membership createMembership(Member member, RecruitmentRound recruitmentRound) {
+        return Membership.createMembership(member, recruitmentRound);
+    }
+
+    public IssuedCoupon createAndIssue(Money money, Member member) {
+        Coupon coupon = Coupon.createCoupon("테스트쿠폰", money);
+        return IssuedCoupon.issue(coupon, member);
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #490

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
- 통합테스트의 경우 `IntegrationTest` 를 상속받는 형태로 픽스처 유틸리티를 사용할 수 있는데요, 도메인 테스트에도 픽스처 유틸이 필요한 상황입니다.
- 특히 이번에 주문 테스트 / 주문 검증기 테스트 작성할 때 둘다 멤버 픽스처 세팅이 필요해서 공통 로직으로 추출해내는 과정이 필요했습니다.
- 기존 `IntegrationTest` 의 경우 상속 관계를 사용하기 때문에 공통 세팅 (ex. `@ActiveProfile`, `@SpringBootTest`) 을 공유할 수 있다는 장점이 있었지만 부모 클래스와 강결합된다는 문제가 있었습니다.
- 도메인 테스트의 경우 각 도메인 간의 격리가 중요하다고 생각했고 때문에 상속 대신 컴포지션을 사용하여, `FixtureHelper` 인스턴스를 사용하도록 개선했습니다. 그리고 각 테스트에서 해당 헬퍼 유틸리티를 적절히 래핑하여 사용하도록 했습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- 주문 취소를 위한 새로운 API 엔드포인트 추가.
	- 주문 취소 요청을 처리하기 위한 새로운 데이터 전송 객체(DTO) 도입.
	- 주문 정보에 취소 시간을 기록하는 기능 추가.
	- 주문 취소 기능 강화를 위한 로직 개선.

- **Bug Fixes**
	- 주문 취소 관련 오류 코드 추가 및 개선.

- **Tests**
	- 주문 취소 프로세스의 유닛 테스트 추가.
	- 주문 취소 성공 및 실패 시나리오에 대한 검증 강화.
	- 테스트 코드 가독성과 유지보수성을 향상시키기 위한 리팩토링.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->