### PR TITLE
fix: DTO를 적절한 위치로 이동

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyMentorController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudyMentorController.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.study.api;
 
 import com.gdschongik.gdsc.domain.study.application.StudyMentorService;
-import com.gdschongik.gdsc.domain.study.domain.request.AssignmentCreateRequest;
+import com.gdschongik.gdsc.domain.study.dto.request.AssignmentCreateRequest;
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/request/AssignmentCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/request/AssignmentCreateRequest.java
@@ -1,4 +1,4 @@
-package com.gdschongik.gdsc.domain.study.domain.request;
+package com.gdschongik.gdsc.domain.study.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Future;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #568

## 📌 작업 내용 및 특이사항
- AssignmentCreateRequest가 domain/requset의 위치에 있습니다. dto/request로 옮겼습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - `AssignmentCreateRequest`의 임포트 경로가 수정되어 코드 구조가 개선되었습니다.  


<!-- end of auto-generated comment: release notes by coderabbit.ai -->