### PR TITLE
feat: 과제 조회 API 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyMentorController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyMentorController.java
@@ -1,9 +1,12 @@
 package com.gdschongik.gdsc.domain.study.api;
 
+import com.gdschongik.gdsc.domain.study.application.StudyMentorService;
 import com.gdschongik.gdsc.domain.study.domain.request.AssignmentCreateRequest;
+import com.gdschongik.gdsc.domain.study.dto.response.AssignmentResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,10 +17,26 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class StudyMentorController {
 
+    private final StudyMentorService studyMentorService;
+
     @Operation(summary = "스터디 과제 개설", description = "멘토만 과제를 개설할 수 있습니다.")
     @PutMapping("/assignment/{assignmentId}")
     public ResponseEntity<Void> createStudyAssignment(
             @PathVariable Long assignmentId, @Valid @RequestBody AssignmentCreateRequest request) {
         return null;
+    }
+
+    @Operation(summary = "스터디 주차별 과제 목록 조회", description = "주차별 스터디 과제 목록을 조회합니다.")
+    @GetMapping("/assignments/{studyId}")
+    public ResponseEntity<List<AssignmentResponse>> getWeeklyAssignments(@PathVariable Long studyId) {
+        List<AssignmentResponse> response = studyMentorService.getWeeklyAssignments(studyId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "스터디 과제 상세 조회", description = "멘토가 자신의 스터디 과제를 조회합니다.")
+    @GetMapping("/assignments/{studyDetailId}")
+    public ResponseEntity<AssignmentResponse> getStudyAssignment(@PathVariable Long studyDetailId) {
+        AssignmentResponse response = studyMentorService.getAssignment(studyDetailId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyMentorService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyMentorService.java
@@ -15,16 +15,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class StudyMentorService {
 
     private final StudyDetailRepository studyDetailRepository;
 
+    @Transactional(readOnly = true)
     public List<AssignmentResponse> getWeeklyAssignments(Long studyId) {
         List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyId(studyId);
         return studyDetails.stream().map(AssignmentResponse::from).toList();
     }
 
+    @Transactional(readOnly = true)
     public AssignmentResponse getAssignment(Long studyDetailId) {
         StudyDetail studyDetail = studyDetailRepository
                 .findById(studyDetailId)

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyMentorService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyMentorService.java
@@ -1,0 +1,34 @@
+package com.gdschongik.gdsc.domain.study.application;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.domain.study.dao.StudyDetailRepository;
+import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
+import com.gdschongik.gdsc.domain.study.dto.response.AssignmentResponse;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudyMentorService {
+
+    private final StudyDetailRepository studyDetailRepository;
+
+    public List<AssignmentResponse> getWeeklyAssignments(Long studyId) {
+        List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyId(studyId);
+        return studyDetails.stream().map(AssignmentResponse::from).toList();
+    }
+
+    public AssignmentResponse getAssignment(Long studyDetailId) {
+        StudyDetail studyDetail = studyDetailRepository
+                .findById(studyDetailId)
+                .orElseThrow(() -> new CustomException(STUDY_DETAIL_NOT_FOUND));
+        return AssignmentResponse.from(studyDetail);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyDetailRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyDetailRepository.java
@@ -1,6 +1,10 @@
 package com.gdschongik.gdsc.domain.study.dao;
 
 import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StudyDetailRepository extends JpaRepository<StudyDetail, Long> {}
+public interface StudyDetailRepository extends JpaRepository<StudyDetail, Long> {
+
+    List<StudyDetail> findAllByStudyId(Long studyId);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentResponse.java
@@ -1,0 +1,23 @@
+package com.gdschongik.gdsc.domain.study.dto.response;
+
+import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
+import com.gdschongik.gdsc.domain.study.domain.StudyStatus;
+import com.gdschongik.gdsc.domain.study.domain.vo.Assignment;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AssignmentResponse(
+        Long studyDetailId,
+        @Schema(description = "과제 제목") String title,
+        @Schema(description = "마감 기한") String deadline,
+        @Schema(description = "과제 명세 링크") String descriptionLink,
+        @Schema(description = "과제 상태") StudyStatus assignmentStatus) {
+    public static AssignmentResponse from(StudyDetail studyDetail) {
+        Assignment assignment = studyDetail.getAssignment();
+        return new AssignmentResponse(
+                studyDetail.getId(),
+                assignment.getTitle(),
+                assignment.getDeadline().toString(),
+                assignment.getDescriptionLink(),
+                assignment.getStatus());
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -109,6 +109,9 @@ public enum ErrorCode {
     STUDY_NOT_APPLICABLE(HttpStatus.CONFLICT, "스터디 신청기간이 아닙니다."),
     STUDY_NOT_CANCELABLE_APPLICATION_PERIOD(HttpStatus.CONFLICT, "스터디 신청기간이 아니라면 취소할 수 없습니다."),
 
+    // StudyDetail
+    STUDY_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 상세 정보입니다."),
+
     // StudyHistory
     STUDY_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 수강 기록입니다."),
     STUDY_HISTORY_DUPLICATE(HttpStatus.CONFLICT, "이미 해당 스터디를 신청했습니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #538

## 📌 작업 내용 및 특이사항
- `과제 목록 조회`와 `과제 상세 조회` api를 구현했습니다.
- 두 api에서 필요로 하는 응답 내용이 같아서 하나의 Dto로 처리했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 스터디 과제를 조회할 수 있는 새로운 API 엔드포인트 추가.
  - 주간 과제 목록과 특정 과제의 세부 정보를 제공하는 기능 추가.

- **버그 수정**
  - 세부 정보를 찾을 수 없는 경우의 에러 처리를 개선하는 새로운 에러 코드 추가.

- **문서화**
  - API 문서화 개선을 위한 응답 객체 `AssignmentResponse` 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->