### PR TITLE
feat: 스터디 수강신청 API 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyController.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.domain.study.api;
 
 import com.gdschongik.gdsc.domain.study.application.StudyService;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,12 +21,14 @@ public class StudyController {
 
     private final StudyService studyService;
 
+    @Operation(summary = "신청 가능한 스터디 조회", description = "모집 기간 중에 있는 스터디를 조회합니다.")
     @GetMapping("/apply")
     public ResponseEntity<List<StudyResponse>> getAllApplicableStudies() {
         List<StudyResponse> response = studyService.getAllApplicableStudies();
         return ResponseEntity.ok().body(response);
     }
 
+    @Operation(summary = "스터디 수강신청", description = "스터디에 수강신청 합니다. 모집 기간 중이어야 하고, 이미 수강 중인 스터디가 없어야 합니다.")
     @PostMapping("/apply/{studyId}")
     public ResponseEntity<Void> applyStudy(@PathVariable Long studyId) {
         studyService.applyStudy(studyId);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyController.java
@@ -7,6 +7,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,5 +24,11 @@ public class StudyController {
     public ResponseEntity<List<StudyResponse>> getAllApplicableStudies() {
         List<StudyResponse> response = studyService.getAllApplicableStudies();
         return ResponseEntity.ok().body(response);
+    }
+
+    @PostMapping("/apply/{studyId}")
+    public ResponseEntity<Void> applyStudy(@PathVariable Long studyId) {
+        studyService.applyStudy(studyId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyService.java
@@ -34,6 +34,7 @@ public class StudyService {
                 .toList();
     }
 
+    @Transactional
     public void applyStudy(Long studyId) {
         Study study =
                 studyRepository.findById(studyId).orElseThrow(() -> new CustomException(ErrorCode.STUDY_NOT_FOUND));

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyService.java
@@ -5,6 +5,7 @@ import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyRepository;
 import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
+import com.gdschongik.gdsc.domain.study.domain.StudyHistoryValidator;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
@@ -24,6 +25,7 @@ public class StudyService {
     private final MemberUtil memberUtil;
     private final StudyRepository studyRepository;
     private final StudyHistoryRepository studyHistoryRepository;
+    private final StudyHistoryValidator studyHistoryValidator;
 
     public List<StudyResponse> getAllApplicableStudies() {
         return studyRepository.findAll().stream()
@@ -33,9 +35,13 @@ public class StudyService {
     }
 
     public void applyStudy(Long studyId) {
-        Member currentMember = memberUtil.getCurrentMember();
         Study study =
                 studyRepository.findById(studyId).orElseThrow(() -> new CustomException(ErrorCode.STUDY_NOT_FOUND));
+        Member currentMember = memberUtil.getCurrentMember();
+
+        List<StudyHistory> currentMemberStudyHistories = studyHistoryRepository.findAllByMentee(currentMember);
+
+        studyHistoryValidator.validateApplyStudy(study, currentMemberStudyHistories);
 
         StudyHistory studyHistory = StudyHistory.create(currentMember, study);
         studyHistoryRepository.save(studyHistory);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyService.java
@@ -1,24 +1,45 @@
 package com.gdschongik.gdsc.domain.study.application;
 
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyRepository;
 import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyResponse;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.exception.ErrorCode;
+import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class StudyService {
 
+    private final MemberUtil memberUtil;
     private final StudyRepository studyRepository;
+    private final StudyHistoryRepository studyHistoryRepository;
 
     public List<StudyResponse> getAllApplicableStudies() {
         return studyRepository.findAll().stream()
                 .filter(Study::isApplicable)
                 .map(StudyResponse::from)
                 .toList();
+    }
+
+    public void applyStudy(Long studyId) {
+        Member currentMember = memberUtil.getCurrentMember();
+        Study study =
+                studyRepository.findById(studyId).orElseThrow(() -> new CustomException(ErrorCode.STUDY_NOT_FOUND));
+
+        StudyHistory studyHistory = StudyHistory.create(currentMember, study);
+        studyHistoryRepository.save(studyHistory);
+
+        log.info("[StudyService] 스터디 수강신청: studyHistoryId={}", studyHistory.getId());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryRepository.java
@@ -1,0 +1,6 @@
+package com.gdschongik.gdsc.domain.study.dao;
+
+import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyHistoryRepository extends JpaRepository<StudyHistory, Long> {}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryRepository.java
@@ -1,6 +1,11 @@
 package com.gdschongik.gdsc.domain.study.dao;
 
+import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StudyHistoryRepository extends JpaRepository<StudyHistory, Long> {}
+public interface StudyHistoryRepository extends JpaRepository<StudyHistory, Long> {
+
+    List<StudyHistory> findAllByMentee(Member member);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
@@ -167,4 +167,8 @@ public class Study extends BaseSemesterEntity {
     public boolean isApplicable() {
         return applicationPeriod.isOpen();
     }
+
+    public boolean isStudyOngoing() {
+        return period.isOpen();
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -42,4 +42,9 @@ public class StudyHistory extends BaseEntity {
     public static StudyHistory create(Member mentee, Study study) {
         return StudyHistory.builder().mentee(mentee).study(study).build();
     }
+
+    // 데이터 전달 로직
+    public boolean isStudyOngoing() {
+        return study.isStudyOngoing();
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -31,4 +32,14 @@ public class StudyHistory extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "study_id")
     private Study study;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private StudyHistory(Member mentee, Study study) {
+        this.mentee = mentee;
+        this.study = study;
+    }
+
+    public static StudyHistory create(Member mentee, Study study) {
+        return StudyHistory.builder().mentee(mentee).study(study).build();
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
@@ -1,0 +1,33 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.global.annotation.DomainService;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import java.util.List;
+
+@DomainService
+public class StudyHistoryValidator {
+
+    public void validateApplyStudy(Study study, List<StudyHistory> currentMemberStudyHistories) {
+        // 이미 해당 스터디에 수강신청한 경우
+        boolean isStudyHistoryDuplicate = currentMemberStudyHistories.stream()
+                .anyMatch(studyHistory -> studyHistory.getStudy().equals(study));
+
+        if (isStudyHistoryDuplicate) {
+            throw new CustomException(STUDY_HISTORY_DUPLICATE);
+        }
+
+        // 스터디 수강신청 기간이 아닌 경우
+        if (!study.isApplicable()) {
+            throw new CustomException(STUDY_NOT_APPLICABLE);
+        }
+
+        // 이미 듣고 있는 스터디가 있는 경우
+        boolean isInOngoingStudy = currentMemberStudyHistories.stream().anyMatch(StudyHistory::isStudyOngoing);
+
+        if (isInOngoingStudy) {
+            throw new CustomException(STUDY_HISTORY_ONGOING_ALREADY_EXISTS);
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -105,6 +105,11 @@ public enum ErrorCode {
     STUDY_TIME_INVALID(HttpStatus.CONFLICT, "스터디종료 시각이 스터디시작 시각보다 빠릅니다."),
     ASSIGNMENT_STUDY_CAN_NOT_INPUT_STUDY_TIME(HttpStatus.CONFLICT, "과제 스터디는 스터디 시간을 입력할 수 없습니다."),
     STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디입니다."),
+    STUDY_NOT_APPLICABLE(HttpStatus.CONFLICT, "스터디 신청기간이 아닙니다."),
+
+    // StudyHistory
+    STUDY_HISTORY_DUPLICATE(HttpStatus.CONFLICT, "이미 해당 스터디를 신청했습니다."),
+    STUDY_HISTORY_ONGOING_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 진행중인 스터디가 있습니다."),
 
     // Order
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문이 존재하지 않습니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -104,6 +104,7 @@ public enum ErrorCode {
     ON_OFF_LINE_STUDY_TIME_IS_ESSENTIAL(HttpStatus.CONFLICT, "온오프라인 스터디는 스터디 시간이 필요합니다."),
     STUDY_TIME_INVALID(HttpStatus.CONFLICT, "스터디종료 시각이 스터디시작 시각보다 빠릅니다."),
     ASSIGNMENT_STUDY_CAN_NOT_INPUT_STUDY_TIME(HttpStatus.CONFLICT, "과제 스터디는 스터디 시간을 입력할 수 없습니다."),
+    STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디입니다."),
 
     // Order
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문이 존재하지 않습니다."),

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/StudyServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/StudyServiceTest.java
@@ -1,0 +1,28 @@
+package com.gdschongik.gdsc.domain.study.application;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.exception.ErrorCode;
+import com.gdschongik.gdsc.helper.IntegrationTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class StudyServiceTest extends IntegrationTest {
+
+    @Autowired
+    private StudyService studyService;
+
+    @Nested
+    class 스터디_수강신청시 {
+
+        @Test
+        void 존재하지_않는_스터디라면_실패한다() {
+            // when & then
+            assertThatThrownBy(() -> studyService.applyStudy(1L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.STUDY_NOT_FOUND.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidatorTest.java
@@ -1,0 +1,95 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.helper.FixtureHelper;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class StudyHistoryValidatorTest {
+
+    FixtureHelper fixtureHelper = new FixtureHelper();
+    StudyHistoryValidator studyHistoryValidator = new StudyHistoryValidator();
+
+    private Study createStudy(Member mentor, Period period, Period applicationPeriod) {
+        return Study.createStudy(
+                ACADEMIC_YEAR,
+                SEMESTER_TYPE,
+                mentor,
+                period,
+                applicationPeriod,
+                TOTAL_WEEK,
+                ONLINE_STUDY,
+                DAY_OF_WEEK,
+                STUDY_START_TIME,
+                STUDY_END_TIME);
+    }
+
+    @Nested
+    class 스터디_수강신청시 {
+
+        @Test
+        void 이미_해당_스터디를_신청했다면_실패한다() {
+            // given
+            Member mentor = fixtureHelper.createAssociateMember(1L);
+
+            LocalDateTime now = LocalDateTime.now();
+            Period period = Period.createPeriod(now.plusDays(10), now.plusDays(15));
+            Period applicationPeriod = Period.createPeriod(now.minusDays(10), now.plusDays(5));
+            Study study = createStudy(mentor, period, applicationPeriod);
+
+            Member mentee = fixtureHelper.createGuestMember(2L);
+            StudyHistory studyHistory = StudyHistory.create(mentee, study);
+
+            // when & then
+            assertThatThrownBy(() -> studyHistoryValidator.validateApplyStudy(study, List.of(studyHistory)))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(STUDY_HISTORY_DUPLICATE.getMessage());
+        }
+
+        @Test
+        void 해당_스터디의_신청기간이_아니라면_실패한다() {
+            // given
+            Member mentor = fixtureHelper.createAssociateMember(1L);
+
+            LocalDateTime now = LocalDateTime.now();
+            Period period = Period.createPeriod(now.plusDays(10), now.plusDays(15));
+            Period applicationPeriod = Period.createPeriod(now.minusDays(10), now.minusDays(5));
+            Study study = createStudy(mentor, period, applicationPeriod);
+
+            // when & then
+            assertThatThrownBy(() -> studyHistoryValidator.validateApplyStudy(study, List.of()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(STUDY_NOT_APPLICABLE.getMessage());
+        }
+
+        @Test
+        void 이미_듣고_있는_스터디가_있다면_실패한다() {
+            // given
+            Member mentor = fixtureHelper.createAssociateMember(1L);
+
+            LocalDateTime now = LocalDateTime.now();
+            Period period = Period.createPeriod(now.minusDays(5), now.plusDays(15));
+            Period applicationPeriod = Period.createPeriod(now.minusDays(15), now.plusDays(5));
+            Study study = createStudy(mentor, period, applicationPeriod);
+
+            Study anotherStudy = createStudy(mentor, period, applicationPeriod);
+
+            Member mentee = fixtureHelper.createGuestMember(2L);
+            StudyHistory studyHistory = StudyHistory.create(mentee, anotherStudy);
+
+            // when & then
+            assertThatThrownBy(() -> studyHistoryValidator.validateApplyStudy(study, List.of(studyHistory)))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(STUDY_HISTORY_ONGOING_ALREADY_EXISTS.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidatorTest.java
@@ -19,20 +19,6 @@ public class StudyHistoryValidatorTest {
     FixtureHelper fixtureHelper = new FixtureHelper();
     StudyHistoryValidator studyHistoryValidator = new StudyHistoryValidator();
 
-    private Study createStudy(Member mentor, Period period, Period applicationPeriod) {
-        return Study.createStudy(
-                ACADEMIC_YEAR,
-                SEMESTER_TYPE,
-                mentor,
-                period,
-                applicationPeriod,
-                TOTAL_WEEK,
-                ONLINE_STUDY,
-                DAY_OF_WEEK,
-                STUDY_START_TIME,
-                STUDY_END_TIME);
-    }
-
     @Nested
     class 스터디_수강신청시 {
 
@@ -44,7 +30,7 @@ public class StudyHistoryValidatorTest {
             LocalDateTime now = LocalDateTime.now();
             Period period = Period.createPeriod(now.plusDays(10), now.plusDays(15));
             Period applicationPeriod = Period.createPeriod(now.minusDays(10), now.plusDays(5));
-            Study study = createStudy(mentor, period, applicationPeriod);
+            Study study = fixtureHelper.createStudy(mentor, period, applicationPeriod);
 
             Member mentee = fixtureHelper.createGuestMember(2L);
             StudyHistory studyHistory = StudyHistory.create(mentee, study);
@@ -63,7 +49,7 @@ public class StudyHistoryValidatorTest {
             LocalDateTime now = LocalDateTime.now();
             Period period = Period.createPeriod(now.plusDays(10), now.plusDays(15));
             Period applicationPeriod = Period.createPeriod(now.minusDays(10), now.minusDays(5));
-            Study study = createStudy(mentor, period, applicationPeriod);
+            Study study = fixtureHelper.createStudy(mentor, period, applicationPeriod);
 
             // when & then
             assertThatThrownBy(() -> studyHistoryValidator.validateApplyStudy(study, List.of()))
@@ -79,9 +65,9 @@ public class StudyHistoryValidatorTest {
             LocalDateTime now = LocalDateTime.now();
             Period period = Period.createPeriod(now.minusDays(5), now.plusDays(15));
             Period applicationPeriod = Period.createPeriod(now.minusDays(15), now.plusDays(5));
-            Study study = createStudy(mentor, period, applicationPeriod);
+            Study study = fixtureHelper.createStudy(mentor, period, applicationPeriod);
 
-            Study anotherStudy = createStudy(mentor, period, applicationPeriod);
+            Study anotherStudy = fixtureHelper.createStudy(mentor, period, applicationPeriod);
 
             Member mentee = fixtureHelper.createGuestMember(2L);
             StudyHistory studyHistory = StudyHistory.create(mentee, anotherStudy);

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -5,6 +5,7 @@ import static com.gdschongik.gdsc.domain.member.domain.Member.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.SemesterConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
@@ -16,6 +17,7 @@ import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.domain.study.domain.Study;
 import java.time.LocalDateTime;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -62,5 +64,19 @@ public class FixtureHelper {
     public IssuedCoupon createAndIssue(Money money, Member member) {
         Coupon coupon = Coupon.createCoupon("테스트쿠폰", money);
         return IssuedCoupon.issue(coupon, member);
+    }
+
+    public Study createStudy(Member mentor, Period period, Period applicationPeriod) {
+        return Study.createStudy(
+                ACADEMIC_YEAR,
+                SEMESTER_TYPE,
+                mentor,
+                period,
+                applicationPeriod,
+                TOTAL_WEEK,
+                ONLINE_STUDY,
+                DAY_OF_WEEK,
+                STUDY_START_TIME,
+                STUDY_END_TIME);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #424

## 📌 작업 내용 및 특이사항
- 스터디 수강신청 api를 구현했습니다.
- 검증 대상은 다음과 같습니다.
  1. 이미 해당 스터디에 수강신청한 경우
  2. 해당 스터디 수강신청 기간이 아닌 경우
  3. 이미 듣고 있는 스터디가 있는 경우(정책상 한번에 하나의 스터디만 들을 수 있습니다.)

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 사용자가 특정 연구에 신청할 수 있는 새로운 API 엔드포인트 추가.
  - 연구의 진행 상태를 확인할 수 있는 메서드 추가.
  - 연구 신청을 위한 검증 로직 도입 및 예외 처리 개선.
  
- **버그 수정**
  - 연구 신청 시 중복 검증 및 진행 중인 연구 확인 로직 개선.

- **테스트**
  - 연구 신청 검증 로직에 대한 단위 테스트 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->