### PR TITLE
feat: 신청 가능한 스터디 조회 API 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyController.java
@@ -1,0 +1,26 @@
+package com.gdschongik.gdsc.domain.study.api;
+
+import com.gdschongik.gdsc.domain.study.application.StudyService;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Study", description = "사용자 스터디 API입니다.")
+@RestController
+@RequestMapping("/studies")
+@RequiredArgsConstructor
+public class StudyController {
+
+    private final StudyService studyService;
+
+    @GetMapping("/applicable")
+    public ResponseEntity<List<StudyResponse>> getAllApplicableStudies() {
+        List<StudyResponse> response = studyService.getAllApplicableStudies();
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyController.java
@@ -18,7 +18,7 @@ public class StudyController {
 
     private final StudyService studyService;
 
-    @GetMapping("/applicable")
+    @GetMapping("/apply")
     public ResponseEntity<List<StudyResponse>> getAllApplicableStudies() {
         List<StudyResponse> response = studyService.getAllApplicableStudies();
         return ResponseEntity.ok().body(response);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyService.java
@@ -1,0 +1,23 @@
+package com.gdschongik.gdsc.domain.study.application;
+
+import com.gdschongik.gdsc.domain.study.dao.StudyRepository;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudyService {
+
+    private final StudyRepository studyRepository;
+
+    public List<StudyResponse> getAllApplicableStudies() {
+        return studyRepository.findAll().stream()
+                .filter(study -> study.getApplicationPeriod().isOpen())
+                .map(StudyResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyService.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.study.application;
 
 import com.gdschongik.gdsc.domain.study.dao.StudyRepository;
+import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +17,7 @@ public class StudyService {
 
     public List<StudyResponse> getAllApplicableStudies() {
         return studyRepository.findAll().stream()
-                .filter(study -> study.getApplicationPeriod().isOpen())
+                .filter(Study::isApplicable)
                 .map(StudyResponse::from)
                 .toList();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
@@ -162,4 +162,9 @@ public class Study extends BaseSemesterEntity {
             throw new CustomException(ASSIGNMENT_STUDY_CAN_NOT_INPUT_STUDY_TIME);
         }
     }
+
+    // 데이터 전달 로직
+    public boolean isApplicable() {
+        return applicationPeriod.isOpen();
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyType.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum StudyType {
+    // todo: value를 과제 스터디, 온라인 세션, 오프라인 세션으로 변경 해야함.
     ASSIGNMENT("과제"),
     ONLINE("온라인"),
     OFFLINE("오프라인");

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyType.java
@@ -6,10 +6,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum StudyType {
-    // todo: value를 과제 스터디, 온라인 세션, 오프라인 세션으로 변경 해야함.
-    ASSIGNMENT("과제"),
-    ONLINE("온라인"),
-    OFFLINE("오프라인");
+    ASSIGNMENT("과제 스터디"),
+    ONLINE("온라인 세션"),
+    OFFLINE("오프라인 세션");
 
     private final String value;
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/request/StudyCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/request/StudyCreateRequest.java
@@ -26,7 +26,7 @@ public record StudyCreateRequest(
                 LocalDate startDate,
         @NotNull(message = "스터디 요일은 null이 될 수 없습니다.") @Schema(description = "스터디 요일", implementation = DayOfWeek.class)
                 DayOfWeek dayOfWeek,
-        @Schema(description = "스터디 시작 시간", implementation = LocalTime.class) LocalTime studyStartTime,
-        @Schema(description = "스터디 종료 시간", implementation = LocalTime.class) LocalTime studyEndTime,
+        @NotNull @Schema(description = "스터디 시작 시간", implementation = LocalTime.class) LocalTime studyStartTime,
+        @NotNull @Schema(description = "스터디 종료 시간", implementation = LocalTime.class) LocalTime studyEndTime,
         @NotNull(message = "스터디 타입은 null이 될 수 없습니다.") @Schema(description = "스터디 타입", implementation = StudyType.class)
                 StudyType studyType) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyResponse.java
@@ -1,0 +1,54 @@
+package com.gdschongik.gdsc.domain.study.dto.response;
+
+import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+public record StudyResponse(
+        Long studyId,
+        @Schema(description = "이름") String title,
+        @Schema(description = "종류") String studyType,
+        @Schema(description = "상세설명 노션 링크") String notionLink,
+        @Schema(description = "한 줄 소개") String introduction,
+        @Schema(description = "멘토 이름") String mentorName,
+        @Schema(description = "스터디 시간") String schedule,
+        @Schema(description = "총 주차수") String totalWeek,
+        @Schema(description = "개강일") String openingDate) {
+
+    public static StudyResponse from(Study study) {
+        return new StudyResponse(
+                study.getId(),
+                study.getTitle(),
+                study.getStudyType().getValue(),
+                study.getNotionLink(),
+                study.getIntroduction(),
+                study.getMentor().getName(),
+                getSchedule(study.getDayOfWeek(), study.getStartTime()),
+                study.getTotalWeek().toString() + "주 코스",
+                DateTimeFormatter.ofPattern("MM.dd").format(study.getPeriod().getStartDate()) + " 개강");
+    }
+
+    private static String getSchedule(DayOfWeek dayOfWeek, LocalTime startTime) {
+        if (startTime == null) {
+            throw new CustomException(ErrorCode.STUDY_START_TIME_IS_NULL);
+        }
+        return getKoreanDayOfWeek(dayOfWeek) + startTime.format(DateTimeFormatter.ofPattern("HH")) + "시";
+    }
+
+    private static String getKoreanDayOfWeek(DayOfWeek dayOfWeek) {
+        return switch (dayOfWeek) {
+            case MONDAY -> "월";
+            case TUESDAY -> "화";
+            case WEDNESDAY -> "수";
+            case THURSDAY -> "목";
+            case FRIDAY -> "금";
+            case SATURDAY -> "토";
+            case SUNDAY -> "일";
+            default -> "";
+        };
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyResponse.java
@@ -1,8 +1,6 @@
 package com.gdschongik.gdsc.domain.study.dto.response;
 
 import com.gdschongik.gdsc.domain.study.domain.Study;
-import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
@@ -33,9 +31,6 @@ public record StudyResponse(
     }
 
     private static String getSchedule(DayOfWeek dayOfWeek, LocalTime startTime) {
-        if (startTime == null) {
-            throw new CustomException(ErrorCode.STUDY_START_TIME_IS_NULL);
-        }
         return getKoreanDayOfWeek(dayOfWeek) + startTime.format(DateTimeFormatter.ofPattern("HH")) + "시";
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyResponse.java
@@ -18,6 +18,7 @@ public record StudyResponse(
         @Schema(description = "개강일") String openingDate) {
 
     public static StudyResponse from(Study study) {
+        // todo: 포맷터로 분리
         return new StudyResponse(
                 study.getId(),
                 study.getTitle(),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -104,7 +104,6 @@ public enum ErrorCode {
     ON_OFF_LINE_STUDY_TIME_IS_ESSENTIAL(HttpStatus.CONFLICT, "온오프라인 스터디는 스터디 시간이 필요합니다."),
     STUDY_TIME_INVALID(HttpStatus.CONFLICT, "스터디종료 시각이 스터디시작 시각보다 빠릅니다."),
     ASSIGNMENT_STUDY_CAN_NOT_INPUT_STUDY_TIME(HttpStatus.CONFLICT, "과제 스터디는 스터디 시간을 입력할 수 없습니다."),
-    STUDY_START_TIME_IS_NULL(HttpStatus.CONFLICT, "스터디 시작 시간이 비어있습니다."),
 
     // Order
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문이 존재하지 않습니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -104,6 +104,7 @@ public enum ErrorCode {
     ON_OFF_LINE_STUDY_TIME_IS_ESSENTIAL(HttpStatus.CONFLICT, "온오프라인 스터디는 스터디 시간이 필요합니다."),
     STUDY_TIME_INVALID(HttpStatus.CONFLICT, "스터디종료 시각이 스터디시작 시각보다 빠릅니다."),
     ASSIGNMENT_STUDY_CAN_NOT_INPUT_STUDY_TIME(HttpStatus.CONFLICT, "과제 스터디는 스터디 시간을 입력할 수 없습니다."),
+    STUDY_START_TIME_IS_NULL(HttpStatus.CONFLICT, "스터디 시작 시간이 비어있습니다."),
 
     // Order
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문이 존재하지 않습니다."),

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -16,6 +16,8 @@ import com.gdschongik.gdsc.domain.order.domain.OrderStatus;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCancelRequest;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCompleteRequest;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCreateRequest;
+import com.gdschongik.gdsc.domain.order.dto.request.OrderQueryOption;
+import com.gdschongik.gdsc.domain.order.dto.response.OrderAdminResponse;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.IntegrationTest;
@@ -23,12 +25,15 @@ import com.gdschongik.gdsc.infra.feign.payment.dto.request.PaymentCancelRequest;
 import com.gdschongik.gdsc.infra.feign.payment.dto.request.PaymentConfirmRequest;
 import com.gdschongik.gdsc.infra.feign.payment.dto.response.PaymentResponse;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 class OrderServiceTest extends IntegrationTest {
 
@@ -234,55 +239,55 @@ class OrderServiceTest extends IntegrationTest {
         }
     }
 
-    // @Nested
-    // class 일자기준으로_주문목록_조회시 {
-    //
-    //     @Test
-    //     void 조회된다() {
-    //         // given
-    //         Member member = createMember();
-    //         logoutAndReloginAs(1L, MemberRole.ASSOCIATE);
-    //         RecruitmentRound recruitmentRound = createRecruitmentRound(
-    //                 RECRUITMENT_ROUND_NAME,
-    //                 LocalDateTime.now().minusDays(1),
-    //                 LocalDateTime.now().plusDays(1),
-    //                 ACADEMIC_YEAR,
-    //                 SEMESTER_TYPE,
-    //                 ROUND_TYPE,
-    //                 MONEY_20000_WON);
-    //
-    //         Membership membership = createMembership(member, recruitmentRound);
-    //         IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
-    //
-    //         String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
-    //         orderService.createPendingOrder(new OrderCreateRequest(
-    //                 orderNanoId,
-    //                 membership.getId(),
-    //                 issuedCoupon.getId(),
-    //                 BigDecimal.valueOf(20000),
-    //                 BigDecimal.valueOf(5000),
-    //                 BigDecimal.valueOf(15000)));
-    //
-    //         String paymentKey = "testPaymentKey";
-    //
-    //         ZonedDateTime approvedAt = ZonedDateTime.now();
-    //         PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
-    //         when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
-    //         when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
-    //         var request = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);
-    //         orderService.completeOrder(request);
-    //
-    //         LocalDate date = LocalDate.now();
-    //         OrderQueryOption queryOption = new OrderQueryOption(null, null, null, null, null, null, null, date);
-    //
-    //         // when
-    //         Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
-    //
-    //         // then
-    //         boolean orderExists = orderResponse.getContent().stream()
-    //                 .anyMatch(order -> order.nanoId().equals(orderNanoId));
-    //
-    //         assertThat(orderExists).isTrue();
-    //     }
-    // }
+    @Nested
+    class 일자기준으로_주문목록_조회시 {
+
+        @Test
+        void 조회된다() {
+            // given
+            Member member = createMember();
+            logoutAndReloginAs(1L, MemberRole.ASSOCIATE);
+            RecruitmentRound recruitmentRound = createRecruitmentRound(
+                    RECRUITMENT_ROUND_NAME,
+                    LocalDateTime.now().minusDays(1),
+                    LocalDateTime.now().plusDays(1),
+                    ACADEMIC_YEAR,
+                    SEMESTER_TYPE,
+                    ROUND_TYPE,
+                    MONEY_20000_WON);
+
+            Membership membership = createMembership(member, recruitmentRound);
+            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
+
+            String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
+            orderService.createPendingOrder(new OrderCreateRequest(
+                    orderNanoId,
+                    membership.getId(),
+                    issuedCoupon.getId(),
+                    BigDecimal.valueOf(20000),
+                    BigDecimal.valueOf(5000),
+                    BigDecimal.valueOf(15000)));
+
+            String paymentKey = "testPaymentKey";
+
+            ZonedDateTime approvedAt = ZonedDateTime.now();
+            PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
+            when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
+            when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
+            var request = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);
+            orderService.completeOrder(request);
+
+            LocalDate date = LocalDate.now();
+            OrderQueryOption queryOption = new OrderQueryOption(null, null, null, null, null, null, null, date);
+
+            // when
+            Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
+
+            // then
+            boolean orderExists = orderResponse.getContent().stream()
+                    .anyMatch(order -> order.nanoId().equals(orderNanoId));
+
+            assertThat(orderExists).isTrue();
+        }
+    }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -239,55 +239,55 @@ class OrderServiceTest extends IntegrationTest {
         }
     }
 
-    @Nested
-    class 일자기준으로_주문목록_조회시 {
+    // @Nested
+    // class 일자기준으로_주문목록_조회시 {
 
-        @Test
-        void 조회된다() {
-            // given
-            Member member = createMember();
-            logoutAndReloginAs(1L, MemberRole.ASSOCIATE);
-            RecruitmentRound recruitmentRound = createRecruitmentRound(
-                    RECRUITMENT_ROUND_NAME,
-                    LocalDateTime.now().minusDays(1),
-                    LocalDateTime.now().plusDays(1),
-                    ACADEMIC_YEAR,
-                    SEMESTER_TYPE,
-                    ROUND_TYPE,
-                    MONEY_20000_WON);
+    @Test
+    void 조회된다() {
+        // given
+        Member member = createAssociateMember();
+        logoutAndReloginAs(1L, MemberRole.ASSOCIATE);
+        RecruitmentRound recruitmentRound = createRecruitmentRound(
+                RECRUITMENT_ROUND_NAME,
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(1),
+                ACADEMIC_YEAR,
+                SEMESTER_TYPE,
+                ROUND_TYPE,
+                MONEY_20000_WON);
 
-            Membership membership = createMembership(member, recruitmentRound);
-            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
+        Membership membership = createMembership(member, recruitmentRound);
+        IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
 
-            String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
-            orderService.createPendingOrder(new OrderCreateRequest(
-                    orderNanoId,
-                    membership.getId(),
-                    issuedCoupon.getId(),
-                    BigDecimal.valueOf(20000),
-                    BigDecimal.valueOf(5000),
-                    BigDecimal.valueOf(15000)));
+        String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
+        orderService.createPendingOrder(new OrderCreateRequest(
+                orderNanoId,
+                membership.getId(),
+                issuedCoupon.getId(),
+                BigDecimal.valueOf(20000),
+                BigDecimal.valueOf(5000),
+                BigDecimal.valueOf(15000)));
 
-            String paymentKey = "testPaymentKey";
+        String paymentKey = "testPaymentKey";
 
-            ZonedDateTime approvedAt = ZonedDateTime.now();
-            PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
-            when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
-            when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
-            var request = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);
-            orderService.completeOrder(request);
+        ZonedDateTime approvedAt = ZonedDateTime.now();
+        PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
+        when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
+        when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
+        var request = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);
+        orderService.completeOrder(request);
 
-            LocalDate date = LocalDate.now();
-            OrderQueryOption queryOption = new OrderQueryOption(null, null, null, null, null, null, null, date);
+        LocalDate date = LocalDate.now();
+        OrderQueryOption queryOption = new OrderQueryOption(null, null, null, null, null, null, null, date);
 
-            // when
-            Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
+        // when
+        Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
 
-            // then
-            boolean orderExists = orderResponse.getContent().stream()
-                    .anyMatch(order -> order.nanoId().equals(orderNanoId));
+        // then
+        boolean orderExists = orderResponse.getContent().stream()
+                .anyMatch(order -> order.nanoId().equals(orderNanoId));
 
-            assertThat(orderExists).isTrue();
-        }
+        assertThat(orderExists).isTrue();
     }
+    // }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -17,7 +17,6 @@ import com.gdschongik.gdsc.domain.order.dto.request.OrderCancelRequest;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCompleteRequest;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCreateRequest;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderQueryOption;
-import com.gdschongik.gdsc.domain.order.dto.response.OrderAdminResponse;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.IntegrationTest;
@@ -32,8 +31,6 @@ import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 
 class OrderServiceTest extends IntegrationTest {
 
@@ -280,14 +277,14 @@ class OrderServiceTest extends IntegrationTest {
             LocalDate date = LocalDate.now();
             OrderQueryOption queryOption = new OrderQueryOption(null, null, null, null, null, null, null, date);
 
-            // when
-            Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
-
-            // then
-            boolean orderExists = orderResponse.getContent().stream()
-                    .anyMatch(order -> order.nanoId().equals(orderNanoId));
-
-            assertThat(orderExists).isTrue();
+            // // when
+            // Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
+            //
+            // // then
+            // boolean orderExists = orderResponse.getContent().stream()
+            //         .anyMatch(order -> order.nanoId().equals(orderNanoId));
+            //
+            // assertThat(orderExists).isTrue();
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -17,6 +17,7 @@ import com.gdschongik.gdsc.domain.order.dto.request.OrderCancelRequest;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCompleteRequest;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCreateRequest;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderQueryOption;
+import com.gdschongik.gdsc.domain.order.dto.response.OrderAdminResponse;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.IntegrationTest;
@@ -31,6 +32,8 @@ import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 class OrderServiceTest extends IntegrationTest {
 
@@ -277,9 +280,9 @@ class OrderServiceTest extends IntegrationTest {
             LocalDate date = LocalDate.now();
             OrderQueryOption queryOption = new OrderQueryOption(null, null, null, null, null, null, null, date);
 
-            // // when
-            // Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
-            //
+            // when
+            Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
+
             // // then
             // boolean orderExists = orderResponse.getContent().stream()
             //         .anyMatch(order -> order.nanoId().equals(orderNanoId));

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -239,55 +239,55 @@ class OrderServiceTest extends IntegrationTest {
         }
     }
 
-    // @Nested
-    // class 일자기준으로_주문목록_조회시 {
+    @Nested
+    class 일자기준으로_주문목록_조회시 {
 
-    @Test
-    void 조회된다() {
-        // given
-        Member member = createAssociateMember();
-        logoutAndReloginAs(1L, MemberRole.ASSOCIATE);
-        RecruitmentRound recruitmentRound = createRecruitmentRound(
-                RECRUITMENT_ROUND_NAME,
-                LocalDateTime.now().minusDays(1),
-                LocalDateTime.now().plusDays(1),
-                ACADEMIC_YEAR,
-                SEMESTER_TYPE,
-                ROUND_TYPE,
-                MONEY_20000_WON);
+        @Test
+        void 조회된다() {
+            // given
+            Member member = createAssociateMember();
+            logoutAndReloginAs(1L, MemberRole.ASSOCIATE);
+            RecruitmentRound recruitmentRound = createRecruitmentRound(
+                    RECRUITMENT_ROUND_NAME,
+                    LocalDateTime.now().minusDays(1),
+                    LocalDateTime.now().plusDays(1),
+                    ACADEMIC_YEAR,
+                    SEMESTER_TYPE,
+                    ROUND_TYPE,
+                    MONEY_20000_WON);
 
-        Membership membership = createMembership(member, recruitmentRound);
-        IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
+            Membership membership = createMembership(member, recruitmentRound);
+            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
 
-        String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
-        orderService.createPendingOrder(new OrderCreateRequest(
-                orderNanoId,
-                membership.getId(),
-                issuedCoupon.getId(),
-                BigDecimal.valueOf(20000),
-                BigDecimal.valueOf(5000),
-                BigDecimal.valueOf(15000)));
+            String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
+            orderService.createPendingOrder(new OrderCreateRequest(
+                    orderNanoId,
+                    membership.getId(),
+                    issuedCoupon.getId(),
+                    BigDecimal.valueOf(20000),
+                    BigDecimal.valueOf(5000),
+                    BigDecimal.valueOf(15000)));
 
-        String paymentKey = "testPaymentKey";
+            String paymentKey = "testPaymentKey";
 
-        ZonedDateTime approvedAt = ZonedDateTime.now();
-        PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
-        when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
-        when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
-        var request = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);
-        orderService.completeOrder(request);
+            ZonedDateTime approvedAt = ZonedDateTime.now();
+            PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
+            when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
+            when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
+            var request = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);
+            orderService.completeOrder(request);
 
-        LocalDate date = LocalDate.now();
-        OrderQueryOption queryOption = new OrderQueryOption(null, null, null, null, null, null, null, date);
+            LocalDate date = LocalDate.now();
+            OrderQueryOption queryOption = new OrderQueryOption(null, null, null, null, null, null, null, date);
 
-        // when
-        Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
+            // when
+            Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
 
-        // then
-        boolean orderExists = orderResponse.getContent().stream()
-                .anyMatch(order -> order.nanoId().equals(orderNanoId));
+            // then
+            boolean orderExists = orderResponse.getContent().stream()
+                    .anyMatch(order -> order.nanoId().equals(orderNanoId));
 
-        assertThat(orderExists).isTrue();
+            assertThat(orderExists).isTrue();
+        }
     }
-    // }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -29,14 +29,12 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
-@Slf4j
 class OrderServiceTest extends IntegrationTest {
 
     public static final Money MONEY_20000_WON = Money.from(20000L);
@@ -289,7 +287,6 @@ class OrderServiceTest extends IntegrationTest {
             boolean orderExists = orderResponse.getContent().stream()
                     .anyMatch(order -> order.nanoId().equals(orderNanoId));
 
-            log.info("orderExists = {}", orderExists);
             assertThat(orderExists).isTrue();
         }
     }

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -287,7 +287,7 @@ class OrderServiceTest extends IntegrationTest {
             boolean orderExists = orderResponse.getContent().stream()
                     .anyMatch(order -> order.nanoId().equals(orderNanoId));
 
-            // assertThat(orderExists).isTrue();
+            assertThat(orderExists).isTrue();
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -16,8 +16,6 @@ import com.gdschongik.gdsc.domain.order.domain.OrderStatus;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCancelRequest;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCompleteRequest;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderCreateRequest;
-import com.gdschongik.gdsc.domain.order.dto.request.OrderQueryOption;
-import com.gdschongik.gdsc.domain.order.dto.response.OrderAdminResponse;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.IntegrationTest;
@@ -25,15 +23,12 @@ import com.gdschongik.gdsc.infra.feign.payment.dto.request.PaymentCancelRequest;
 import com.gdschongik.gdsc.infra.feign.payment.dto.request.PaymentConfirmRequest;
 import com.gdschongik.gdsc.infra.feign.payment.dto.response.PaymentResponse;
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 
 class OrderServiceTest extends IntegrationTest {
 
@@ -239,55 +234,55 @@ class OrderServiceTest extends IntegrationTest {
         }
     }
 
-    @Nested
-    class 일자기준으로_주문목록_조회시 {
-
-        @Test
-        void 조회된다() {
-            // given
-            Member member = createMember();
-            logoutAndReloginAs(1L, MemberRole.ASSOCIATE);
-            RecruitmentRound recruitmentRound = createRecruitmentRound(
-                    RECRUITMENT_ROUND_NAME,
-                    LocalDateTime.now().minusDays(1),
-                    LocalDateTime.now().plusDays(1),
-                    ACADEMIC_YEAR,
-                    SEMESTER_TYPE,
-                    ROUND_TYPE,
-                    MONEY_20000_WON);
-
-            Membership membership = createMembership(member, recruitmentRound);
-            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
-
-            String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
-            orderService.createPendingOrder(new OrderCreateRequest(
-                    orderNanoId,
-                    membership.getId(),
-                    issuedCoupon.getId(),
-                    BigDecimal.valueOf(20000),
-                    BigDecimal.valueOf(5000),
-                    BigDecimal.valueOf(15000)));
-
-            String paymentKey = "testPaymentKey";
-
-            ZonedDateTime approvedAt = ZonedDateTime.now();
-            PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
-            when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
-            when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
-            var request = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);
-            orderService.completeOrder(request);
-
-            LocalDate date = LocalDate.now();
-            OrderQueryOption queryOption = new OrderQueryOption(null, null, null, null, null, null, null, date);
-
-            // when
-            Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
-
-            // then
-            boolean orderExists = orderResponse.getContent().stream()
-                    .anyMatch(order -> order.nanoId().equals(orderNanoId));
-
-            assertThat(orderExists).isTrue();
-        }
-    }
+    // @Nested
+    // class 일자기준으로_주문목록_조회시 {
+    //
+    //     @Test
+    //     void 조회된다() {
+    //         // given
+    //         Member member = createMember();
+    //         logoutAndReloginAs(1L, MemberRole.ASSOCIATE);
+    //         RecruitmentRound recruitmentRound = createRecruitmentRound(
+    //                 RECRUITMENT_ROUND_NAME,
+    //                 LocalDateTime.now().minusDays(1),
+    //                 LocalDateTime.now().plusDays(1),
+    //                 ACADEMIC_YEAR,
+    //                 SEMESTER_TYPE,
+    //                 ROUND_TYPE,
+    //                 MONEY_20000_WON);
+    //
+    //         Membership membership = createMembership(member, recruitmentRound);
+    //         IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
+    //
+    //         String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
+    //         orderService.createPendingOrder(new OrderCreateRequest(
+    //                 orderNanoId,
+    //                 membership.getId(),
+    //                 issuedCoupon.getId(),
+    //                 BigDecimal.valueOf(20000),
+    //                 BigDecimal.valueOf(5000),
+    //                 BigDecimal.valueOf(15000)));
+    //
+    //         String paymentKey = "testPaymentKey";
+    //
+    //         ZonedDateTime approvedAt = ZonedDateTime.now();
+    //         PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
+    //         when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
+    //         when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
+    //         var request = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);
+    //         orderService.completeOrder(request);
+    //
+    //         LocalDate date = LocalDate.now();
+    //         OrderQueryOption queryOption = new OrderQueryOption(null, null, null, null, null, null, null, date);
+    //
+    //         // when
+    //         Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
+    //
+    //         // then
+    //         boolean orderExists = orderResponse.getContent().stream()
+    //                 .anyMatch(order -> order.nanoId().equals(orderNanoId));
+    //
+    //         assertThat(orderExists).isTrue();
+    //     }
+    // }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -29,12 +29,14 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
+@Slf4j
 class OrderServiceTest extends IntegrationTest {
 
     public static final Money MONEY_20000_WON = Money.from(20000L);
@@ -287,6 +289,7 @@ class OrderServiceTest extends IntegrationTest {
             boolean orderExists = orderResponse.getContent().stream()
                     .anyMatch(order -> order.nanoId().equals(orderNanoId));
 
+            log.info("orderExists = {}", orderExists);
             assertThat(orderExists).isTrue();
         }
     }

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -283,10 +283,10 @@ class OrderServiceTest extends IntegrationTest {
             // when
             Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
 
-            // // then
-            // boolean orderExists = orderResponse.getContent().stream()
-            //         .anyMatch(order -> order.nanoId().equals(orderNanoId));
-            //
+            // then
+            boolean orderExists = orderResponse.getContent().stream()
+                    .anyMatch(order -> order.nanoId().equals(orderNanoId));
+
             // assertThat(orderExists).isTrue();
         }
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #448

## 📌 작업 내용 및 특이사항
- 신청 가능한 스터디를 조회하는 api입니다.
- 단순 조회라서 test는 생략했습니다.

## 📝 참고사항
- StudyType의 value를 과제 스터디, 온라인 세션, 오프라인 세션으로 변경했습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **신규 기능**
	- 연구 관련 작업을 관리하기 위한 RESTful API 엔드포인트를 추가했습니다.
	- `적용 가능한 연구` 목록을 가져오는 기능이 추가되었습니다.
	- 연구 응답 객체를 정의하는 `StudyResponse` 클래스를 새롭게 도입했습니다.
	- 연구 생성 요청 시 필수 필드에 대한 검증을 강화했습니다.

- **버그 수정**
	- 연구 시작 시간이 NULL일 경우의 오류 처리를 위한 새로운 오류 코드가 추가되었습니다.

- **문서화**
	- API 문서화를 위한 메타데이터 제공을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->