### PR TITLE
refactor: 멘토 컨트롤러 엔드포인트 정리

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyDetailController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyDetailController.java
@@ -9,18 +9,25 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Mentor Study", description = "멘토 스터디 관리 API입니다.")
+@Tag(name = "Mentor StudyDetail", description = "멘토 스터디 상세 관리 API입니다.")
 @RestController
-@RequestMapping("/mentor/studies")
+@RequestMapping("/mentor/studydetails")
 @RequiredArgsConstructor
-public class StudyMentorController {
+public class MentorStudyDetailController {
 
     private final StudyMentorService studyMentorService;
 
     @Operation(summary = "스터디 과제 개설", description = "멘토만 과제를 개설할 수 있습니다.")
-    @PutMapping("/assignments/{studyDetailId}")
+    @PutMapping("/{studyDetailId}/assignments")
     public ResponseEntity<Void> publishStudyAssignment(
             @PathVariable Long studyDetailId, @Valid @RequestBody AssignmentCreateRequest request) {
         studyMentorService.publishStudyAssignment(studyDetailId, request);
@@ -28,22 +35,23 @@ public class StudyMentorController {
     }
 
     @Operation(summary = "스터디 주차별 과제 목록 조회", description = "주차별 스터디 과제 목록을 조회합니다.")
-    @GetMapping("/assignments/{studyId}")
-    public ResponseEntity<List<AssignmentResponse>> getWeeklyAssignments(@PathVariable Long studyId) {
+    @GetMapping("/assignments")
+    public ResponseEntity<List<AssignmentResponse>> getWeeklyAssignments(@RequestParam(name = "studyId") Long studyId) {
         List<AssignmentResponse> response = studyMentorService.getWeeklyAssignments(studyId);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "스터디 과제 상세 조회", description = "멘토가 자신의 스터디 과제를 조회합니다.")
-    @GetMapping("/assignments/{studyDetailId}")
-    public ResponseEntity<AssignmentResponse> getStudyAssignment(@PathVariable Long studyDetailId) {
+    @GetMapping("/{studyDetailId}/assignments")
+    public ResponseEntity<AssignmentResponse> getStudyAssignment(
+            @RequestParam(name = "studyDetailId") Long studyDetailId) {
         AssignmentResponse response = studyMentorService.getAssignment(studyDetailId);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "스터디 과제 휴강 처리", description = "해당 주차 과제를 휴강 처리합니다.")
-    @PatchMapping("/assignments/{studyDetailId}/cancel")
-    public ResponseEntity<Void> cancelStudyAssignment(@PathVariable Long studyDetailId) {
+    @PatchMapping("/{studyDetailId}/assignments/cancel")
+    public ResponseEntity<Void> cancelStudyAssignment(@RequestParam(name = "studyDetailId") Long studyDetailId) {
         studyMentorService.cancelStudyAssignment(studyDetailId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyDetailController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyDetailController.java
@@ -43,15 +43,14 @@ public class MentorStudyDetailController {
 
     @Operation(summary = "스터디 과제 상세 조회", description = "멘토가 자신의 스터디 과제를 조회합니다.")
     @GetMapping("/{studyDetailId}/assignments")
-    public ResponseEntity<AssignmentResponse> getStudyAssignment(
-            @RequestParam(name = "studyDetailId") Long studyDetailId) {
+    public ResponseEntity<AssignmentResponse> getStudyAssignment(@PathVariable Long studyDetailId) {
         AssignmentResponse response = studyMentorService.getAssignment(studyDetailId);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "스터디 과제 휴강 처리", description = "해당 주차 과제를 휴강 처리합니다.")
     @PatchMapping("/{studyDetailId}/assignments/cancel")
-    public ResponseEntity<Void> cancelStudyAssignment(@RequestParam(name = "studyDetailId") Long studyDetailId) {
+    public ResponseEntity<Void> cancelStudyAssignment(@PathVariable Long studyDetailId) {
         studyMentorService.cancelStudyAssignment(studyDetailId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyDetailController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyDetailController.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.study.api;
 
-import com.gdschongik.gdsc.domain.study.application.StudyMentorService;
+import com.gdschongik.gdsc.domain.study.application.MentorStudyDetailService;
 import com.gdschongik.gdsc.domain.study.dto.request.AssignmentCreateRequest;
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,34 +24,34 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MentorStudyDetailController {
 
-    private final StudyMentorService studyMentorService;
+    private final MentorStudyDetailService mentorStudyDetailService;
 
     @Operation(summary = "스터디 과제 개설", description = "멘토만 과제를 개설할 수 있습니다.")
     @PutMapping("/{studyDetailId}/assignments")
     public ResponseEntity<Void> publishStudyAssignment(
             @PathVariable Long studyDetailId, @Valid @RequestBody AssignmentCreateRequest request) {
-        studyMentorService.publishStudyAssignment(studyDetailId, request);
+        mentorStudyDetailService.publishStudyAssignment(studyDetailId, request);
         return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "스터디 주차별 과제 목록 조회", description = "주차별 스터디 과제 목록을 조회합니다.")
     @GetMapping("/assignments")
     public ResponseEntity<List<AssignmentResponse>> getWeeklyAssignments(@RequestParam(name = "studyId") Long studyId) {
-        List<AssignmentResponse> response = studyMentorService.getWeeklyAssignments(studyId);
+        List<AssignmentResponse> response = mentorStudyDetailService.getWeeklyAssignments(studyId);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "스터디 과제 상세 조회", description = "멘토가 자신의 스터디 과제를 조회합니다.")
     @GetMapping("/{studyDetailId}/assignments")
     public ResponseEntity<AssignmentResponse> getStudyAssignment(@PathVariable Long studyDetailId) {
-        AssignmentResponse response = studyMentorService.getAssignment(studyDetailId);
+        AssignmentResponse response = mentorStudyDetailService.getAssignment(studyDetailId);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "스터디 과제 휴강 처리", description = "해당 주차 과제를 휴강 처리합니다.")
     @PatchMapping("/{studyDetailId}/assignments/cancel")
     public ResponseEntity<Void> cancelStudyAssignment(@PathVariable Long studyDetailId) {
-        studyMentorService.cancelStudyAssignment(studyDetailId);
+        mentorStudyDetailService.cancelStudyAssignment(studyDetailId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyDetailController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyDetailController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Mentor StudyDetail", description = "멘토 스터디 상세 관리 API입니다.")
 @RestController
-@RequestMapping("/mentor/studydetails")
+@RequestMapping("/mentor/study-details")
 @RequiredArgsConstructor
 public class MentorStudyDetailController {
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class StudyMentorService {
+public class MentorStudyDetailService {
 
     private final MemberUtil memberUtil;
     private final StudyDetailRepository studyDetailRepository;

--- a/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
@@ -116,6 +116,8 @@ public class WebSecurityConfig {
                 .authenticated()
                 .requestMatchers("/admin/**")
                 .hasRole("ADMIN")
+                .requestMatchers("/mentor/**")
+                .hasRole("MENTOR")
                 .anyRequest()
                 .authenticated());
 

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailServiceTest.java
@@ -15,10 +15,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class StudyMentorServiceTest extends IntegrationTest {
+public class MentorStudyDetailServiceTest extends IntegrationTest {
 
     @Autowired
-    private StudyMentorService studyMentorService;
+    private MentorStudyDetailService mentorStudyDetailService;
 
     @Autowired
     private StudyDetailRepository studyDetailRepository;
@@ -39,7 +39,7 @@ public class StudyMentorServiceTest extends IntegrationTest {
             logoutAndReloginAs(studyDetail.getStudy().getMentor().getId(), MemberRole.ASSOCIATE);
 
             // when
-            studyMentorService.cancelStudyAssignment(studyDetail.getId());
+            mentorStudyDetailService.cancelStudyAssignment(studyDetail.getId());
 
             // then
             StudyDetail cancelledStudyDetail =


### PR DESCRIPTION
## 🌱 관련 이슈
- close #558

## 📌 작업 내용 및 특이사항
- 기존 `StudyMentorController`의 이름을 `MentorStudyDetailController`로 바꿨습니다.
- `studies`로 시작하던 엔드 포인트를 `study-details`로 시작하도록 수정했습니다.
- `/assignments/{studyDetailId}` 구조였지만, studyDetail이 assignment를 포함하는 관계이므로 `/{studyDetailId}/assignments`로 수정했습니다.
- `/mentor/**`에 대한 Security 설정을 추가했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- 멘토 학습 할당 관련 API 엔드포인트의 구조를 개선했습니다.
	- 새로운 요청 매핑 경로 `/mentor/study-details`로 변경하여 더 명확한 기능 제공.
	- 주간 할당 조회 및 학습 할당 세부사항 조회 방식 개선.
	- 학습 할당 취소 기능의 요청 구조를 통일하여 사용자 편의성 강화.

- **Bug Fixes**
	- API 엔드포인트의 경로 변경으로 인해 발생할 수 있는 오류를 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->