### PR TITLE
feat: 결제 취소 후 정회원 권한을 회수하는 정책 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/MemberDiscordRoleRevokeHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/MemberDiscordRoleRevokeHandler.java
@@ -1,0 +1,35 @@
+package com.gdschongik.gdsc.domain.discord.application.handler;
+
+import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.*;
+
+import com.gdschongik.gdsc.domain.member.domain.MemberDemotedToAssociateEvent;
+import com.gdschongik.gdsc.global.util.DiscordUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberDiscordRoleRevokeHandler implements SpringEventHandler {
+
+    private final DiscordUtil discordUtil;
+
+    @Override
+    public void delegate(Object context) {
+        MemberDemotedToAssociateEvent event = (MemberDemotedToAssociateEvent) context;
+        Guild guild = discordUtil.getCurrentGuild();
+        Member member = discordUtil.getMemberById(event.discordId());
+        Role role = discordUtil.findRoleByName(MEMBER_ROLE_NAME);
+
+        guild.removeRoleFromMember(member, role).queue();
+
+        log.info(
+                "[MemberDiscordRoleRevokeHandler] 디스코드 서버 정회원 역할 제거 완료: memberId={}, discordId={}",
+                event.memberId(),
+                event.discordId());
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/MemberDemotedToAssociateEventListener.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/MemberDemotedToAssociateEventListener.java
@@ -1,0 +1,26 @@
+package com.gdschongik.gdsc.domain.discord.application.listener;
+
+import com.gdschongik.gdsc.domain.discord.application.handler.MemberDiscordRoleRevokeHandler;
+import com.gdschongik.gdsc.domain.member.domain.MemberDemotedToAssociateEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberDemotedToAssociateEventListener {
+
+    private final MemberDiscordRoleRevokeHandler memberDiscordRoleRevokeHandler;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void demoteMemberToAssociate(MemberDemotedToAssociateEvent event) {
+        log.info(
+                "[MemberDemotedToAssociateEventListener] 회원 준회원 강등 이벤트 수신: memberId={}, discordId={}",
+                event.memberId(),
+                event.discordId());
+        memberDiscordRoleRevokeHandler.delegate(event);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/CommonMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/CommonMemberService.java
@@ -66,7 +66,7 @@ public class CommonMemberService {
     /**
      * 이벤트 핸들러에서 사용되므로, `@Transactional` 을 사용하지 않습니다.
      */
-    public void demoteMemberToAssocidateByMembership(Long membershipId) {
+    public void demoteMemberToAssociateByMembership(Long membershipId) {
         Membership membership = membershipRepository
                 .findById(membershipId)
                 .orElseThrow(() -> new CustomException(MEMBERSHIP_NOT_FOUND));

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/CommonMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/CommonMemberService.java
@@ -62,4 +62,23 @@ public class CommonMemberService {
             log.info("[CommonMemberService] 정회원 승급 완료: memberId={}", member.getId());
         }
     }
+
+    /**
+     * 이벤트 핸들러에서 사용되므로, `@Transactional` 을 사용하지 않습니다.
+     */
+    public void demoteMemberToAssocidateByMembership(Long membershipId) {
+        Membership membership = membershipRepository
+                .findById(membershipId)
+                .orElseThrow(() -> new CustomException(MEMBERSHIP_NOT_FOUND));
+
+        Member member = memberRepository
+                .findById(membership.getMember().getId())
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+        member.demoteToAssociate();
+
+        memberRepository.save(member);
+
+        log.info("[CommonMemberService] 준회원 강등 완료: memberId={}", member.getId());
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -259,6 +259,8 @@ public class Member extends BaseEntity {
         validateStatusUpdatable();
 
         role = ASSOCIATE;
+
+        registerEvent(new MemberDemotedToAssociateEvent(id, discordId));
     }
 
     /**

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberDemotedToAssociateEvent.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberDemotedToAssociateEvent.java
@@ -1,0 +1,3 @@
+package com.gdschongik.gdsc.domain.member.domain;
+
+public record MemberDemotedToAssociateEvent(Long memberId, String discordId) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipEventHandler.java
@@ -24,6 +24,6 @@ public class MembershipEventHandler {
     @EventListener
     public void handleMembershipPaymentRevokedEvent(MembershipPaymentRevokedEvent event) {
         log.info("[MembershipEventHandler] 멤버십 회비납입 취소 이벤트 수신: membershipId={}", event.membershipId());
-        commonMemberService.demoteMemberToAssocidateByMembership(event.membershipId());
+        commonMemberService.demoteMemberToAssociateByMembership(event.membershipId());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipEventHandler.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.membership.application;
 
 import com.gdschongik.gdsc.domain.member.application.CommonMemberService;
+import com.gdschongik.gdsc.domain.membership.domain.MembershipPaymentRevokedEvent;
 import com.gdschongik.gdsc.domain.membership.domain.MembershipVerifiedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,5 +19,11 @@ public class MembershipEventHandler {
     public void handleMembershipVerifiedEvent(MembershipVerifiedEvent event) {
         log.info("[MembershipVerifiedEventHandler] 멤버십 인증 이벤트 수신: membershipId={}", event.membershipId());
         commonMemberService.advanceMemberToRegularByMembership(event.membershipId());
+    }
+
+    @EventListener
+    public void handleMembershipPaymentRevokedEvent(MembershipPaymentRevokedEvent event) {
+        log.info("[MembershipVerifiedEventHandler] 멤버십 회비납입 취소 이벤트 수신: membershipId={}", event.membershipId());
+        commonMemberService.demoteMemberToAssocidateByMembership(event.membershipId());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipEventHandler.java
@@ -17,13 +17,13 @@ public class MembershipEventHandler {
 
     @EventListener
     public void handleMembershipVerifiedEvent(MembershipVerifiedEvent event) {
-        log.info("[MembershipVerifiedEventHandler] 멤버십 인증 이벤트 수신: membershipId={}", event.membershipId());
+        log.info("[MembershipEventHandler] 멤버십 인증 이벤트 수신: membershipId={}", event.membershipId());
         commonMemberService.advanceMemberToRegularByMembership(event.membershipId());
     }
 
     @EventListener
     public void handleMembershipPaymentRevokedEvent(MembershipPaymentRevokedEvent event) {
-        log.info("[MembershipVerifiedEventHandler] 멤버십 회비납입 취소 이벤트 수신: membershipId={}", event.membershipId());
+        log.info("[MembershipEventHandler] 멤버십 회비납입 취소 이벤트 수신: membershipId={}", event.membershipId());
         commonMemberService.demoteMemberToAssocidateByMembership(event.membershipId());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipEventHandler.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class MembershipVerifiedEventHandler {
+public class MembershipEventHandler {
 
     private final CommonMemberService commonMemberService;
 

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -111,5 +111,7 @@ public class MembershipService {
         membership.revokePaymentStatus();
 
         membershipRepository.save(membership);
+
+        log.info("[MembershipService] 멤버십 회비납입 취소 완료: membershipId={}", membership.getId());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -97,4 +97,19 @@ public class MembershipService {
 
         myMembershipOpt.ifPresent(membershipRepository::delete);
     }
+
+    /**
+     * 이벤트 핸들러에서 사용되므로, `@Transactional` 을 사용하지 않습니다.
+     */
+    public void revokePaymentStatus(Long orderId) {
+        Order order = orderRepository.findById(orderId).orElseThrow(() -> new CustomException(ORDER_NOT_FOUND));
+
+        Membership membership = membershipRepository
+                .findById(order.getMembershipId())
+                .orElseThrow(() -> new CustomException(MEMBERSHIP_NOT_FOUND));
+
+        membership.revokePaymentStatus();
+
+        membershipRepository.save(membership);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
@@ -84,6 +84,7 @@ public class Membership extends BaseEntity {
     }
 
     private void validatePaymentStatusRevocable() {
+        // TODO: 이벤트로 트리거되는 로직이더라도 예외 던지도록 수정
         if (!regularRequirement.isPaymentSatisfied()) {
             throw new CustomException(MEMBERSHIP_PAYMENT_NOT_REVOCABLE_NOT_SATISFIED);
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
@@ -75,6 +75,20 @@ public class Membership extends BaseEntity {
         registerEvent(new MembershipVerifiedEvent(id));
     }
 
+    public void revokePaymentStatus() {
+        validatePaymentStatusRevocable();
+
+        regularRequirement.updatePaymentStatus(PENDING);
+
+        registerEvent(new MembershipPaymentRevokedEvent(id));
+    }
+
+    private void validatePaymentStatusRevocable() {
+        if (!regularRequirement.isPaymentSatisfied()) {
+            throw new CustomException(MEMBERSHIP_PAYMENT_NOT_REVOCABLE_NOT_SATISFIED);
+        }
+    }
+
     // 데이터 전달 로직
 
     public boolean isRegularRequirementAllSatisfied() {

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/MembershipPaymentRevokedEvent.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/MembershipPaymentRevokedEvent.java
@@ -1,0 +1,3 @@
+package com.gdschongik.gdsc.domain.membership.domain;
+
+public record MembershipPaymentRevokedEvent(Long membershipId) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderEventHandler.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.order.application;
 
 import com.gdschongik.gdsc.domain.membership.application.MembershipService;
+import com.gdschongik.gdsc.domain.order.domain.OrderCanceledEvent;
 import com.gdschongik.gdsc.domain.order.domain.OrderCompletedEvent;
 import com.gdschongik.gdsc.domain.order.domain.OrderCreatedEvent;
 import lombok.RequiredArgsConstructor;
@@ -31,5 +32,11 @@ public class OrderEventHandler {
     public void handleOrderCompletedEvent(OrderCompletedEvent orderCompletedEvent) {
         log.info("[OrderEventHandler] 주문 완료 이벤트 수신: nanoId={}", orderCompletedEvent.nanoId());
         membershipService.verifyPaymentStatus(orderCompletedEvent.nanoId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleOrderCanceledEvent(OrderCanceledEvent orderCanceledEvent) {
+        log.info("[OrderEventHandler] 주문 취소 이벤트 수신: orderId={}", orderCanceledEvent.orderId());
+        membershipService.revokePaymentStatus(orderCanceledEvent.orderId());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
@@ -129,6 +129,8 @@ public class OrderService {
 
         order.cancel(canceledAt);
 
+        orderRepository.save(order);
+
         log.info("[OrderService] 주문 취소: orderId={}", order.getId());
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
@@ -141,10 +141,11 @@ public class Order extends BaseEntity {
      * 상태 변경 및 취소 시각을 저장하며, 예외를 발생시키지 않도록 외부 취소 요청 전에 validateCancelable을 호출합니다.
      */
     public void cancel(ZonedDateTime canceledAt) {
-        // TODO: 취소 이벤트 발행을 통해 멤버십 및 멤버 상태에 대한 변경 로직 추가
         validateCancelable();
         this.status = OrderStatus.CANCELED;
         this.canceledAt = canceledAt;
+
+        registerEvent(new OrderCanceledEvent(id));
     }
 
     public void validateCancelable() {

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderCanceledEvent.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/OrderCanceledEvent.java
@@ -1,0 +1,3 @@
+package com.gdschongik.gdsc.domain.order.domain;
+
+public record OrderCanceledEvent(Long orderId) {}

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -76,6 +76,7 @@ public enum ErrorCode {
     MEMBERSHIP_ALREADY_SATISFIED(HttpStatus.CONFLICT, "이미 이번 학기에 정회원 승급을 완료한 회원입니다."),
     MEMBERSHIP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 멤버십이 존재하지 않습니다."),
     MEMBERSHIP_RECRUITMENT_ROUND_NOT_OPEN(HttpStatus.CONFLICT, "리크루팅 회차 모집기간이 아닙니다."),
+    MEMBERSHIP_PAYMENT_NOT_REVOCABLE_NOT_SATISFIED(HttpStatus.CONFLICT, "회비납부를 완료한 경우에만 멤버십 회비납부상태를 취소할 수 있습니다."),
 
     // Recruitment
     DATE_PRECEDENCE_INVALID(HttpStatus.BAD_REQUEST, "종료일이 시작일과 같거나 앞설 수 없습니다."),

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.domain.order.application;
 
+import static com.gdschongik.gdsc.global.common.constant.OrderConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
@@ -72,7 +73,7 @@ class OrderServiceTest extends IntegrationTest {
 
             // when
             var request = new OrderCreateRequest(
-                    "HnbMWoSZRq3qK1W3tPXCW",
+                    ORDER_NANO_ID,
                     membership.getId(),
                     issuedCoupon.getId(),
                     BigDecimal.valueOf(20000),
@@ -105,16 +106,13 @@ class OrderServiceTest extends IntegrationTest {
             Membership membership = createMembership(member, recruitmentRound);
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
 
-            String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
             orderService.createPendingOrder(new OrderCreateRequest(
-                    orderNanoId,
+                    ORDER_NANO_ID,
                     membership.getId(),
                     issuedCoupon.getId(),
                     BigDecimal.valueOf(20000),
                     BigDecimal.valueOf(5000),
                     BigDecimal.valueOf(15000)));
-
-            String paymentKey = "testPaymentKey";
 
             ZonedDateTime approvedAt = ZonedDateTime.now();
             PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
@@ -122,13 +120,13 @@ class OrderServiceTest extends IntegrationTest {
             when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
 
             // when
-            var request = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);
+            var request = new OrderCompleteRequest(ORDER_PAYMENT_KEY, ORDER_NANO_ID, 15000L);
             orderService.completeOrder(request);
 
             // then
-            Order completedOrder = orderRepository.findByNanoId(orderNanoId).orElseThrow();
+            Order completedOrder = orderRepository.findByNanoId(ORDER_NANO_ID).orElseThrow();
             assertThat(completedOrder.getStatus()).isEqualTo(OrderStatus.COMPLETED);
-            assertThat(completedOrder.getPaymentKey()).isEqualTo(paymentKey);
+            assertThat(completedOrder.getPaymentKey()).isEqualTo(ORDER_PAYMENT_KEY);
 
             IssuedCoupon usedCoupon =
                     issuedCouponRepository.findById(issuedCoupon.getId()).orElseThrow();
@@ -154,16 +152,13 @@ class OrderServiceTest extends IntegrationTest {
             Membership membership = createMembership(member, recruitmentRound);
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
 
-            String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
             orderService.createPendingOrder(new OrderCreateRequest(
-                    orderNanoId,
+                    ORDER_NANO_ID,
                     membership.getId(),
                     issuedCoupon.getId(),
                     BigDecimal.valueOf(20000),
                     BigDecimal.valueOf(5000),
                     BigDecimal.valueOf(15000)));
-
-            String paymentKey = "testPaymentKey";
 
             ZonedDateTime approvedAt = ZonedDateTime.now();
             PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
@@ -171,7 +166,7 @@ class OrderServiceTest extends IntegrationTest {
             when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
 
             // when
-            var request = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);
+            var request = new OrderCompleteRequest(ORDER_PAYMENT_KEY, ORDER_NANO_ID, 15000L);
             orderService.completeOrder(request);
 
             // then
@@ -198,16 +193,13 @@ class OrderServiceTest extends IntegrationTest {
             Membership membership = createMembership(member, recruitmentRound);
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
 
-            String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
             orderService.createPendingOrder(new OrderCreateRequest(
-                    orderNanoId,
+                    ORDER_NANO_ID,
                     membership.getId(),
                     issuedCoupon.getId(),
                     BigDecimal.valueOf(20000),
                     BigDecimal.valueOf(5000),
                     BigDecimal.valueOf(15000)));
-
-            String paymentKey = "testPaymentKey";
 
             ZonedDateTime approvedAt = ZonedDateTime.now();
             PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
@@ -215,7 +207,7 @@ class OrderServiceTest extends IntegrationTest {
             when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
 
             // when
-            var request = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);
+            var request = new OrderCompleteRequest(ORDER_PAYMENT_KEY, ORDER_NANO_ID, 15000L);
             orderService.completeOrder(request);
 
             // then
@@ -244,26 +236,23 @@ class OrderServiceTest extends IntegrationTest {
             Membership membership = createMembership(member, recruitmentRound);
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
 
-            String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
             orderService.createPendingOrder(new OrderCreateRequest(
-                    orderNanoId,
+                    ORDER_NANO_ID,
                     membership.getId(),
                     issuedCoupon.getId(),
                     BigDecimal.valueOf(20000),
                     BigDecimal.valueOf(5000),
                     BigDecimal.valueOf(15000)));
 
-            String paymentKey = "testPaymentKey";
-
             ZonedDateTime approvedAt = ZonedDateTime.now();
             PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
             when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
             when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
 
-            var completeRequest = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);
+            var completeRequest = new OrderCompleteRequest(ORDER_PAYMENT_KEY, ORDER_NANO_ID, 15000L);
             orderService.completeOrder(completeRequest);
 
-            Order completedOrder = orderRepository.findByNanoId(orderNanoId).orElseThrow();
+            Order completedOrder = orderRepository.findByNanoId(ORDER_NANO_ID).orElseThrow();
 
             ZonedDateTime canceledAt = ZonedDateTime.now();
             PaymentResponse mockCancelResponse = mock(PaymentResponse.class);
@@ -271,11 +260,11 @@ class OrderServiceTest extends IntegrationTest {
 
             when(mockCancelResponse.cancels()).thenReturn(List.of(mockCancelDto));
             when(mockCancelDto.canceledAt()).thenReturn(canceledAt);
-            when(paymentClient.cancelPayment(eq(paymentKey), any(PaymentCancelRequest.class)))
+            when(paymentClient.cancelPayment(eq(ORDER_PAYMENT_KEY), any(PaymentCancelRequest.class)))
                     .thenReturn(mockCancelResponse);
 
             // when
-            var cancelRequest = new OrderCancelRequest("테스트 취소 사유");
+            var cancelRequest = new OrderCancelRequest(ORDER_CANCEL_REASON);
             orderService.cancelOrder(completedOrder.getId(), cancelRequest);
 
             // then
@@ -284,7 +273,7 @@ class OrderServiceTest extends IntegrationTest {
             assertThat(canceledOrder.getStatus()).isEqualTo(OrderStatus.CANCELED);
             assertThat(canceledOrder.getCanceledAt()).isNotNull();
 
-            verify(paymentClient).cancelPayment(eq(paymentKey), any(PaymentCancelRequest.class));
+            verify(paymentClient).cancelPayment(eq(ORDER_PAYMENT_KEY), any(PaymentCancelRequest.class));
         }
 
         @Test
@@ -303,19 +292,18 @@ class OrderServiceTest extends IntegrationTest {
 
             Membership membership = createMembership(member, recruitmentRound);
 
-            String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
             orderService.createPendingOrder(new OrderCreateRequest(
-                    orderNanoId,
+                    ORDER_NANO_ID,
                     membership.getId(),
                     null,
                     BigDecimal.valueOf(20000),
                     BigDecimal.valueOf(0),
                     BigDecimal.valueOf(20000)));
 
-            Order pendingOrder = orderRepository.findByNanoId(orderNanoId).orElseThrow();
+            Order pendingOrder = orderRepository.findByNanoId(ORDER_NANO_ID).orElseThrow();
             Long id = pendingOrder.getId();
 
-            OrderCancelRequest request = new OrderCancelRequest("테스트 취소 사유");
+            OrderCancelRequest request = new OrderCancelRequest(ORDER_CANCEL_REASON);
 
             // when & then
             assertThatThrownBy(() -> orderService.cancelOrder(id, request))
@@ -342,26 +330,23 @@ class OrderServiceTest extends IntegrationTest {
             Membership membership = createMembership(member, recruitmentRound);
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
 
-            String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
             orderService.createPendingOrder(new OrderCreateRequest(
-                    orderNanoId,
+                    ORDER_NANO_ID,
                     membership.getId(),
                     issuedCoupon.getId(),
                     BigDecimal.valueOf(20000),
                     BigDecimal.valueOf(5000),
                     BigDecimal.valueOf(15000)));
 
-            String paymentKey = "testPaymentKey";
-
             ZonedDateTime approvedAt = ZonedDateTime.now();
             PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
             when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
             when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
 
-            var completeRequest = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);
+            var completeRequest = new OrderCompleteRequest(ORDER_PAYMENT_KEY, ORDER_NANO_ID, 15000L);
             orderService.completeOrder(completeRequest);
 
-            Order completedOrder = orderRepository.findByNanoId(orderNanoId).orElseThrow();
+            Order completedOrder = orderRepository.findByNanoId(ORDER_NANO_ID).orElseThrow();
 
             ZonedDateTime canceledAt = ZonedDateTime.now();
             PaymentResponse mockCancelResponse = mock(PaymentResponse.class);
@@ -369,10 +354,10 @@ class OrderServiceTest extends IntegrationTest {
 
             when(mockCancelResponse.cancels()).thenReturn(List.of(mockCancelDto));
             when(mockCancelDto.canceledAt()).thenReturn(canceledAt);
-            when(paymentClient.cancelPayment(eq(paymentKey), any(PaymentCancelRequest.class)))
+            when(paymentClient.cancelPayment(eq(ORDER_PAYMENT_KEY), any(PaymentCancelRequest.class)))
                     .thenReturn(mockCancelResponse);
 
-            var cancelRequest = new OrderCancelRequest("테스트 취소 사유");
+            var cancelRequest = new OrderCancelRequest(ORDER_CANCEL_REASON);
 
             // when
             orderService.cancelOrder(completedOrder.getId(), cancelRequest);
@@ -401,26 +386,23 @@ class OrderServiceTest extends IntegrationTest {
             Membership membership = createMembership(member, recruitmentRound);
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
 
-            String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
             orderService.createPendingOrder(new OrderCreateRequest(
-                    orderNanoId,
+                    ORDER_NANO_ID,
                     membership.getId(),
                     issuedCoupon.getId(),
                     BigDecimal.valueOf(20000),
                     BigDecimal.valueOf(5000),
                     BigDecimal.valueOf(15000)));
 
-            String paymentKey = "testPaymentKey";
-
             ZonedDateTime approvedAt = ZonedDateTime.now();
             PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
             when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
             when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
 
-            var completeRequest = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);
+            var completeRequest = new OrderCompleteRequest(ORDER_PAYMENT_KEY, ORDER_NANO_ID, 15000L);
             orderService.completeOrder(completeRequest);
 
-            Order completedOrder = orderRepository.findByNanoId(orderNanoId).orElseThrow();
+            Order completedOrder = orderRepository.findByNanoId(ORDER_NANO_ID).orElseThrow();
             Member orderCompletedMember =
                     memberRepository.findById(member.getId()).orElseThrow();
 
@@ -430,10 +412,10 @@ class OrderServiceTest extends IntegrationTest {
 
             when(mockCancelResponse.cancels()).thenReturn(List.of(mockCancelDto));
             when(mockCancelDto.canceledAt()).thenReturn(canceledAt);
-            when(paymentClient.cancelPayment(eq(paymentKey), any(PaymentCancelRequest.class)))
+            when(paymentClient.cancelPayment(eq(ORDER_PAYMENT_KEY), any(PaymentCancelRequest.class)))
                     .thenReturn(mockCancelResponse);
 
-            var cancelRequest = new OrderCancelRequest("테스트 취소 사유");
+            var cancelRequest = new OrderCancelRequest(ORDER_CANCEL_REASON);
 
             // when
             orderService.cancelOrder(completedOrder.getId(), cancelRequest);
@@ -468,22 +450,19 @@ class OrderServiceTest extends IntegrationTest {
             Membership membership = createMembership(member, recruitmentRound);
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
 
-            String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
             orderService.createPendingOrder(new OrderCreateRequest(
-                    orderNanoId,
+                    ORDER_NANO_ID,
                     membership.getId(),
                     issuedCoupon.getId(),
                     BigDecimal.valueOf(20000),
                     BigDecimal.valueOf(5000),
                     BigDecimal.valueOf(15000)));
 
-            String paymentKey = "testPaymentKey";
-
             ZonedDateTime approvedAt = ZonedDateTime.now();
             PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
             when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
             when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
-            var request = new OrderCompleteRequest(paymentKey, orderNanoId, 15000L);
+            var request = new OrderCompleteRequest(ORDER_PAYMENT_KEY, ORDER_NANO_ID, 15000L);
             orderService.completeOrder(request);
 
             LocalDate date = LocalDate.now();
@@ -494,7 +473,7 @@ class OrderServiceTest extends IntegrationTest {
 
             // then
             boolean orderExists = orderResponse.getContent().stream()
-                    .anyMatch(order -> order.nanoId().equals(orderNanoId));
+                    .anyMatch(order -> order.nanoId().equals(ORDER_NANO_ID));
 
             assertThat(orderExists).isTrue();
         }
@@ -520,10 +499,8 @@ class OrderServiceTest extends IntegrationTest {
             Membership membership = createMembership(member, recruitmentRound);
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_20000_WON, member);
 
-            String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
-
             var request = new OrderCreateRequest(
-                    orderNanoId,
+                    ORDER_NANO_ID,
                     membership.getId(),
                     issuedCoupon.getId(),
                     BigDecimal.valueOf(20000),
@@ -557,10 +534,8 @@ class OrderServiceTest extends IntegrationTest {
             Membership membership = createMembership(member, recruitmentRound);
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_20000_WON, member);
 
-            String orderNanoId = "HnbMWoSZRq3qK1W3tPXCW";
-
             var request = new OrderCreateRequest(
-                    orderNanoId,
+                    ORDER_NANO_ID,
                     membership.getId(),
                     issuedCoupon.getId(),
                     BigDecimal.valueOf(20000),

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -30,6 +30,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -49,6 +50,13 @@ class OrderServiceTest extends IntegrationTest {
 
     @Autowired
     private OrderRepository orderRepository;
+
+    private void stubPaymentConfirm() {
+        ZonedDateTime approvedAt = ZonedDateTime.now();
+        PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
+        when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
+        when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
+    }
 
     @Nested
     class 임시주문_생성할때 {
@@ -114,11 +122,6 @@ class OrderServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(5000),
                     BigDecimal.valueOf(15000)));
 
-            ZonedDateTime approvedAt = ZonedDateTime.now();
-            PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
-            when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
-            when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
-
             // when
             var request = new OrderCompleteRequest(ORDER_PAYMENT_KEY, ORDER_NANO_ID, 15000L);
             orderService.completeOrder(request);
@@ -160,11 +163,6 @@ class OrderServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(5000),
                     BigDecimal.valueOf(15000)));
 
-            ZonedDateTime approvedAt = ZonedDateTime.now();
-            PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
-            when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
-            when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
-
             // when
             var request = new OrderCompleteRequest(ORDER_PAYMENT_KEY, ORDER_NANO_ID, 15000L);
             orderService.completeOrder(request);
@@ -201,11 +199,6 @@ class OrderServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(5000),
                     BigDecimal.valueOf(15000)));
 
-            ZonedDateTime approvedAt = ZonedDateTime.now();
-            PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
-            when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
-            when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
-
             // when
             var request = new OrderCompleteRequest(ORDER_PAYMENT_KEY, ORDER_NANO_ID, 15000L);
             orderService.completeOrder(request);
@@ -218,6 +211,22 @@ class OrderServiceTest extends IntegrationTest {
 
     @Nested
     class 주문_취소할때 {
+
+        @BeforeEach
+        void setUp() {
+            stubPaymentCancel();
+        }
+
+        private void stubPaymentCancel() {
+            ZonedDateTime canceledAt = ZonedDateTime.now();
+            PaymentResponse mockCancelResponse = mock(PaymentResponse.class);
+            PaymentResponse.CancelDto mockCancelDto = mock(PaymentResponse.CancelDto.class);
+
+            when(mockCancelResponse.cancels()).thenReturn(List.of(mockCancelDto));
+            when(mockCancelDto.canceledAt()).thenReturn(canceledAt);
+            when(paymentClient.cancelPayment(eq(ORDER_PAYMENT_KEY), any(PaymentCancelRequest.class)))
+                    .thenReturn(mockCancelResponse);
+        }
 
         @Test
         void 성공한다() {
@@ -244,24 +253,10 @@ class OrderServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(5000),
                     BigDecimal.valueOf(15000)));
 
-            ZonedDateTime approvedAt = ZonedDateTime.now();
-            PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
-            when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
-            when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
-
             var completeRequest = new OrderCompleteRequest(ORDER_PAYMENT_KEY, ORDER_NANO_ID, 15000L);
             orderService.completeOrder(completeRequest);
 
             Order completedOrder = orderRepository.findByNanoId(ORDER_NANO_ID).orElseThrow();
-
-            ZonedDateTime canceledAt = ZonedDateTime.now();
-            PaymentResponse mockCancelResponse = mock(PaymentResponse.class);
-            PaymentResponse.CancelDto mockCancelDto = mock(PaymentResponse.CancelDto.class);
-
-            when(mockCancelResponse.cancels()).thenReturn(List.of(mockCancelDto));
-            when(mockCancelDto.canceledAt()).thenReturn(canceledAt);
-            when(paymentClient.cancelPayment(eq(ORDER_PAYMENT_KEY), any(PaymentCancelRequest.class)))
-                    .thenReturn(mockCancelResponse);
 
             // when
             var cancelRequest = new OrderCancelRequest(ORDER_CANCEL_REASON);
@@ -338,24 +333,10 @@ class OrderServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(5000),
                     BigDecimal.valueOf(15000)));
 
-            ZonedDateTime approvedAt = ZonedDateTime.now();
-            PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
-            when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
-            when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
-
             var completeRequest = new OrderCompleteRequest(ORDER_PAYMENT_KEY, ORDER_NANO_ID, 15000L);
             orderService.completeOrder(completeRequest);
 
             Order completedOrder = orderRepository.findByNanoId(ORDER_NANO_ID).orElseThrow();
-
-            ZonedDateTime canceledAt = ZonedDateTime.now();
-            PaymentResponse mockCancelResponse = mock(PaymentResponse.class);
-            PaymentResponse.CancelDto mockCancelDto = mock(PaymentResponse.CancelDto.class);
-
-            when(mockCancelResponse.cancels()).thenReturn(List.of(mockCancelDto));
-            when(mockCancelDto.canceledAt()).thenReturn(canceledAt);
-            when(paymentClient.cancelPayment(eq(ORDER_PAYMENT_KEY), any(PaymentCancelRequest.class)))
-                    .thenReturn(mockCancelResponse);
 
             var cancelRequest = new OrderCancelRequest(ORDER_CANCEL_REASON);
 
@@ -394,26 +375,12 @@ class OrderServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(5000),
                     BigDecimal.valueOf(15000)));
 
-            ZonedDateTime approvedAt = ZonedDateTime.now();
-            PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
-            when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
-            when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
-
             var completeRequest = new OrderCompleteRequest(ORDER_PAYMENT_KEY, ORDER_NANO_ID, 15000L);
             orderService.completeOrder(completeRequest);
 
             Order completedOrder = orderRepository.findByNanoId(ORDER_NANO_ID).orElseThrow();
             Member orderCompletedMember =
                     memberRepository.findById(member.getId()).orElseThrow();
-
-            ZonedDateTime canceledAt = ZonedDateTime.now();
-            PaymentResponse mockCancelResponse = mock(PaymentResponse.class);
-            PaymentResponse.CancelDto mockCancelDto = mock(PaymentResponse.CancelDto.class);
-
-            when(mockCancelResponse.cancels()).thenReturn(List.of(mockCancelDto));
-            when(mockCancelDto.canceledAt()).thenReturn(canceledAt);
-            when(paymentClient.cancelPayment(eq(ORDER_PAYMENT_KEY), any(PaymentCancelRequest.class)))
-                    .thenReturn(mockCancelResponse);
 
             var cancelRequest = new OrderCancelRequest(ORDER_CANCEL_REASON);
 
@@ -458,10 +425,6 @@ class OrderServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(5000),
                     BigDecimal.valueOf(15000)));
 
-            ZonedDateTime approvedAt = ZonedDateTime.now();
-            PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
-            when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
-            when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
             var request = new OrderCompleteRequest(ORDER_PAYMENT_KEY, ORDER_NANO_ID, 15000L);
             orderService.completeOrder(request);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -51,6 +51,11 @@ class OrderServiceTest extends IntegrationTest {
     @Autowired
     private OrderRepository orderRepository;
 
+    @Override
+    protected void doStubTemplate() {
+        stubPaymentConfirm();
+    }
+
     private void stubPaymentConfirm() {
         ZonedDateTime approvedAt = ZonedDateTime.now();
         PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/OrderConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/OrderConstant.java
@@ -1,0 +1,10 @@
+package com.gdschongik.gdsc.global.common.constant;
+
+public class OrderConstant {
+
+    public static final String ORDER_NANO_ID = "HnbMWoSZRq3qK1W3tPXCW";
+    public static final String ORDER_PAYMENT_KEY = "testPaymentKey";
+    public static final String ORDER_CANCEL_REASON = "테스트 주문 취소 사유";
+
+    private OrderConstant() {}
+}

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -14,6 +14,8 @@ import com.gdschongik.gdsc.domain.coupon.dao.IssuedCouponRepository;
 import com.gdschongik.gdsc.domain.coupon.domain.Coupon;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.discord.application.handler.DelegateMemberDiscordEventHandler;
+import com.gdschongik.gdsc.domain.discord.application.handler.MemberDiscordRoleRevokeHandler;
+import com.gdschongik.gdsc.domain.discord.application.handler.SpringEventHandler;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberManageRole;
@@ -87,11 +89,14 @@ public abstract class IntegrationTest {
     @MockBean
     protected DelegateMemberDiscordEventHandler delegateMemberDiscordEventHandler;
 
+    @MockBean
+    protected MemberDiscordRoleRevokeHandler memberDiscordRoleRevokeHandler;
+
     @BeforeEach
     void setUp() {
         databaseCleaner.execute();
         redisCleaner.execute();
-        doNothing().when(delegateMemberDiscordEventHandler).delegate(any());
+        doStubDiscordEventHandler();
         doStubTemplate();
     }
 
@@ -102,6 +107,17 @@ public abstract class IntegrationTest {
      */
     protected void doStubTemplate() {
         // 기본적으로 아무 것도 하지 않습니다. 필요한 경우에만 오버라이드하여 사용합니다.
+    }
+
+    /**
+     * {@link SpringEventHandler#delegate} 메서드를 stubbing합니다.
+     * 해당 핸들러 메서드는 스프링 이벤트를 수신하여 JDA를 통해 디스코드 관련 로직을 처리합니다.
+     * JDA는 외부 API의 커넥션을 필요로 하기 때문에 테스트에서는 `@MockBean`으로 주입한 핸들러를 stubbing하여 verify로 호출 여부만 확인합니다.
+     * 기본적으로 아무 것도 하지 않도록 설정합니다.
+     */
+    private void doStubDiscordEventHandler() {
+        doNothing().when(delegateMemberDiscordEventHandler).delegate(any());
+        doNothing().when(memberDiscordRoleRevokeHandler).delegate(any());
     }
 
     protected void logoutAndReloginAs(Long memberId, MemberRole memberRole) {

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -88,7 +88,7 @@ public abstract class IntegrationTest {
     protected DelegateMemberDiscordEventHandler delegateMemberDiscordEventHandler;
 
     @BeforeEach
-    protected void setUp() {
+    void setUp() {
         databaseCleaner.execute();
         redisCleaner.execute();
         doNothing().when(delegateMemberDiscordEventHandler).delegate(any());

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -88,10 +88,20 @@ public abstract class IntegrationTest {
     protected DelegateMemberDiscordEventHandler delegateMemberDiscordEventHandler;
 
     @BeforeEach
-    void setUp() {
+    protected void setUp() {
         databaseCleaner.execute();
         redisCleaner.execute();
         doNothing().when(delegateMemberDiscordEventHandler).delegate(any());
+        doStubTemplate();
+    }
+
+    /**
+     * stubbing에 사용할 템플릿 메서드입니다.
+     * 하위 클래스에서 이 메서드를 오버라이드하여 stubbing을 수행합니다.
+     * 오버라이드된 경우, `@BeforeEach`의 맨 마지막에 호출됩니다.
+     */
+    protected void doStubTemplate() {
+        // 기본적으로 아무 것도 하지 않습니다. 필요한 경우에만 오버라이드하여 사용합니다.
     }
 
     protected void logoutAndReloginAs(Long memberId, MemberRole memberRole) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #518

## 📌 작업 내용 및 특이사항
### 테스트 공통 로직 추출 (1)
- 기존 주문 테스트에 `PaymentClient` mocking / stubbing 하는 부분이 중복해서 등장해서, 메서드로 추출하고 + `@BeforeEach` 로 해당 메서드 호출하는 부분을 제거하는 식으로 개선해봤습니다.
- 주문 승인하는 로직에 대한 stubbing은 전체 `OrderServiceTest` 에 필요하고, 주문 취소 stubbing은 취소 테스트에만 필요합니다.
```java
@Nested
class 주문_취소할때 {

    @BeforeEach
    void setUp() {
        stubPaymentCancel();
    }

    private void stubPaymentCancel() {
        ZonedDateTime canceledAt = ZonedDateTime.now();
        PaymentResponse mockCancelResponse = mock(PaymentResponse.class);
        PaymentResponse.CancelDto mockCancelDto = mock(PaymentResponse.CancelDto.class);

        when(mockCancelResponse.cancels()).thenReturn(List.of(mockCancelDto));
        when(mockCancelDto.canceledAt()).thenReturn(canceledAt);
        when(paymentClient.cancelPayment(eq(ORDER_PAYMENT_KEY), any(PaymentCancelRequest.class)))
                .thenReturn(mockCancelResponse);
    }
```
- 요렇게 `@Nested` 안에서만 `@BeforeEach` 를 호출하면 주문 취소 테스트 건에 대해서만 스터빙이 적용됩니다.
- 문제는 전역적으로 적용하는 경우인데요. 아래와 같이 작성하면 테스트가 터지게 됩니다.
```java
class OrderServiceTest extends IntegrationTest {

    @BeforeEach
    protected void setUp() {
        stubPaymentConfirm();
    }

    private void stubPaymentConfirm() {
        ZonedDateTime approvedAt = ZonedDateTime.now();
        PaymentResponse mockPaymentResponse = mock(PaymentResponse.class);
        when(mockPaymentResponse.approvedAt()).thenReturn(approvedAt);
        when(paymentClient.confirm(any(PaymentConfirmRequest.class))).thenReturn(mockPaymentResponse);
    }
```
- 이유는, 부모 클래스인 `IntegrationTest` 에 있는 `setUp()` 이 오버라이드 되어 작동하지 않게 되기 때문입니다.
```java
@BeforeEach
private void setUp() {
    databaseCleaner.execute();
    redisCleaner.execute();
    doNothing().when(delegateMemberDiscordEventHandler).delegate(any());
}
```
- 그렇다면 `setUp()` 의 접근 제어자를 protected로 변경하고, 하위 클래스에서 오버라이드 하면 어떨까요?
```java
@Override
protected void setUp() {
    super.setUp();
    stubPaymentConfirm();
}
```
- 이는 작동하지 않습니다. 왜냐면, `@BeforeEach` 어노테이션은 오버라이드 되지 않는 경우에'만' 하위 클래스로 상속되기 때문입니다.
> ### Inheritance
> `@BeforeEach` methods are inherited from superclasses as long as they are not overridden 
- 즉 오버라이드된 `setUp()` 은 `@BeforeEach` 이 상속되지 않기 때문에, 직접 달아줘야 합니다.
```java
@BeforeEach
@Override
protected void setUp() {
    super.setUp();
    stubPaymentConfirm();
}
```
### 테스트 공통 로직 추출 (2)
- 해당 방식은 상당히 불편합니다. `@BeforeEach()` 를 직접 달아줘야 하는 것도 그렇고, `super.setUp()` 을 명시적으로 호출해야 하는 것도 그렇습니다.
- 템플릿 메서드 패턴을 사용하여 이를 개선할 수 있습니다.
```java
@BeforeEach
protected void setUp() {
    databaseCleaner.execute();
    redisCleaner.execute();
    doNothing().when(delegateMemberDiscordEventHandler).delegate(any());
    doStubTemplate();
}

/**
 * stubbing에 사용할 템플릿 메서드입니다.
 * 하위 클래스에서 이 메서드를 오버라이드하여 stubbing을 수행합니다.
 * 오버라이드된 경우, `@BeforeEach`의 맨 마지막에 호출됩니다.
 */
protected void doStubTemplate() {
    // 기본적으로 아무 것도 하지 않습니다. 필요한 경우에만 오버라이드하여 사용합니다.
}
```
- 이제 `setUp()` 은 기본적으로 동작하는대로 내버려두고, `doStubTemplate()` 만 서브클래스에서 오버라이드 하여 호출하면 됩니다.


## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- 회원의 상태를 '어소시에이트'로 강등하는 기능 추가.
	- 결제 취소 이벤트를 처리하는 새로운 기능 추가.
	- 결제 상태를 취소하는 기능 추가.
	- 주문 취소 이벤트를 처리하는 기능 추가.
	- 결제 취소 이벤트를 나타내는 새로운 데이터 구조 추가.

- **Bug Fixes**
	- 주문 취소 시 데이터베이스에 변경 사항을 저장하는 기능 개선.

- **Documentation**
	- 특정 결제 취소 상황에 대한 오류 코드 추가.

- **Tests**
	- 회원 상태 업데이트 및 결제 취소 로직 검증을 위한 테스트 추가.
	- 통합 테스트 클래스의 메서드 가시성 및 기능 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->