### PR TITLE
feat: 도메인 이벤트 명시적 save호출 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
@@ -74,6 +74,7 @@ public class OnboardingDiscordService {
 
         updateDiscordId(request.discordUsername(), currentMember);
 
+        memberRepository.save(currentMember);
         log.info("[OnboardingDiscordService] 디스코드 연동: memberId={}", currentMember.getId());
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/OnboardingDiscordService.java
@@ -75,6 +75,7 @@ public class OnboardingDiscordService {
         updateDiscordId(request.discordUsername(), currentMember);
 
         memberRepository.save(currentMember);
+
         log.info("[OnboardingDiscordService] 디스코드 연동: memberId={}", currentMember.getId());
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/email/application/UnivEmailVerificationService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/email/application/UnivEmailVerificationService.java
@@ -24,6 +24,7 @@ public class UnivEmailVerificationService {
         EmailVerificationTokenDto emailVerificationToken = getEmailVerificationToken(request.token());
         Member member = getMemberById(emailVerificationToken.memberId());
         member.completeUnivEmailVerification(emailVerificationToken.email());
+        memberRepository.save(member);
     }
 
     private EmailVerificationTokenDto getEmailVerificationToken(String verificationToken) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -77,6 +77,9 @@ public class AdminMemberService {
         List<Member> regularMembers = memberRepository.findAllByRole(MemberRole.REGULAR);
 
         regularMembers.forEach(Member::demoteToAssociate);
+
+        memberRepository.saveAll(regularMembers);
+
         log.info(
                 "[AdminMemberService] 정회원 일괄 강등: demotedMemberIds={}",
                 regularMembers.stream().map(Member::getId).toList());

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
@@ -46,6 +46,7 @@ public class OnboardingMemberService {
     public void verifyBevyStatus() {
         Member currentMember = memberUtil.getCurrentMember();
         currentMember.verifyBevy();
+        memberRepository.save(currentMember);
     }
 
     @Transactional
@@ -53,6 +54,7 @@ public class OnboardingMemberService {
         Member currentMember = memberUtil.getCurrentMember();
         currentMember.updateBasicMemberInfo(
                 request.studentId(), request.name(), request.phone(), request.department(), request.email());
+        memberRepository.save(currentMember);
     }
 
     public MemberBasicInfoResponse getMemberBasicInfo() {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #511 

## 📌 작업 내용 및 특이사항
- member guest -> 준회원 승급 로직 적용
- 정회원 -> 준회원 강등 로직 적용
- email verify 로직 적용
- jpa가 제공하는 도메인 이벤트의 발행을 위해서는 **항상** 명시적으로 호출해야합니다

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **신규 기능**
	- 대학 이메일 인증 프로세스를 완료한 후 회원 상태가 데이터베이스에 저장됩니다.
	- 모든 정회원의 역할을 준회원으로 변경한 후 이 변경사항이 데이터베이스에 반영됩니다.
	- 회원 인증 상태와 기본 정보 변경 후 해당 정보가 데이터베이스에 저장됩니다.
	- Discord ID가 업데이트된 후 회원 정보가 데이터베이스에 저장됩니다.

- **버그 수정**
	- 회원 상태 업데이트가 메모리에서 데이터베이스로 일관되게 반영되도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->