### PR TITLE
feat: 쿠키 로직을 사용하기 쉽게 개선

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/TestMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/TestMemberController.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.domain.member.api;
 
 import com.gdschongik.gdsc.domain.member.application.AdminMemberService;
 import com.gdschongik.gdsc.domain.member.application.OnboardingMemberService;
+import com.gdschongik.gdsc.domain.member.application.TestMemberService;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberTokenRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberTokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,8 +18,16 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class TestMemberController {
 
+    private final TestMemberService testMemberService;
     private final OnboardingMemberService onboardingMemberService;
     private final AdminMemberService adminMemberService;
+
+    @Operation(summary = "게스트 회원 생성", description = "테스트용 API입니다. 깃허브 핸들명을 입력받아 임시 회원을 생성합니다.")
+    @PostMapping
+    public ResponseEntity<Void> createTemporaryMember(@RequestParam("handle") String githubHandle) {
+        testMemberService.createTestMember(githubHandle);
+        return ResponseEntity.ok().build();
+    }
 
     @Operation(summary = "임시 토큰 생성", description = "테스트용 API입니다. oauth_id를 입력받아 해당하는 유저의 토큰을 생성합니다.")
     @PostMapping("/token")

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/TestMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/TestMemberService.java
@@ -1,0 +1,49 @@
+package com.gdschongik.gdsc.domain.member.application;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Service
+public class TestMemberService {
+
+    private final MemberRepository memberRepository;
+    private final RestClient restClient;
+
+    public TestMemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+        this.restClient = RestClient.builder().baseUrl("https://api.github.com").build();
+    }
+
+    @Transactional
+    public void createTestMember(String githubHandle) {
+        String githubOauthId = getGithubOauthId(githubHandle);
+
+        if (memberRepository.findByOauthId(githubOauthId).isPresent()) {
+            throw new CustomException(INTERNAL_SERVER_ERROR);
+        }
+
+        Member guestMember = Member.createGuestMember(githubOauthId);
+        memberRepository.save(guestMember);
+    }
+
+    private String getGithubOauthId(String githubHandle) {
+        return Optional.ofNullable(restClient
+                        .get()
+                        .uri("/users/{githubHandle}", githubHandle)
+                        .retrieve()
+                        .body(GithubUser.class))
+                .map(GithubUser::id)
+                .orElseThrow(() -> new CustomException(INTERNAL_SERVER_ERROR));
+    }
+
+    private record GithubUser(String id) {}
+}

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/SecurityConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/SecurityConstant.java
@@ -7,8 +7,6 @@ public class SecurityConstant {
     public static final String TOKEN_STUDY_ROLE_NAME = "studyRole";
     public static final String GITHUB_NAME_ATTR_KEY = "id";
     public static final String ACCESS_TOKEN_HEADER_PREFIX = "Bearer ";
-    public static final String OAUTH_BASE_URI_COOKIE_NAME = "oauth-base-uri";
-    public static final String OAUTH_REDIRECT_PATH_SEGMENT = "/social-login/redirect";
 
     private SecurityConstant() {}
 }

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/SecurityConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/SecurityConstant.java
@@ -2,15 +2,11 @@ package com.gdschongik.gdsc.global.common.constant;
 
 public class SecurityConstant {
 
-    public static final String LANDING_STATUS_PARAM = "landing-status";
-    public static final String ACCESS_TOKEN_PARAM = "access";
-    public static final String REFRESH_TOKEN_PARAM = "refresh";
     public static final String TOKEN_ROLE_NAME = "role";
     public static final String TOKEN_MANAGE_ROLE_NAME = "manageRole";
     public static final String TOKEN_STUDY_ROLE_NAME = "studyRole";
     public static final String GITHUB_NAME_ATTR_KEY = "id";
     public static final String ACCESS_TOKEN_HEADER_PREFIX = "Bearer ";
-    public static final String ACCESS_TOKEN_HEADER_NAME = "Authorization";
     public static final String OAUTH_BASE_URI_COOKIE_NAME = "oauth-base-uri";
     public static final String OAUTH_REDIRECT_PATH_SEGMENT = "/social-login/redirect";
 

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/UrlConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/UrlConstant.java
@@ -1,7 +1,5 @@
 package com.gdschongik.gdsc.global.common.constant;
 
-import java.util.List;
-
 public class UrlConstant {
 
     private UrlConstant() {}
@@ -16,12 +14,6 @@ public class UrlConstant {
     public static final String LOCAL_VITE_CLIENT_URL = "http://localhost:5173";
     public static final String LOCAL_VITE_CLIENT_SECURE_URL = "https://localhost:5173";
     public static final String LOCAL_PROXY_CLIENT_ONBOARDING_URL = "https://local-onboarding.gdschongik.com";
-    public static final List<String> LOCAL_CLIENT_URLS = List.of(
-            LOCAL_REACT_CLIENT_URL,
-            LOCAL_REACT_CLIENT_SECURE_URL,
-            LOCAL_VITE_CLIENT_URL,
-            LOCAL_VITE_CLIENT_SECURE_URL,
-            LOCAL_PROXY_CLIENT_ONBOARDING_URL);
 
     // 서버 URL
     public static final String PROD_SERVER_URL = "https://api.gdschongik.com";

--- a/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
@@ -172,9 +172,10 @@ public class WebSecurityConfig {
             configuration.addAllowedOriginPattern(LOCAL_REACT_CLIENT_SECURE_URL);
             configuration.addAllowedOriginPattern(LOCAL_VITE_CLIENT_URL);
             configuration.addAllowedOriginPattern(LOCAL_VITE_CLIENT_SECURE_URL);
-            configuration.addAllowedOriginPattern(LOCAL_PROXY_CLIENT_ONBOARDING_URL);
             configuration.addAllowedOriginPattern(DEV_SERVER_URL);
         }
+
+        configuration.addAllowedOriginPattern(LOCAL_PROXY_CLIENT_ONBOARDING_URL);
 
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -18,8 +18,6 @@ public enum ErrorCode {
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
     AUTH_NOT_EXIST(HttpStatus.INTERNAL_SERVER_ERROR, "시큐리티 인증 정보가 존재하지 않습니다."),
     AUTH_NOT_PARSABLE(HttpStatus.INTERNAL_SERVER_ERROR, "시큐리티 인증 정보 파싱에 실패했습니다."),
-    BASE_URI_COOKIE_NOT_FOUND(HttpStatus.NOT_FOUND, "Base URI 쿠키가 존재하지 않습니다."),
-    NOT_ALLOWED_BASE_URI(HttpStatus.FORBIDDEN, "허용되지 않은 Base URI입니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
     INVALID_ROLE(HttpStatus.FORBIDDEN, "권한이 없습니다."),
 

--- a/src/main/java/com/gdschongik/gdsc/global/security/CustomOAuth2User.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/CustomOAuth2User.java
@@ -11,11 +11,9 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 public class CustomOAuth2User extends DefaultOAuth2User {
 
     private final MemberAuthInfo memberAuthInfo;
-    private final LandingStatus landingStatus;
 
     public CustomOAuth2User(OAuth2User oAuth2User, Member member) {
         super(oAuth2User.getAuthorities(), oAuth2User.getAttributes(), GITHUB_NAME_ATTR_KEY);
         memberAuthInfo = MemberAuthInfo.from(member);
-        landingStatus = LandingStatus.TO_DASHBOARD;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/security/CustomSuccessHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/CustomSuccessHandler.java
@@ -45,9 +45,6 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         String redirectUri = UriComponentsBuilder.fromHttpUrl(baseUri)
                 .path(OAUTH_REDIRECT_PATH_SEGMENT)
-                .queryParam(LANDING_STATUS_PARAM, oAuth2User.getLandingStatus().name())
-                .queryParam(ACCESS_TOKEN_PARAM, accessTokenDto.tokenValue())
-                .queryParam(REFRESH_TOKEN_PARAM, refreshTokenDto.tokenValue())
                 .toUriString();
 
         getRedirectStrategy().sendRedirect(request, response, redirectUri);

--- a/src/main/java/com/gdschongik/gdsc/global/security/CustomSuccessHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/CustomSuccessHandler.java
@@ -7,16 +7,14 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.auth.application.JwtService;
 import com.gdschongik.gdsc.domain.auth.dto.AccessTokenDto;
 import com.gdschongik.gdsc.domain.auth.dto.RefreshTokenDto;
-import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.CookieUtil;
-import jakarta.servlet.http.Cookie;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
@@ -27,14 +25,13 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     public CustomSuccessHandler(JwtService jwtService, CookieUtil cookieUtil) {
         this.jwtService = jwtService;
         this.cookieUtil = cookieUtil;
+        setUseReferer(true);
     }
 
     @Override
     public void onAuthenticationSuccess(
             HttpServletRequest request, HttpServletResponse response, Authentication authentication)
-            throws IOException {
-        String baseUri = determineTargetUrl(request, response);
-
+            throws IOException, ServletException {
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
 
         // 토큰 생성 후 쿠키에 저장
@@ -43,31 +40,6 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         RefreshTokenDto refreshTokenDto = jwtService.createRefreshToken(memberAuthInfo.memberId());
         cookieUtil.addTokenCookies(response, accessTokenDto.tokenValue(), refreshTokenDto.tokenValue());
 
-        String redirectUri = UriComponentsBuilder.fromHttpUrl(baseUri)
-                .path(OAUTH_REDIRECT_PATH_SEGMENT)
-                .toUriString();
-
-        getRedirectStrategy().sendRedirect(request, response, redirectUri);
-    }
-
-    @Override
-    protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response) {
-        Cookie baseUriCookie = cookieUtil
-                .findCookie(request, OAUTH_BASE_URI_COOKIE_NAME)
-                .orElseThrow(() -> new CustomException(BASE_URI_COOKIE_NOT_FOUND));
-
-        String baseUri = baseUriCookie.getValue();
-        validateBaseUri(baseUri);
-
-        cookieUtil.deleteCookie(response, baseUriCookie);
-
-        return baseUri;
-    }
-
-    private void validateBaseUri(String baseUri) {
-        if (!baseUri.endsWith(ROOT_DOMAIN)) {
-            log.warn("허용되지 않은 BASE URI로의 리다이렉트 요청 발생. 쿠키 조작이 의심됩니다: baseUri={}", baseUri);
-            throw new CustomException(NOT_ALLOWED_BASE_URI);
-        }
+        super.onAuthenticationSuccess(request, response, authentication);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/security/CustomSuccessHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/CustomSuccessHandler.java
@@ -65,8 +65,8 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     }
 
     private void validateBaseUri(String baseUri) {
-        if (!baseUri.endsWith(ROOT_DOMAIN) && !LOCAL_CLIENT_URLS.contains(baseUri)) {
-            log.error("허용되지 않은 BASE URI로의 리다이렉트 요청 발생: {}", baseUri);
+        if (!baseUri.endsWith(ROOT_DOMAIN)) {
+            log.warn("허용되지 않은 BASE URI로의 리다이렉트 요청 발생. 쿠키 조작이 의심됩니다: baseUri={}", baseUri);
             throw new CustomException(NOT_ALLOWED_BASE_URI);
         }
     }

--- a/src/main/java/com/gdschongik/gdsc/global/security/CustomSuccessHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/CustomSuccessHandler.java
@@ -43,9 +43,6 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         RefreshTokenDto refreshTokenDto = jwtService.createRefreshToken(memberAuthInfo.memberId());
         cookieUtil.addTokenCookies(response, accessTokenDto.tokenValue(), refreshTokenDto.tokenValue());
 
-        // 임시로 헤더에 엑세스 토큰 추가
-        response.addHeader(ACCESS_TOKEN_HEADER_NAME, ACCESS_TOKEN_HEADER_PREFIX + accessTokenDto.tokenValue());
-
         String redirectUri = UriComponentsBuilder.fromHttpUrl(baseUri)
                 .path(OAUTH_REDIRECT_PATH_SEGMENT)
                 .queryParam(LANDING_STATUS_PARAM, oAuth2User.getLandingStatus().name())

--- a/src/main/java/com/gdschongik/gdsc/global/security/LandingStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/LandingStatus.java
@@ -1,5 +1,0 @@
-package com.gdschongik.gdsc.global.security;
-
-public enum LandingStatus {
-    TO_DASHBOARD;
-}

--- a/src/main/java/com/gdschongik/gdsc/global/util/CookieUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/CookieUtil.java
@@ -7,7 +7,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.server.Cookie;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;

--- a/src/main/java/com/gdschongik/gdsc/global/util/CookieUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/CookieUtil.java
@@ -1,5 +1,7 @@
 package com.gdschongik.gdsc.global.util;
 
+import static com.gdschongik.gdsc.global.common.constant.UrlConstant.*;
+
 import com.gdschongik.gdsc.global.common.constant.JwtConstant;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -12,39 +14,26 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class CookieUtil {
 
-    private final EnvironmentUtil environmentUtil;
-
     public void addTokenCookies(HttpServletResponse response, String accessToken, String refreshToken) {
-
-        String sameSite = determineSameSitePolicy();
-
-        ResponseCookie accessTokenCookie =
-                generateTokenCookie(JwtConstant.ACCESS_TOKEN.getCookieName(), accessToken, sameSite);
+        ResponseCookie accessTokenCookie = generateTokenCookie(JwtConstant.ACCESS_TOKEN.getCookieName(), accessToken);
 
         ResponseCookie refreshTokenCookie =
-                generateTokenCookie(JwtConstant.REFRESH_TOKEN.getCookieName(), refreshToken, sameSite);
+                generateTokenCookie(JwtConstant.REFRESH_TOKEN.getCookieName(), refreshToken);
 
         response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
     }
 
-    private ResponseCookie generateTokenCookie(String cookieName, String tokenValue, String sameSite) {
+    private ResponseCookie generateTokenCookie(String cookieName, String tokenValue) {
         return ResponseCookie.from(cookieName, tokenValue)
                 .path("/")
                 .secure(true)
-                .sameSite(sameSite)
+                .sameSite(Cookie.SameSite.LAX.attributeValue())
+                .domain(ROOT_DOMAIN)
                 .httpOnly(true)
                 .build();
-    }
-
-    private String determineSameSitePolicy() {
-        if (environmentUtil.isProdProfile()) {
-            return Cookie.SameSite.LAX.attributeValue();
-        }
-        return Cookie.SameSite.NONE.attributeValue();
     }
 
     public Optional<jakarta.servlet.http.Cookie> findCookie(HttpServletRequest request, String cookieName) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #370

## 📌 작업 내용 및 특이사항
### 회원 생성하는 테스트 API 추가
- 현재 소셜 로그인 로직에 쿠키가 사용되기 때문에, 로컬 환경에서 소셜 로그인 케이스를 테스트하기도 어렵고, 테스트 멤버를 생성하기도 어렵습니다.
- 이러한 문제를 해결하기 위해 게스트 멤버를 생성하는 테스트 API를 구현했습니다.
- 특징으로는 실제 존재하는 github handle을 받아서 github api로 요청을 보낸 뒤 oauth_id를 받아온다는 것입니다.
- 직접 api 요청을 날려서 oauth_id를 확인할 수도 있겠지만, 이렇게 하시진 않을 것 같고 + 그러면 아무 값으로나 oauth_id를 채우는 상황이 만들어질 것 같아서 핸들명 입력하면 바로 회원가입 처리가 되도록 만들었습니다.
- 내부에서만 사용하는 RestClient 및 GithubUser라는 inner static record 클래스가 있습니다. 
- 별도 dto로 빼지 않은 이유는 해당 클래스 내부에서만 사용해야 하는 임시 DTO이기 때문에 public으로 노출시키고 싶지 않았습니다. 또, 추후 깃허브 로직 자동완성에서 튀어나오는 문제 등을 방지하고 싶었습니다.

### 쿠키 관련 변경
- 이제 로컬에서 쿠키 관련 테스트가 필요하다면, 클라이언트 쪽과 마찬가지로 ophiuchi 사용하여 `local-api.gdschongik.com` 으로 프록시 설정하여 사용하도록 합니다. 방법은 노션에서 클라이언트 워크스페이스 문서에 ophiuchi 검색하면 나올 겁니다.
- 쿠키 관련 로직에서 로컬 케이스를 대응하지 않도록 관련 로직들을 전부 삭제했습니다.
    - ~`oauth-base-uri` 쿠키에서 루트 도메인 외 로컬 URL을 고려하는 케이스를 제거했습니다.~ -> `oauth-base-uri` 관련 로직을 모두 제거했습니다.
- 모든 쿠키의 samesite 정책을 LAX로 설정했습니다. 더 이상 로컬 프로파일이라고 해서 NONE으로 만들지 않습니다.

---

## 240807 변경된 쿠키 로직 관련 (중요!!)

### 요약
- 오늘 낮에 이런저런 이야기를 했었는데요, 기본 전제부터가 틀렸었습니다.
- `쿠키가 없으면 리다이렉트 위치를 결정할 수 없다` -> 결정할 수 있습니다. 크롬의 referer policy 준수하면 서버에서 소셜 로그인 요청 보는 클라이언트 호스트를 식별할 수 있습니다.
- 따라서 해결책으로 제시되었던 기존 방법들도 전부 필요가 없어졌습니다.
    - OAuth2 인증 필터를 커스터마이징할 필요도 없고
    - 현재 방식처럼 클라이언트가 리다이렉트 위치에 대한 쿠키를 저장해둘 필요도 없고
    - 세션을 유지해서 리다이렉트 위치를 불러올 필요도 없습니다.
- 그냥 referer로 리다이렉트 되도록 만들면 끝입니다. 단, 로컬 환경에서는 referer가 oauth 프로토콜 수행 중간에 유실되기 때문에, 프록시 설정 해줘야 쓸 수 있습니다. 
- 클라이언트 로컬 작업 환경에는 해당 사항이 이미 반영되어 있으므로, 정상적으로 작동하게 됩니다.

### 예전 컨텍스트 + 원인
- 먼저 결론부터 말씀드리자면 크롬의 경우`strict-origin-when-cross-origin` referer policy를 사용하고 있는데, 배포 환경의 `클라이언트 -> 깃허브 인증서버`와 `깃허브 리소스 서버 -> 서버 리다이렉트`간 referer가 유지되기 때문에, 깃허브 리소스 서버로부터 리다이렉트를 받은 서버가 호스트 정보를 식별할 수 있게 되고, 따라서 이 호스트로 리다이렉트를 해주도록 oauth 성공 핸들러 로직을 변경했습니다.
- 클라이언트는 localhost:3000 환경을 사용하는데요, 서버는 https를 사용하고, 이때 scheme이 다르기 때문에 여차저차 (레퍼런스 참고) referer가 유실되는 것이었습니다. 이게 `oauth-base-uri` 의 도입 배경입니다.
- 지금은 로컬 클라이언트에서 ssl proxy 설정을 해두었기 때문에 문제 없이 사용 가능합니다.
- 참고: [(레퍼런스)](https://velog.io/@sejinkim/Referrer-Policy%EC%9D%98-%EC%9D%B4%ED%95%B4#same-site-same-origin)

### 해결
- `SimpleUrlAuthenticationSuccessHandler` 의 경우 `onAuthenticationSuccess` 가 호출되면 `handle()` 을 통해서 어디로 어떠헥 리다이렉트 할 지를 결정합니다.
```java
protected void handle(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
    throws IOException, ServletException {
    String targetUrl = determineTargetUrl(request, response, authentication);
    if (response.isCommitted()) {
        this.logger.debug(LogMessage.format("Did not redirect to %s since response already committed.", targetUrl));
        return;
    }
    this.redirectStrategy.sendRedirect(request, response, targetUrl);
}
```
- 이때 리다이렉트 위치를 결정하는 `determineTargetUrl` 은 다음 로직으로 작동합니다.
```java
protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response) {
    if (isAlwaysUseDefaultTargetUrl()) {
        return this.defaultTargetUrl;
    }
    String targetUrlParameterValue = getTargetUrlParameterValue(request);
    if (StringUtils.hasText(targetUrlParameterValue)) {
        trace("Using url %s from request parameter %s", targetUrlParameterValue, this.targetUrlParameter);
        return targetUrlParameterValue;
    }
    if (this.useReferer) {
        trace("Using url %s from Referer header", request.getHeader("Referer"));
        return request.getHeader("Referer");
    }
    return this.defaultTargetUrl;
}
```
- 보시면 크게 네 가지 방식으로 결정하는 것을 보실 수 있습니다. 다음은 `AbstractAuthenticationTargetUrlRequestHandler` javadoc입니다.
    1. `alwaysUseDefaultTargetUrl` 속성이 `true`로 설정된 경우, `defaultTargetUrl` 속성이 목적지로 사용됩니다.
    2. 요청에 `targetUrlParameter` 값과 일치하는 매개변수가 설정된 경우, 해당 값이 목적지로 사용됩니다. 이 기능을 활성화할 때는 매개변수를 공격자가 악성 사이트로 리디렉션하는 데 사용하지 못하도록 주의해야 합니다 (예: 매개변수가 포함된 URL을 클릭하는 경우). 일반적으로 이 매개변수는 로그인 폼에 포함되어 사용자 이름과 비밀번호와 함께 제출될 때 사용됩니다.
    3. `useReferer` 속성이 설정된 경우, "Referer" HTTP 헤더 값이 존재하는 경우 사용됩니다.
    4. 마지막으로, `defaultTargetUrl` 값이 사용됩니다.
- 저희는 3번에 해당합니다. referer 헤더를 사용해야 하기 때문에, `setUseReferer(true)` 를 통해서 타깃 URL 결정 전략을 바꿔줍니다.
```java
public CustomSuccessHandler(JwtService jwtService, CookieUtil cookieUtil) {
    this.jwtService = jwtService;
    this.cookieUtil = cookieUtil;
    setUseReferer(true);
}
```
- 마지막으로, 기존에 사용하고 있던 `oauth-base-uri` 로직을 모두 제거해야 합니다. 클라이언트 쪽으로 슬랙 통해 전달해두었습니다.

## 📝 참고사항
- 로컬 서버 + 로컬 클라이언트 굴리는 경우 감안해서 local profile에서도 CORS 설정하여 로컬 클라이언트 프록시 URL로 접속할 수 있게 했습니다.
- `LandingStatus` 를 제거헀습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **신규 기능**
  - 임시 멤버 생성을 위한 API가 추가되었습니다.
  - GitHub 핸들을 사용하여 테스트 멤버를 생성하는 기능이 도입되었습니다.

- **버그 수정**
  - 성공적인 인증 이후 응답에서 액세스 토큰을 제거하여 보안을 강화했습니다.

- **구성 변경**
  - CORS 설정을 업데이트하여 특정 로컬 프록시 클라이언트의 온보딩 URL을 허용했습니다.

- **문서화**
  - 새로운 API 메서드에 대한 OpenAPI 문서가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->