### PR TITLE
feat: 과제 휴강 처리 API 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyMentorController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyMentorController.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.domain.study.api;
 
+import com.gdschongik.gdsc.domain.study.application.StudyMentorService;
 import com.gdschongik.gdsc.domain.study.domain.request.AssignmentCreateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,10 +15,19 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class StudyMentorController {
 
+    private final StudyMentorService studyMentorService;
+
     @Operation(summary = "스터디 과제 개설", description = "멘토만 과제를 개설할 수 있습니다.")
     @PutMapping("/assignment/{assignmentId}")
     public ResponseEntity<Void> createStudyAssignment(
             @PathVariable Long assignmentId, @Valid @RequestBody AssignmentCreateRequest request) {
         return null;
+    }
+
+    @Operation(summary = "스터디 과제 휴강 처리", description = "해당 주차 과제를 휴강 처리합니다.")
+    @PatchMapping("/assignment/{studyDetailId}/cancel")
+    public ResponseEntity<Void> cancelStudyAssignment(@PathVariable Long studyDetailId) {
+        studyMentorService.cancelStudyAssignment(studyDetailId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyMentorController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyMentorController.java
@@ -18,14 +18,14 @@ public class StudyMentorController {
     private final StudyMentorService studyMentorService;
 
     @Operation(summary = "스터디 과제 개설", description = "멘토만 과제를 개설할 수 있습니다.")
-    @PutMapping("/assignment/{assignmentId}")
+    @PutMapping("/assignments/{assignmentId}")
     public ResponseEntity<Void> createStudyAssignment(
             @PathVariable Long assignmentId, @Valid @RequestBody AssignmentCreateRequest request) {
         return null;
     }
 
     @Operation(summary = "스터디 과제 휴강 처리", description = "해당 주차 과제를 휴강 처리합니다.")
-    @PatchMapping("/assignment/{studyDetailId}/cancel")
+    @PatchMapping("/assignments/{studyDetailId}/cancel")
     public ResponseEntity<Void> cancelStudyAssignment(@PathVariable Long studyDetailId) {
         studyMentorService.cancelStudyAssignment(studyDetailId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyMentorService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyMentorService.java
@@ -1,0 +1,31 @@
+package com.gdschongik.gdsc.domain.study.application;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.domain.study.dao.StudyDetailRepository;
+import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudyMentorService {
+
+    private final StudyDetailRepository studyDetailRepository;
+
+    @Transactional
+    public void cancelStudyAssignment(Long studyDetailId) {
+        StudyDetail studyDetail = studyDetailRepository
+                .findById(studyDetailId)
+                .orElseThrow(() -> new CustomException(ASSIGNMENT_NOT_FOUND));
+
+        studyDetail.cancelAssignment();
+
+        log.info("[StudyMentorService] 과제 휴강 처리: studyDetailId={}", studyDetail.getId());
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyMentorService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyMentorService.java
@@ -22,7 +22,7 @@ public class StudyMentorService {
     public void cancelStudyAssignment(Long studyDetailId) {
         StudyDetail studyDetail = studyDetailRepository
                 .findById(studyDetailId)
-                .orElseThrow(() -> new CustomException(ASSIGNMENT_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(STUDY_DETAIL_NOT_FOUND));
 
         studyDetail.cancelAssignment();
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyMentorService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyMentorService.java
@@ -2,9 +2,12 @@ package com.gdschongik.gdsc.domain.study.application;
 
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
+import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.dao.StudyDetailRepository;
 import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
+import com.gdschongik.gdsc.domain.study.domain.StudyDetailValidator;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,6 +33,7 @@ public class StudyMentorService {
         studyDetailValidator.validateCancelStudyAssignment(currentMember, studyDetail);
 
         studyDetail.cancelAssignment();
+        studyDetailRepository.save(studyDetail);
 
         log.info("[StudyMentorService] 과제 휴강 처리: studyDetailId={}", studyDetail.getId());
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyMentorService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyMentorService.java
@@ -18,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class StudyMentorService {
 
     private final MemberUtil memberUtil;

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyMentorService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyMentorService.java
@@ -16,13 +16,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class StudyMentorService {
 
+    private final MemberUtil memberUtil;
     private final StudyDetailRepository studyDetailRepository;
+    private final StudyDetailValidator studyDetailValidator;
 
     @Transactional
     public void cancelStudyAssignment(Long studyDetailId) {
+        Member currentMember = memberUtil.getCurrentMember();
         StudyDetail studyDetail = studyDetailRepository
                 .findById(studyDetailId)
                 .orElseThrow(() -> new CustomException(STUDY_DETAIL_NOT_FOUND));
+
+        studyDetailValidator.validateCancelStudyAssignment(currentMember, studyDetail);
 
         studyDetail.cancelAssignment();
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
@@ -69,4 +69,8 @@ public class StudyDetail extends BaseEntity {
                 .assignment(Assignment.createEmptyAssignment())
                 .build();
     }
+
+    public void cancelAssignment() {
+        assignment = Assignment.cancelAssignment();
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailValidator.java
@@ -1,0 +1,17 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.global.annotation.DomainService;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.exception.ErrorCode;
+
+@DomainService
+public class StudyDetailValidator {
+
+    public void validateCancelStudyAssignment(Member currentMember, StudyDetail studyDetail) {
+        // 멘토가 아니라면 과제를 휴강처리 할 수 없다.
+        if (!currentMember.equals(studyDetail.getStudy().getMentor())) {
+            throw new CustomException(ErrorCode.STUDY_DETAIL_NOT_MODIFIABLE_INVALID_ROLE);
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailValidator.java
@@ -9,8 +9,12 @@ import com.gdschongik.gdsc.global.exception.ErrorCode;
 public class StudyDetailValidator {
 
     public void validateCancelStudyAssignment(Member currentMember, StudyDetail studyDetail) {
-        // 멘토가 아니라면 과제를 휴강처리 할 수 없다.
-        if (!currentMember.equals(studyDetail.getStudy().getMentor())) {
+        validateMemberIsMentor(currentMember, studyDetail);
+    }
+
+    // 멘토가 아니라면 과제를 휴강처리 할 수 없다.
+    private void validateMemberIsMentor(Member member, StudyDetail studyDetail) {
+        if (!member.equals(studyDetail.getStudy().getMentor())) {
             throw new CustomException(ErrorCode.STUDY_DETAIL_NOT_MODIFIABLE_INVALID_ROLE);
         }
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
@@ -1,5 +1,7 @@
 package com.gdschongik.gdsc.domain.study.domain.vo;
 
+import static com.gdschongik.gdsc.domain.study.domain.StudyStatus.*;
+
 import com.gdschongik.gdsc.domain.study.domain.Difficulty;
 import com.gdschongik.gdsc.domain.study.domain.StudyStatus;
 import jakarta.persistence.Column;
@@ -46,6 +48,10 @@ public class Assignment {
     }
 
     public static Assignment createEmptyAssignment() {
-        return Assignment.builder().status(StudyStatus.NONE).build();
+        return Assignment.builder().status(NONE).build();
+    }
+
+    public static Assignment cancelAssignment() {
+        return Assignment.builder().status(CANCELLED).build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -135,6 +135,9 @@ public enum ErrorCode {
 
     // Order - MoneyInfo
     ORDER_FINAL_PAYMENT_AMOUNT_MISMATCH(HttpStatus.CONFLICT, "주문 최종결제금액은 주문총액에서 할인금액을 뺀 값이어야 합니다."),
+
+    // Assignment
+    ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "과제가 존재하지 않습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -111,6 +111,7 @@ public enum ErrorCode {
 
     // StudyDetail
     STUDY_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 상세정보입니다."),
+    STUDY_DETAIL_NOT_MODIFIABLE_INVALID_ROLE(HttpStatus.FORBIDDEN, "수정할 수 있는 권한이 없습니다."),
 
     // StudyHistory
     STUDY_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 수강 기록입니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -109,6 +109,9 @@ public enum ErrorCode {
     STUDY_NOT_APPLICABLE(HttpStatus.CONFLICT, "스터디 신청기간이 아닙니다."),
     STUDY_NOT_CANCELABLE_APPLICATION_PERIOD(HttpStatus.CONFLICT, "스터디 신청기간이 아니라면 취소할 수 없습니다."),
 
+    // StudyDetail
+    STUDY_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 상세정보입니다."),
+
     // StudyHistory
     STUDY_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 수강 기록입니다."),
     STUDY_HISTORY_DUPLICATE(HttpStatus.CONFLICT, "이미 해당 스터디를 신청했습니다."),
@@ -135,9 +138,6 @@ public enum ErrorCode {
 
     // Order - MoneyInfo
     ORDER_FINAL_PAYMENT_AMOUNT_MISMATCH(HttpStatus.CONFLICT, "주문 최종결제금액은 주문총액에서 할인금액을 뺀 값이어야 합니다."),
-
-    // Assignment
-    ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "과제가 존재하지 않습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/StudyMentorServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/StudyMentorServiceTest.java
@@ -2,8 +2,11 @@ package com.gdschongik.gdsc.domain.study.application;
 
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.domain.study.dao.StudyDetailRepository;
+import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import com.gdschongik.gdsc.domain.study.domain.StudyStatus;
 import com.gdschongik.gdsc.helper.IntegrationTest;
@@ -27,7 +30,12 @@ public class StudyMentorServiceTest extends IntegrationTest {
         void 성공한다() {
             // given
             LocalDateTime now = LocalDateTime.now();
-            StudyDetail studyDetail = createStudyDetail(now, now.plusDays(7));
+            Member mentor = createAssociateMember();
+            Study study = createStudy(
+                    mentor,
+                    Period.createPeriod(now.plusDays(5), now.plusDays(10)),
+                    Period.createPeriod(now.minusDays(5), now));
+            StudyDetail studyDetail = createStudyDetail(study, now, now.plusDays(7));
             logoutAndReloginAs(studyDetail.getStudy().getMentor().getId(), MemberRole.ASSOCIATE);
 
             // when

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/StudyMentorServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/StudyMentorServiceTest.java
@@ -1,0 +1,40 @@
+package com.gdschongik.gdsc.domain.study.application;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.study.dao.StudyDetailRepository;
+import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
+import com.gdschongik.gdsc.domain.study.domain.StudyStatus;
+import com.gdschongik.gdsc.helper.IntegrationTest;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class StudyMentorServiceTest extends IntegrationTest {
+
+    @Autowired
+    private StudyMentorService studyMentorService;
+
+    @Autowired
+    private StudyDetailRepository studyDetailRepository;
+
+    @Nested
+    class 스터디_과제_휴강_처리시 {
+
+        @Test
+        void 성공한다() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            StudyDetail studyDetail = createStudyDetail(now, now.plusDays(7));
+
+            // when
+            studyMentorService.cancelStudyAssignment(studyDetail.getId());
+
+            // then
+            StudyDetail cancelledStudyDetail =
+                    studyDetailRepository.findById(studyDetail.getId()).get();
+            assertThat(cancelledStudyDetail.getAssignment().getStatus()).isEqualTo(StudyStatus.CANCELLED);
+        }
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/StudyMentorServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/StudyMentorServiceTest.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.domain.study.application;
 
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import com.gdschongik.gdsc.domain.study.dao.StudyDetailRepository;
 import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import com.gdschongik.gdsc.domain.study.domain.StudyStatus;
@@ -27,6 +28,7 @@ public class StudyMentorServiceTest extends IntegrationTest {
             // given
             LocalDateTime now = LocalDateTime.now();
             StudyDetail studyDetail = createStudyDetail(now, now.plusDays(7));
+            logoutAndReloginAs(studyDetail.getStudy().getMentor().getId(), MemberRole.ASSOCIATE);
 
             // when
             studyMentorService.cancelStudyAssignment(studyDetail.getId());

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailTest.java
@@ -1,0 +1,38 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.helper.FixtureHelper;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class StudyDetailTest {
+
+    @Nested
+    class 과제_휴강_처리시 {
+
+        FixtureHelper fixtureHelper = new FixtureHelper();
+
+        @Test
+        void 과제_상태가_휴강이_된다() {
+            // given
+            Member mentor = fixtureHelper.createAssociateMember(1L);
+            LocalDateTime now = LocalDateTime.now();
+            StudyDetail studyDetail = fixtureHelper.createStudyDetail(
+                    mentor,
+                    Period.createPeriod(now.plusDays(5), now.plusDays(10)),
+                    Period.createPeriod(now.minusDays(5), now),
+                    now,
+                    now.plusDays(7));
+
+            // when
+            studyDetail.cancelAssignment();
+
+            // then
+            assertThat(studyDetail.getAssignment().getStatus()).isEqualTo(StudyStatus.CANCELLED);
+        }
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailTest.java
@@ -21,12 +21,11 @@ public class StudyDetailTest {
             // given
             Member mentor = fixtureHelper.createAssociateMember(1L);
             LocalDateTime now = LocalDateTime.now();
-            StudyDetail studyDetail = fixtureHelper.createStudyDetail(
+            Study study = fixtureHelper.createStudy(
                     mentor,
                     Period.createPeriod(now.plusDays(5), now.plusDays(10)),
-                    Period.createPeriod(now.minusDays(5), now),
-                    now,
-                    now.plusDays(7));
+                    Period.createPeriod(now.minusDays(5), now));
+            StudyDetail studyDetail = fixtureHelper.createStudyDetail(study, now, now.plusDays(7));
 
             // when
             studyDetail.cancelAssignment();

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailValidatorTest.java
@@ -1,0 +1,40 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.helper.FixtureHelper;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class StudyDetailValidatorTest {
+
+    FixtureHelper fixtureHelper = new FixtureHelper();
+    StudyDetailValidator studyDetailValidator = new StudyDetailValidator();
+
+    @Nested
+    class 과제_휴강_처리시 {
+
+        @Test
+        void 멘토가_아니라면_실패한다() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            Member mentor = fixtureHelper.createAssociateMember(1L);
+            Study study = fixtureHelper.createStudy(
+                    mentor,
+                    Period.createPeriod(now.plusDays(5), now.plusDays(10)),
+                    Period.createPeriod(now.minusDays(5), now));
+            StudyDetail studyDetail = fixtureHelper.createStudyDetail(study, now, now.plusDays(7));
+            Member anotherMember = fixtureHelper.createAssociateMember(2L);
+
+            // when & then
+            assertThatThrownBy(() -> studyDetailValidator.validateCancelStudyAssignment(anotherMember, studyDetail))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(STUDY_DETAIL_NOT_MODIFIABLE_INVALID_ROLE.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/StudyConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/StudyConstant.java
@@ -13,4 +13,7 @@ public class StudyConstant {
     public static final DayOfWeek DAY_OF_WEEK = DayOfWeek.FRIDAY;
     public static final LocalTime STUDY_START_TIME = LocalTime.of(19, 0, 0);
     public static final LocalTime STUDY_END_TIME = LocalTime.of(20, 0, 0);
+
+    // StudyDetail
+    public static final String ATTENDANCE_NUMBER = "1234";
 }

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -18,6 +18,7 @@ import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import java.time.LocalDateTime;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -78,5 +79,12 @@ public class FixtureHelper {
                 DAY_OF_WEEK,
                 STUDY_START_TIME,
                 STUDY_END_TIME);
+    }
+
+    public StudyDetail createStudyDetail(
+            Member mentor, Period period, Period applicationPeriod, LocalDateTime startDate, LocalDateTime endDate) {
+        Study study = createStudy(mentor, period, applicationPeriod);
+
+        return StudyDetail.createStudyDetail(study, 1L, ATTENDANCE_NUMBER, Period.createPeriod(startDate, endDate));
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -81,10 +81,7 @@ public class FixtureHelper {
                 STUDY_END_TIME);
     }
 
-    public StudyDetail createStudyDetail(
-            Member mentor, Period period, Period applicationPeriod, LocalDateTime startDate, LocalDateTime endDate) {
-        Study study = createStudy(mentor, period, applicationPeriod);
-
+    public StudyDetail createStudyDetail(Study study, LocalDateTime startDate, LocalDateTime endDate) {
         return StudyDetail.createStudyDetail(study, 1L, ATTENDANCE_NUMBER, Period.createPeriod(startDate, endDate));
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -4,6 +4,7 @@ import static com.gdschongik.gdsc.domain.member.domain.Department.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.SemesterConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
 import static org.mockito.Mockito.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
@@ -25,6 +26,10 @@ import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.domain.study.dao.StudyDetailRepository;
+import com.gdschongik.gdsc.domain.study.dao.StudyRepository;
+import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import com.gdschongik.gdsc.global.security.PrincipalDetails;
 import com.gdschongik.gdsc.infra.feign.payment.client.PaymentClient;
 import java.time.LocalDateTime;
@@ -61,6 +66,12 @@ public abstract class IntegrationTest {
 
     @Autowired
     protected RecruitmentRoundRepository recruitmentRoundRepository;
+
+    @Autowired
+    protected StudyRepository studyRepository;
+
+    @Autowired
+    protected StudyDetailRepository studyDetailRepository;
 
     @MockBean
     protected OnboardingRecruitmentService onboardingRecruitmentService;
@@ -159,5 +170,34 @@ public abstract class IntegrationTest {
         couponRepository.save(coupon);
         IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
         return issuedCouponRepository.save(issuedCoupon);
+    }
+
+    protected Study createStudy(Member mentor, Period period, Period applicationPeriod) {
+        Study study = Study.createStudy(
+                ACADEMIC_YEAR,
+                SEMESTER_TYPE,
+                mentor,
+                period,
+                applicationPeriod,
+                TOTAL_WEEK,
+                ONLINE_STUDY,
+                DAY_OF_WEEK,
+                STUDY_START_TIME,
+                STUDY_END_TIME);
+
+        return studyRepository.save(study);
+    }
+
+    protected StudyDetail createStudyDetail(LocalDateTime startDate, LocalDateTime endDate) {
+        Member mentor = createAssociateMember();
+        LocalDateTime now = LocalDateTime.now();
+        Study study = createStudy(
+                mentor,
+                Period.createPeriod(now.plusDays(5), now.plusDays(10)),
+                Period.createPeriod(now.minusDays(5), now));
+
+        StudyDetail studyDetail =
+                StudyDetail.createStudyDetail(study, 1L, ATTENDANCE_NUMBER, Period.createPeriod(startDate, endDate));
+        return studyDetailRepository.save(studyDetail);
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -188,14 +188,7 @@ public abstract class IntegrationTest {
         return studyRepository.save(study);
     }
 
-    protected StudyDetail createStudyDetail(LocalDateTime startDate, LocalDateTime endDate) {
-        Member mentor = createAssociateMember();
-        LocalDateTime now = LocalDateTime.now();
-        Study study = createStudy(
-                mentor,
-                Period.createPeriod(now.plusDays(5), now.plusDays(10)),
-                Period.createPeriod(now.minusDays(5), now));
-
+    protected StudyDetail createStudyDetail(Study study, LocalDateTime startDate, LocalDateTime endDate) {
         StudyDetail studyDetail =
                 StudyDetail.createStudyDetail(study, 1L, ATTENDANCE_NUMBER, Period.createPeriod(startDate, endDate));
         return studyDetailRepository.save(studyDetail);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #537

## 📌 작업 내용 및 특이사항
- 과제 휴강 처리 api를 구현했습니다.
- FixtureHelper와 IntegrationTest에 Study관련 메서드들을 생성했습니다.

## 📝 참고사항
- 

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - 새로운 스터디 할당 취소 기능 추가: 사용자가 특정 스터디의 할당을 취소할 수 있습니다.
  - 사용자 친화적인 오류 처리 개선: 할당을 찾을 수 없는 경우에 대한 구체적인 오류 코드 제공.

- **Bug Fixes**
  - 할당 상태 업데이트 로직 개선: 할당 취소 시 상태가 올바르게 변경되도록 수정.

- **Tests**
  - 새로운 단위 테스트 추가: 스터디 세부 정보의 할당 취소 유효성 검증.
  - 스터디 멘토 서비스의 할당 취소 기능을 검증하는 통합 테스트 도입.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->