### PR TITLE
fix: PaymentFeignClient 설정 중복 제거

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/infra/feign/payment/config/PaymentClientConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/feign/payment/config/PaymentClientConfig.java
@@ -1,14 +1,7 @@
 package com.gdschongik.gdsc.infra.feign.payment.config;
 
 import com.gdschongik.gdsc.infra.feign.payment.error.PaymentErrorDecoder;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
 @Import({BasicAuthConfig.class, PaymentErrorDecoder.class})
-public class PaymentClientConfig {
-
-    @Bean
-    public PaymentErrorDecoder paymentErrorDecoder() {
-        return new PaymentErrorDecoder();
-    }
-}
+public class PaymentClientConfig {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #526

## 📌 작업 내용 및 특이사항
- PaymentFeignConfig에서 에러디코더를 Import안에도 넣고, 메소드로 빈등록을 둘다 하여 충돌하기떄문에 에러메세지가 프론트로 넘어가지 않고, INTERNAL_SERVER_ERROR로 나왔던 거였습니다!
아마, 높은확률로 현영님께서 만료된 주문을 결제하는거라 에러가 뜬걸로 예상됩니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - `PaymentErrorDecoder`의 인스턴스 생성 방식 변경으로 인해 관련된 오류가 수정되었습니다.  
- **기능 개선**
  - `PaymentClientConfig`의 간소화로 코드 유지 관리가 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->