### PR TITLE
feat: 주문 목록 검색 시 승인일시를 일자 기준으로 수정 

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderQueryMethod.java
@@ -8,7 +8,7 @@ import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderQueryOption;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import java.time.LocalDate;
+import java.time.*;
 
 public interface OrderQueryMethod {
 
@@ -20,7 +20,7 @@ public interface OrderQueryMethod {
                 .and(eqStudentId(queryOption.studentId()))
                 .and(eqNanoId(queryOption.nanoId()))
                 .and(eqPaymentKey(queryOption.paymentKey()))
-                .and(eqApprovedAt(queryOption.approvedAt()));
+                .and(eqApprovedAt(queryOption.approvedDate()));
     }
 
     default BooleanExpression eqMember() {
@@ -57,6 +57,12 @@ public interface OrderQueryMethod {
     }
 
     default BooleanExpression eqApprovedAt(LocalDate approvedAt) {
-        return approvedAt != null ? order.approvedAt.stringValue().contains(approvedAt.toString()) : null;
+        if (approvedAt == null) {
+            return null;
+        }
+        ZoneId seoulZone = ZoneId.of("Asia/Seoul");
+        ZonedDateTime startOfDay = approvedAt.atStartOfDay(seoulZone);
+        ZonedDateTime endOfDay = approvedAt.atTime(LocalTime.MAX).atZone(seoulZone);
+        return order.approvedAt.between(startOfDay, endOfDay);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderQueryMethod.java
@@ -8,7 +8,7 @@ import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderQueryOption;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 
 public interface OrderQueryMethod {
 
@@ -56,7 +56,7 @@ public interface OrderQueryMethod {
         return paymentKey != null ? order.paymentKey.contains(paymentKey) : null;
     }
 
-    default BooleanExpression eqApprovedAt(ZonedDateTime approvedAt) {
-        return approvedAt != null ? order.approvedAt.eq(approvedAt) : null;
+    default BooleanExpression eqApprovedAt(LocalDate approvedAt) {
+        return approvedAt != null ? order.approvedAt.stringValue().contains(approvedAt.toString()) : null;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dto/request/OrderQueryOption.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dto/request/OrderQueryOption.java
@@ -3,7 +3,7 @@ package com.gdschongik.gdsc.domain.order.dto.request;
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.order.domain.OrderStatus;
 import jakarta.validation.constraints.Min;
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 
 public record OrderQueryOption(
         String name,
@@ -13,4 +13,4 @@ public record OrderQueryOption(
         OrderStatus status,
         String nanoId,
         String paymentKey,
-        ZonedDateTime approvedAt) {}
+        LocalDate approvedAt) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dto/request/OrderQueryOption.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dto/request/OrderQueryOption.java
@@ -13,4 +13,4 @@ public record OrderQueryOption(
         OrderStatus status,
         String nanoId,
         String paymentKey,
-        LocalDate approvedAt) {}
+        LocalDate approvedDate) {}

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -3,6 +3,7 @@ package com.gdschongik.gdsc.domain.order.application;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 import com.gdschongik.gdsc.domain.common.vo.Money;
@@ -16,6 +17,8 @@ import com.gdschongik.gdsc.domain.order.domain.OrderStatus;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCancelRequest;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCompleteRequest;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCreateRequest;
+import com.gdschongik.gdsc.domain.order.dto.request.OrderQueryOption;
+import com.gdschongik.gdsc.domain.order.dto.response.OrderAdminResponse;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.IntegrationTest;
@@ -23,12 +26,15 @@ import com.gdschongik.gdsc.infra.feign.payment.dto.request.PaymentCancelRequest;
 import com.gdschongik.gdsc.infra.feign.payment.dto.request.PaymentConfirmRequest;
 import com.gdschongik.gdsc.infra.feign.payment.dto.response.PaymentResponse;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 class OrderServiceTest extends IntegrationTest {
 
@@ -231,6 +237,59 @@ class OrderServiceTest extends IntegrationTest {
                     .hasMessage(ORDER_CANCEL_NOT_COMPLETED.getMessage());
 
             verify(paymentClient, never()).cancelPayment(any(), any());
+        }
+    }
+
+    @Nested
+    class 일자기준으로_주문목록_조회시 {
+
+        @Test
+        void 조회된다() {
+            // given
+            Member member = createMember();
+            logoutAndReloginAs(1L, MemberRole.ASSOCIATE);
+            RecruitmentRound recruitmentRound = createRecruitmentRound(
+                    RECRUITMENT_ROUND_NAME,
+                    LocalDateTime.now().minusDays(1),
+                    LocalDateTime.now().plusDays(1),
+                    ACADEMIC_YEAR,
+                    SEMESTER_TYPE,
+                    ROUND_TYPE,
+                    MONEY_20000_WON);
+
+            Membership membership = createMembership(member, recruitmentRound);
+            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
+
+            String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
+            orderService.createPendingOrder(new OrderCreateRequest(
+                    orderNanoId,
+                    membership.getId(),
+                    issuedCoupon.getId(),
+                    BigDecimal.valueOf(20000),
+                    BigDecimal.valueOf(5000),
+                    BigDecimal.valueOf(15000)));
+
+            String paymentKey = "testPaymentKey";
+
+            ZonedDateTime approvedAt = ZonedDateTime.now();
+            PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
+            when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
+            when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
+
+            // when
+            var request = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);
+            orderService.completeOrder(request);
+
+            LocalDate date = LocalDate.now();
+            OrderQueryOption queryOption = new OrderQueryOption(null, null, null, null, null, null, null, date);
+
+            Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
+
+            // then
+            boolean orderExists = orderResponse.getContent().stream()
+                    .anyMatch(order -> order.nanoId().equals(orderNanoId));
+
+            assertTrue(orderExists);
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -3,7 +3,6 @@ package com.gdschongik.gdsc.domain.order.application;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 import com.gdschongik.gdsc.domain.common.vo.Money;
@@ -275,21 +274,20 @@ class OrderServiceTest extends IntegrationTest {
             PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
             when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
             when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
-
-            // when
             var request = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);
             orderService.completeOrder(request);
 
             LocalDate date = LocalDate.now();
             OrderQueryOption queryOption = new OrderQueryOption(null, null, null, null, null, null, null, date);
 
+            // when
             Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
 
             // then
             boolean orderExists = orderResponse.getContent().stream()
                     .anyMatch(order -> order.nanoId().equals(orderNanoId));
 
-            assertTrue(orderExists);
+            assertThat(orderExists).isTrue();
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #519 

## 📌 작업 내용 및 특이사항
- 먼저, LocalDateTime, zoneId -> ZoneDateTime으로는 가능합니다. 하지만 LocalDate로 받는 것으로 되어 있으니 다른 방법을 찾아보았습니다
- LocalDate 로 받아서 string으로 변환하고. 기존의 디비에 저장되어있는 ZoneDateTime또한 string으로 변환하여 string으로 비교를 하는 로직으로 구현하였습니다
- 사실 구현보다는 이름 수정정도로 봐주시면 됩니다
- 근데 이제 테스트가 조금 규모가 큰데, 단순히 repository테스트에다가 두기에는 이것저것 많이 필요해서 주문 통합 테스트에 두었습니다! (대부분의 로직은 이미 존재하는 것 가져다 썼습니다!)

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- 주문 승인 날짜의 데이터 형식이 `ZonedDateTime`에서 `LocalDate`로 변경되었습니다. 이 변경은 날짜 처리 방식을 단순화합니다.
	- 주문 검색 기준에 대한 새로운 테스트 시나리오가 추가되어 날짜 기준으로 주문 목록을 조회하는 기능이 강화되었습니다.

- **Bug Fixes**
	- `OrderQueryOption`의 `approvedAt` 필드 수정으로 인해 발생할 수 있는 날짜 처리 관련 문제들이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->