### PR TITLE
fix: PrincipalDetails가 역할의 값을 반환하도록 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/global/security/PrincipalDetails.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/PrincipalDetails.java
@@ -28,9 +28,9 @@ public class PrincipalDetails implements UserDetails {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> authorities = new ArrayList<>();
 
-        authorities.add(new SimpleGrantedAuthority(role.name()));
-        authorities.add(new SimpleGrantedAuthority(manageRole.name()));
-        authorities.add(new SimpleGrantedAuthority(studyRole.name()));
+        authorities.add(new SimpleGrantedAuthority(role.getValue()));
+        authorities.add(new SimpleGrantedAuthority(manageRole.getValue()));
+        authorities.add(new SimpleGrantedAuthority(studyRole.getValue()));
 
         return authorities;
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #572

## 📌 작업 내용 및 특이사항
- securityConfig에서는 hasRole로 역할이 있는지 검사합니다. 이 메서드는 들어온 값에 "ROLE_"이라는 prefix를 붙여서 실행하므로 아래의 메서드에서 enum의 name이 아닌 value를 넣어줘야 합니다.

```java
    @Override
    public Collection<? extends GrantedAuthority> getAuthorities() {
        Collection<GrantedAuthority> authorities = new ArrayList<>();

        authorities.add(new SimpleGrantedAuthority(role.getValue()));
        authorities.add(new SimpleGrantedAuthority(manageRole.getValue()));
        authorities.add(new SimpleGrantedAuthority(studyRole.getValue()));

        return authorities;
    }
```

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
	- 역할 권한을 보다 설명적이고 사용자 친화적인 값으로 가져오도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->