### PR TITLE
fix: 주문 조회하기 쿼리 메서드 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderCustomRepositoryImpl.java
@@ -66,6 +66,8 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository, OrderQu
         return queryFactory
                 .select(order.id)
                 .from(order)
+                .innerJoin(recruitmentRound)
+                .on(order.recruitmentRoundId.eq(recruitmentRound.id))
                 .where(matchesOrderQueryOption(queryOption), predicate)
                 .orderBy(orderSpecifiers)
                 .fetch();

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderQueryMethod.java
@@ -3,6 +3,8 @@ package com.gdschongik.gdsc.domain.order.dao;
 import static com.gdschongik.gdsc.domain.member.domain.QMember.*;
 import static com.gdschongik.gdsc.domain.order.domain.QOrder.*;
 import static com.gdschongik.gdsc.domain.recruitment.domain.QRecruitment.*;
+import static com.gdschongik.gdsc.domain.recruitment.domain.QRecruitmentRound.*;
+import static com.querydsl.jpa.JPAExpressions.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.order.dto.request.OrderQueryOption;
@@ -37,11 +39,19 @@ public interface OrderQueryMethod {
     }
 
     default BooleanExpression eqAcademicYear(Integer academicYear) {
-        return academicYear != null ? recruitment.academicYear.eq(academicYear) : null;
+        return academicYear != null
+                ? order.recruitmentRoundId.in(select(recruitmentRound.id)
+                        .from(recruitmentRound)
+                        .where(recruitmentRound.academicYear.eq(academicYear)))
+                : null;
     }
 
     default BooleanExpression eqSemesterType(SemesterType semesterType) {
-        return semesterType != null ? recruitment.semesterType.eq(semesterType) : null;
+        return semesterType != null
+                ? order.recruitmentRoundId.in(select(recruitmentRound.id)
+                        .from(recruitmentRound)
+                        .where(recruitmentRound.semesterType.eq(semesterType)))
+                : null;
     }
 
     default BooleanExpression eqStudentId(String studentId) {

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderQueryMethod.java
@@ -39,19 +39,11 @@ public interface OrderQueryMethod {
     }
 
     default BooleanExpression eqAcademicYear(Integer academicYear) {
-        return academicYear != null
-                ? order.recruitmentRoundId.in(select(recruitmentRound.id)
-                        .from(recruitmentRound)
-                        .where(recruitmentRound.academicYear.eq(academicYear)))
-                : null;
+        return academicYear != null ? recruitmentRound.academicYear.eq(academicYear) : null;
     }
 
     default BooleanExpression eqSemesterType(SemesterType semesterType) {
-        return semesterType != null
-                ? order.recruitmentRoundId.in(select(recruitmentRound.id)
-                        .from(recruitmentRound)
-                        .where(recruitmentRound.semesterType.eq(semesterType)))
-                : null;
+        return semesterType != null ? recruitmentRound.semesterType.eq(semesterType) : null;
     }
 
     default BooleanExpression eqStudentId(String studentId) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #528

## 📌 작업 내용 및 특이사항
- Order는 Recruitment가 아니라 Long 타입의 recruitmentRoundId를 가지고 있는데,
recruitment로 쿼리 메서드를 작성해서 `Could not interpret path expression 'recruitment.semesterType' `의 사유로 500 에러가 발생하고 있었습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **신규 기능**
	- 주문 필터링 기능이 개선되어 학년도 및 학기 유형에 따라 더 정확한 결과를 제공하도록 업데이트되었습니다.

- **버그 수정**
	- 주문 쿼리 로직의 수정으로 인해 이전보다 더 정확한 필터링이 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->