### PR TITLE
feat: 깃허브 api 연결 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,9 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'io.github.openfeign:feign-jackson'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+    // Github
+    implementation 'org.kohsuke:github-api:1.323'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gdschongik/gdsc/global/config/GithubConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/GithubConfig.java
@@ -1,0 +1,21 @@
+package com.gdschongik.gdsc.global.config;
+
+import com.gdschongik.gdsc.global.property.GithubProperty;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class GithubConfig {
+
+    private final GithubProperty githubProperty;
+
+    @Bean
+    public GitHub github() throws IOException {
+        return new GitHubBuilder().withOAuthToken(githubProperty.getSecretKey()).build();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/config/PropertyConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/PropertyConfig.java
@@ -3,6 +3,7 @@ package com.gdschongik.gdsc.global.config;
 import com.gdschongik.gdsc.global.property.BasicAuthProperty;
 import com.gdschongik.gdsc.global.property.DiscordProperty;
 import com.gdschongik.gdsc.global.property.EmailProperty;
+import com.gdschongik.gdsc.global.property.GithubProperty;
 import com.gdschongik.gdsc.global.property.JwtProperty;
 import com.gdschongik.gdsc.global.property.PaymentProperty;
 import com.gdschongik.gdsc.global.property.RedisProperty;
@@ -15,7 +16,8 @@ import org.springframework.context.annotation.Configuration;
     BasicAuthProperty.class,
     DiscordProperty.class,
     EmailProperty.class,
-    PaymentProperty.class
+    PaymentProperty.class,
+    GithubProperty.class
 })
 @Configuration
 public class PropertyConfig {}

--- a/src/main/java/com/gdschongik/gdsc/global/property/GithubProperty.java
+++ b/src/main/java/com/gdschongik/gdsc/global/property/GithubProperty.java
@@ -1,0 +1,12 @@
+package com.gdschongik.gdsc.global.property;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@AllArgsConstructor
+@ConfigurationProperties(prefix = "github")
+public class GithubProperty {
+    private final String secretKey;
+}

--- a/src/main/java/com/gdschongik/gdsc/global/util/github/GithubUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/github/GithubUtil.java
@@ -1,0 +1,12 @@
+package com.gdschongik.gdsc.global.util.github;
+
+import lombok.RequiredArgsConstructor;
+import org.kohsuke.github.GitHub;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GithubUtil {
+
+    private final GitHub github;
+}

--- a/src/main/java/com/gdschongik/gdsc/infra/client/github/GithubClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/client/github/GithubClient.java
@@ -1,4 +1,4 @@
-package com.gdschongik.gdsc.global.util.github;
+package com.gdschongik.gdsc.infra.client.github;
 
 import lombok.RequiredArgsConstructor;
 import org.kohsuke.github.GitHub;
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class GithubUtil {
+public class GithubClient {
 
     private final GitHub github;
 }

--- a/src/main/resources/application-github.yml
+++ b/src/main/resources/application-github.yml
@@ -1,0 +1,2 @@
+github:
+  secret-key: ${GITHUB_SECRET_KEY:}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
       - discord
       - email
       - payment
+      - github
 
 logging:
   level:


### PR DESCRIPTION
## 🌱 관련 이슈
- close #550

## 📌 작업 내용 및 특이사항
- 깃허브에서는 두 좋류의 api(rest api와 graphql api)를 제공하고 있습니다.
graphql api의 경우 필요한 정보만 가져올 수 있다는 장점이 있지만, rest api에 비해 기술에 대한 이해도가 떨어져서 당장 도입하기에는 부적절한 것 같습니다.
- rest api의 경우, 필요없는 정보까지 가져오는 단점이 있습니다만, [Java용 GitHub API 라이브러리](http://github-api.kohsuke.org/)를 활용하면 주로 사용하는 정보들만 받아 사용할 수 있도록 class 들이 구현되어 있으며,
무엇보다 직접 api call을 한다면 직접 구현해야 하는 Dto 등이 필요없어진다는 장점이 있습니다.
특히, [꾸준히 유지 보수가 되고 있는](https://github.com/hub4j/github-api/releases) 라이브러리이고 [깃허브 공식 문서](https://docs.github.com/ko/rest/using-the-rest-api/libraries-for-the-rest-api?apiVersion=2022-11-28#java)에서도 소개하고 있는 라이브러라서 안정성에도 문제가 없을 것 같습니다.
- 결론적으로, github가 제공하는 rest와 graphql 중 rest api의 활용을 돕는 [Java용 GitHub API 라이브러리](http://github-api.kohsuke.org/)를 활용하기로 했고, api 호출을 위한 Util 클래스를 구현했습니다.


## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- GitHub API와의 통합을 위한 새로운 구성과 기능 추가.
	- OAuth 인증을 사용하여 GitHub 클라이언트를 설정하는 기능 제공.
	- GitHub 관련 속성을 관리하는 새로운 구성 파일 추가.
	- GitHub API와의 상호작용을 위한 새로운 클라이언트 구성.

- **Bug Fixes**
	- 없음.

- **Documentation**
	- GitHub 통합 관련 문서 업데이트 (YAML 구성 파일).

- **Chores**
	- `build.gradle`에 GitHub API 라이브러리 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->