### PR TITLE
feat: 스터디 수강신청 취소 API 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyController.java
@@ -40,6 +40,6 @@ public class StudyController {
     @DeleteMapping("/apply/{studyId}")
     public ResponseEntity<Void> cancelStudyApply(@PathVariable Long studyId) {
         studyService.cancelStudyApply(studyId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -32,6 +33,13 @@ public class StudyController {
     @PostMapping("/apply/{studyId}")
     public ResponseEntity<Void> applyStudy(@PathVariable Long studyId) {
         studyService.applyStudy(studyId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "스터디 수강신청 취소", description = "수강 신청을 취소합니다. 모집 기간이 끝나지 않았어야 취소할 수 있습니다.")
+    @DeleteMapping("/apply/{studyId}")
+    public ResponseEntity<Void> cancelStudyApply(@PathVariable Long studyId) {
+        studyService.cancelStudyApply(studyId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyController.java
@@ -36,7 +36,7 @@ public class StudyController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "스터디 수강신청 취소", description = "수강 신청을 취소합니다. 모집 기간이 끝나지 않았어야 취소할 수 있습니다.")
+    @Operation(summary = "스터디 수강신청 취소", description = "수강신청을 취소합니다. 스터디 수강신청 기간 중에만 취소할 수 있습니다.")
     @DeleteMapping("/apply/{studyId}")
     public ResponseEntity<Void> cancelStudyApply(@PathVariable Long studyId) {
         studyService.cancelStudyApply(studyId);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryRepository.java
@@ -1,11 +1,15 @@
 package com.gdschongik.gdsc.domain.study.dao;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudyHistoryRepository extends JpaRepository<StudyHistory, Long> {
 
     List<StudyHistory> findAllByMentee(Member member);
+
+    Optional<StudyHistory> findByMenteeAndStudy(Member member, Study study);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
@@ -32,6 +32,7 @@ public class StudyHistoryValidator {
     }
 
     public void validateCancelStudyApply(Study study) {
+        // todo: 스터디 정정기간 고려하도록 수정
         // 스터디 수강신청 기간이 아닌 경우
         if (!study.isApplicable()) {
             throw new CustomException(STUDY_APPLY_NOT_CANCELABLE);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
@@ -35,7 +35,7 @@ public class StudyHistoryValidator {
         // todo: 스터디 정정기간 고려하도록 수정
         // 스터디 수강신청 기간이 아닌 경우
         if (!study.isApplicable()) {
-            throw new CustomException(STUDY_APPLY_NOT_CANCELABLE);
+            throw new CustomException(STUDY_NOT_CANCELABLE_APPLICATION_PERIOD);
         }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
@@ -32,7 +32,6 @@ public class StudyHistoryValidator {
     }
 
     public void validateCancelStudyApply(Study study) {
-        // todo: 스터디 정정기간 고려하도록 수정
         // 스터디 수강신청 기간이 아닌 경우
         if (!study.isApplicable()) {
             throw new CustomException(STUDY_NOT_CANCELABLE_APPLICATION_PERIOD);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
@@ -30,4 +30,11 @@ public class StudyHistoryValidator {
             throw new CustomException(STUDY_HISTORY_ONGOING_ALREADY_EXISTS);
         }
     }
+
+    public void validateCancelStudyApply(Study study) {
+        // 스터디 수강신청 기간이 아닌 경우
+        if (!study.isApplicable()) {
+            throw new CustomException(STUDY_HISTORY_NOT_CANCELABLE);
+        }
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
@@ -34,7 +34,7 @@ public class StudyHistoryValidator {
     public void validateCancelStudyApply(Study study) {
         // 스터디 수강신청 기간이 아닌 경우
         if (!study.isApplicable()) {
-            throw new CustomException(STUDY_HISTORY_NOT_CANCELABLE);
+            throw new CustomException(STUDY_APPLY_NOT_CANCELABLE);
         }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -106,12 +106,12 @@ public enum ErrorCode {
     ASSIGNMENT_STUDY_CAN_NOT_INPUT_STUDY_TIME(HttpStatus.CONFLICT, "과제 스터디는 스터디 시간을 입력할 수 없습니다."),
     STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디입니다."),
     STUDY_NOT_APPLICABLE(HttpStatus.CONFLICT, "스터디 신청기간이 아닙니다."),
+    STUDY_APPLY_NOT_CANCELABLE(HttpStatus.CONFLICT, "스터디 신청기간이 아니라면 취소할 수 없습니다."),
 
     // StudyHistory
     STUDY_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 수강 기록입니다."),
     STUDY_HISTORY_DUPLICATE(HttpStatus.CONFLICT, "이미 해당 스터디를 신청했습니다."),
     STUDY_HISTORY_ONGOING_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 진행중인 스터디가 있습니다."),
-    STUDY_HISTORY_NOT_CANCELABLE(HttpStatus.CONFLICT, "스터디 신청기간이 아니라면 취소할 수 없습니다."),
 
     // Order
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문이 존재하지 않습니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -106,7 +106,7 @@ public enum ErrorCode {
     ASSIGNMENT_STUDY_CAN_NOT_INPUT_STUDY_TIME(HttpStatus.CONFLICT, "과제 스터디는 스터디 시간을 입력할 수 없습니다."),
     STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디입니다."),
     STUDY_NOT_APPLICABLE(HttpStatus.CONFLICT, "스터디 신청기간이 아닙니다."),
-    STUDY_APPLY_NOT_CANCELABLE(HttpStatus.CONFLICT, "스터디 신청기간이 아니라면 취소할 수 없습니다."),
+    STUDY_NOT_CANCELABLE_APPLICATION_PERIOD(HttpStatus.CONFLICT, "스터디 신청기간이 아니라면 취소할 수 없습니다."),
 
     // StudyHistory
     STUDY_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 수강 기록입니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -108,8 +108,10 @@ public enum ErrorCode {
     STUDY_NOT_APPLICABLE(HttpStatus.CONFLICT, "스터디 신청기간이 아닙니다."),
 
     // StudyHistory
+    STUDY_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 수강 기록입니다."),
     STUDY_HISTORY_DUPLICATE(HttpStatus.CONFLICT, "이미 해당 스터디를 신청했습니다."),
     STUDY_HISTORY_ONGOING_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 진행중인 스터디가 있습니다."),
+    STUDY_HISTORY_NOT_CANCELABLE(HttpStatus.CONFLICT, "스터디 신청기간이 아니라면 취소할 수 없습니다."),
 
     // Order
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문이 존재하지 않습니다."),

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidatorTest.java
@@ -78,4 +78,24 @@ public class StudyHistoryValidatorTest {
                     .hasMessage(STUDY_HISTORY_ONGOING_ALREADY_EXISTS.getMessage());
         }
     }
+
+    @Nested
+    class 스터디_수강신청_취소시 {
+
+        @Test
+        void 해당_스터디의_신청기간이_아니라면_실패한다() {
+            // given
+            Member mentor = fixtureHelper.createAssociateMember(1L);
+
+            LocalDateTime now = LocalDateTime.now();
+            Period period = Period.createPeriod(now.plusDays(10), now.plusDays(15));
+            Period applicationPeriod = Period.createPeriod(now.minusDays(10), now.minusDays(5));
+            Study study = fixtureHelper.createStudy(mentor, period, applicationPeriod);
+
+            // when & then
+            assertThatThrownBy(() -> studyHistoryValidator.validateCancelStudyApply(study))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(STUDY_HISTORY_NOT_CANCELABLE.getMessage());
+        }
+    }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidatorTest.java
@@ -93,7 +93,7 @@ public class StudyHistoryValidatorTest {
             // when & then
             assertThatThrownBy(() -> studyHistoryValidator.validateCancelStudyApply(study))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(STUDY_APPLY_NOT_CANCELABLE.getMessage());
+                    .hasMessage(STUDY_NOT_CANCELABLE_APPLICATION_PERIOD.getMessage());
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidatorTest.java
@@ -1,7 +1,5 @@
 package com.gdschongik.gdsc.domain.study.domain;
 
-import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -95,7 +93,7 @@ public class StudyHistoryValidatorTest {
             // when & then
             assertThatThrownBy(() -> studyHistoryValidator.validateCancelStudyApply(study))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(STUDY_HISTORY_NOT_CANCELABLE.getMessage());
+                    .hasMessage(STUDY_APPLY_NOT_CANCELABLE.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #535

## 📌 작업 내용 및 특이사항
- 스터디 수강신청 취소 api를 구현했습니다.
- 스터디 수강신청 기간이 끝나지 않았어야만 취소할 수 있습니다.

## 📝 참고사항
-

## 📚 기타
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **신규 기능**
	- 스터디 신청 취소 기능 추가: 사용자가 스터디 신청을 취소할 수 있는 새로운 API 엔드포인트 제공.
	
- **버그 수정**
	- 스터디 신청 기간 외에 신청을 취소하려 할 때 발생하는 예외 처리 개선.

- **문서화**
	- API 문서에 스터디 신청 취소와 관련된 새 오류 코드 추가: "스터디 신청기간이 아니라면 취소할 수 없습니다." 및 "존재하지 않는 스터디 수강 기록입니다."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->