### PR TITLE
refactor: 모집중인 모집회차가 없을 경우 예외 대신 null을 던지도록 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
@@ -75,13 +75,12 @@ public class OnboardingMemberService {
                 univEmailVerificationService.getUnivEmailVerificationFromRedis(member.getId());
         UnivVerificationStatus univVerificationStatus =
                 emailVerificationStatusService.determineStatus(member, univEmailVerification);
-        final RecruitmentRound currentRecruitmentRound =
-                onboardingRecruitmentService.findCurrentRecruitmentRound().orElse(null);
-        Optional<Membership> myMembership = Optional.ofNullable(currentRecruitmentRound)
-                .flatMap(recruitmentRound -> membershipService.findMyMembership(member, recruitmentRound));
+        Optional<RecruitmentRound> currentRecruitmentRound = onboardingRecruitmentService.findCurrentRecruitmentRound();
+        Optional<Membership> myMembership = currentRecruitmentRound.flatMap(
+                recruitmentRound -> membershipService.findMyMembership(member, recruitmentRound));
 
         return MemberDashboardResponse.of(
-                member, univVerificationStatus, currentRecruitmentRound, myMembership.orElse(null));
+                member, univVerificationStatus, currentRecruitmentRound.orElse(null), myMembership.orElse(null));
     }
 
     public MemberTokenResponse createTemporaryToken(MemberTokenRequest request) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
@@ -71,12 +71,14 @@ public class OnboardingMemberService {
 
     public MemberDashboardResponse getDashboard() {
         final Member member = memberUtil.getCurrentMember();
-        final RecruitmentRound currentRecruitmentRound = onboardingRecruitmentService.findCurrentRecruitmentRound();
-        final Optional<Membership> myMembership = membershipService.findMyMembership(member, currentRecruitmentRound);
         final Optional<UnivEmailVerification> univEmailVerification =
                 univEmailVerificationService.getUnivEmailVerificationFromRedis(member.getId());
         UnivVerificationStatus univVerificationStatus =
                 emailVerificationStatusService.determineStatus(member, univEmailVerification);
+        final RecruitmentRound currentRecruitmentRound =
+                onboardingRecruitmentService.findCurrentRecruitmentRound().orElse(null);
+        Optional<Membership> myMembership = Optional.ofNullable(currentRecruitmentRound)
+                .flatMap(recruitmentRound -> membershipService.findMyMembership(member, recruitmentRound));
 
         return MemberDashboardResponse.of(
                 member, univVerificationStatus, currentRecruitmentRound, myMembership.orElse(null));

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberDashboardResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/response/MemberDashboardResponse.java
@@ -11,7 +11,7 @@ import jakarta.annotation.Nullable;
 
 public record MemberDashboardResponse(
         MemberFullDto member,
-        RecruitmentRoundFullDto currentRecruitmentRound,
+        @Nullable RecruitmentRoundFullDto currentRecruitmentRound,
         @Nullable MembershipFullDto currentMembership) {
     public static MemberDashboardResponse of(
             Member member,
@@ -20,7 +20,7 @@ public record MemberDashboardResponse(
             Membership currentMembership) {
         return new MemberDashboardResponse(
                 MemberFullDto.of(member, univVerificationStatus),
-                RecruitmentRoundFullDto.from(currentRecruitmentRound),
+                currentRecruitmentRound == null ? null : RecruitmentRoundFullDto.from(currentRecruitmentRound),
                 currentMembership == null ? null : MembershipFullDto.from(currentMembership));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/OnboardingRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/OnboardingRecruitmentService.java
@@ -2,8 +2,6 @@ package com.gdschongik.gdsc.domain.recruitment.application;
 
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
-import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.global.exception.ErrorCode;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,11 +15,10 @@ public class OnboardingRecruitmentService {
     private final RecruitmentRoundRepository recruitmentRoundRepository;
 
     // TODO: 모집기간과 별도로 표시기간 사용하여 필터링하도록 변경
-    public RecruitmentRound findCurrentRecruitmentRound() {
+    public Optional<RecruitmentRound> findCurrentRecruitmentRound() {
         return recruitmentRoundRepository.findAll().stream()
                 .filter(RecruitmentRound::isOpen) // isOpen -> isDisplayable
-                .findFirst()
-                .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_ROUND_OPEN_NOT_FOUND));
+                .findFirst();
     }
 
     /**

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -89,7 +89,6 @@ public enum ErrorCode {
     RECRUITMENT_ROUND_TYPE_OVERLAP(HttpStatus.BAD_REQUEST, "모집 차수가 중복됩니다."),
     RECRUITMENT_ROUND_STARTDATE_ALREADY_PASSED(HttpStatus.BAD_REQUEST, "이미 모집 시작일이 지난 모집회차입니다."),
     ROUND_ONE_DOES_NOT_EXIST(HttpStatus.CONFLICT, "1차 모집이 존재하지 않습니다."),
-    RECRUITMENT_ROUND_OPEN_NOT_FOUND(HttpStatus.NOT_FOUND, "진행중인 모집회차가 존재하지 않습니다."),
 
     // Coupon
     COUPON_DISCOUNT_AMOUNT_NOT_POSITIVE(HttpStatus.CONFLICT, "쿠폰의 할인 금액은 0보다 커야 합니다."),

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
@@ -11,6 +11,7 @@ import com.gdschongik.gdsc.domain.recruitment.application.OnboardingRecruitmentS
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.helper.IntegrationTest;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,8 @@ class OnboardingMemberServiceTest extends IntegrationTest {
         @BeforeEach
         void setUp() {
             RecruitmentRound recruitmentRound = createRecruitmentRound();
-            when(onboardingRecruitmentService.findCurrentRecruitmentRound()).thenReturn(recruitmentRound);
+            when(onboardingRecruitmentService.findCurrentRecruitmentRound())
+                    .thenReturn(Optional.ofNullable(recruitmentRound));
         }
 
         @Test


### PR DESCRIPTION
## 🌱 관련 이슈
- close #578

## 📌 작업 내용 및 특이사항
- 현재는 모집중인 모집회차가 없을 경우 404를 던집니다.
- 모집 기간이 아닐 때에도 대시보드에 진입할 수 있도록 예외대신 null을 반환하도록 수정했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- 대시보드에서 현재 모집 라운드와 관련된 회원 정보를 더 안전하게 처리하는 기능 추가.
	- 모집 라운드 검색을 위한 반환 타입을 `Optional`로 변경하여 널 값 처리 개선.

- **Bug Fixes**
	- 대시보드 조회 시 널 포인터 예외 발생 가능성 제거.

- **Documentation**
	- API 명세에 nullable 필드에 대한 명확한 설명 추가.

- **Chores**
	- 불필요한 예외 처리 관련 코드 제거 및 테스트 코드 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->