### PR TITLE
fix: 모집 기간 시작 후에도 수정할 수 있도록 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
@@ -2,7 +2,8 @@ package com.gdschongik.gdsc.domain.recruitment.api;
 
 import com.gdschongik.gdsc.domain.recruitment.application.AdminRecruitmentService;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
-import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentRoundCreateUpdateRequest;
+import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentRoundCreateRequest;
+import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentRoundUpdateRequest;
 import com.gdschongik.gdsc.domain.recruitment.dto.response.AdminRecruitmentResponse;
 import com.gdschongik.gdsc.domain.recruitment.dto.response.AdminRecruitmentRoundResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -50,8 +51,7 @@ public class AdminRecruitmentController {
 
     @Operation(summary = "모집회차 생성", description = "새로운 모집회차를 생성합니다. 모집기간은 학기 시작일로부터 2주 이내입니다.")
     @PostMapping("/rounds")
-    public ResponseEntity<Void> createRecruitmentRound(
-            @Valid @RequestBody RecruitmentRoundCreateUpdateRequest request) {
+    public ResponseEntity<Void> createRecruitmentRound(@Valid @RequestBody RecruitmentRoundCreateRequest request) {
         adminRecruitmentService.createRecruitmentRound(request);
         return ResponseEntity.ok().build();
     }
@@ -59,7 +59,7 @@ public class AdminRecruitmentController {
     @Operation(summary = "모집회차 수정", description = "기존 모집회차를 수정합니다. 학년도와 학기는 수정 대상이 아닙니다.")
     @PutMapping("/rounds/{recruitmentRoundId}")
     public ResponseEntity<Void> updateRecruitmentRound(
-            @PathVariable Long recruitmentRoundId, @Valid @RequestBody RecruitmentRoundCreateUpdateRequest request) {
+            @PathVariable Long recruitmentRoundId, @Valid @RequestBody RecruitmentRoundUpdateRequest request) {
         adminRecruitmentService.updateRecruitmentRound(recruitmentRoundId, request);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -11,7 +11,8 @@ import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRoundValidator;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentValidator;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
-import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentRoundCreateUpdateRequest;
+import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentRoundCreateRequest;
+import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentRoundUpdateRequest;
 import com.gdschongik.gdsc.domain.recruitment.dto.response.AdminRecruitmentResponse;
 import com.gdschongik.gdsc.domain.recruitment.dto.response.AdminRecruitmentRoundResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
@@ -63,7 +64,7 @@ public class AdminRecruitmentService {
     }
 
     @Transactional
-    public void createRecruitmentRound(RecruitmentRoundCreateUpdateRequest request) {
+    public void createRecruitmentRound(RecruitmentRoundCreateRequest request) {
         Recruitment recruitment = recruitmentRepository
                 .findByAcademicYearAndSemesterType(request.academicYear(), request.semesterType())
                 .orElseThrow(() -> new CustomException(RECRUITMENT_NOT_FOUND));
@@ -87,7 +88,7 @@ public class AdminRecruitmentService {
     }
 
     @Transactional
-    public void updateRecruitmentRound(Long recruitmentRoundId, RecruitmentRoundCreateUpdateRequest request) {
+    public void updateRecruitmentRound(Long recruitmentRoundId, RecruitmentRoundUpdateRequest request) {
         List<RecruitmentRound> recruitmentRounds = recruitmentRoundRepository.findAllByAcademicYearAndSemesterType(
                 request.academicYear(), request.semesterType());
 

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentRoundCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentRoundCreateRequest.java
@@ -1,0 +1,20 @@
+package com.gdschongik.gdsc.domain.recruitment.dto.request;
+
+import static com.gdschongik.gdsc.global.common.constant.RegexConstant.*;
+
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record RecruitmentRoundCreateRequest(
+        @NotNull(message = "학년도는 null이 될 수 없습니다.") @Schema(description = "학년도", pattern = ACADEMIC_YEAR)
+                Integer academicYear,
+        @NotNull(message = "학기는 null이 될 수 없습니다.") @Schema(description = "학기") SemesterType semesterType,
+        @NotBlank @Schema(description = "이름") String name,
+        @Future @Schema(description = "모집기간 시작일", pattern = DATETIME) LocalDateTime startDate,
+        @Future @Schema(description = "모집기간 종료일", pattern = DATETIME) LocalDateTime endDate,
+        @NotNull(message = "모집 차수는 null이 될 수 없습니다.") @Schema(description = "모집 차수") RoundType roundType) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentRoundUpdateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/request/RecruitmentRoundUpdateRequest.java
@@ -10,11 +10,11 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
-public record RecruitmentRoundCreateUpdateRequest(
+public record RecruitmentRoundUpdateRequest(
         @NotNull(message = "학년도는 null이 될 수 없습니다.") @Schema(description = "학년도", pattern = ACADEMIC_YEAR)
                 Integer academicYear,
         @NotNull(message = "학기는 null이 될 수 없습니다.") @Schema(description = "학기") SemesterType semesterType,
         @NotBlank @Schema(description = "이름") String name,
-        @Future @Schema(description = "모집기간 시작일", pattern = DATETIME) LocalDateTime startDate,
+        @Schema(description = "모집기간 시작일", pattern = DATETIME) LocalDateTime startDate,
         @Future @Schema(description = "모집기간 종료일", pattern = DATETIME) LocalDateTime endDate,
         @NotNull(message = "모집 차수는 null이 될 수 없습니다.") @Schema(description = "모집 차수") RoundType roundType) {}

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -11,7 +11,8 @@ import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
-import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentRoundCreateUpdateRequest;
+import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentRoundCreateRequest;
+import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentRoundUpdateRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.IntegrationTest;
 import java.time.LocalDateTime;
@@ -53,7 +54,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         @Test
         void 학년도와_학기가_일치하는_리쿠르팅이_존재하지_않는다면_실패한다() {
             // given
-            RecruitmentRoundCreateUpdateRequest request = new RecruitmentRoundCreateUpdateRequest(
+            RecruitmentRoundCreateRequest request = new RecruitmentRoundCreateRequest(
                     ACADEMIC_YEAR, SEMESTER_TYPE, RECRUITMENT_ROUND_NAME, START_DATE, END_DATE, ROUND_TYPE);
 
             // when & then
@@ -77,7 +78,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
                     RECRUITMENT_ROUND_NAME, now.plusDays(1), now.plusDays(2), recruitment, ROUND_TYPE);
             recruitmentRoundRepository.save(recruitmentRound);
 
-            RecruitmentRoundCreateUpdateRequest request = new RecruitmentRoundCreateUpdateRequest(
+            RecruitmentRoundUpdateRequest request = new RecruitmentRoundUpdateRequest(
                     ACADEMIC_YEAR, SEMESTER_TYPE, "수정된 모집회차 이름", now.plusDays(2), now.plusDays(3), ROUND_TYPE);
 
             // when
@@ -95,7 +96,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         @Test
         void 모집회차가_존재하지_않는다면_실패한다() {
             // given
-            RecruitmentRoundCreateUpdateRequest request = new RecruitmentRoundCreateUpdateRequest(
+            RecruitmentRoundUpdateRequest request = new RecruitmentRoundUpdateRequest(
                     ACADEMIC_YEAR, SEMESTER_TYPE, RECRUITMENT_ROUND_NAME, START_DATE, END_DATE, ROUND_TYPE);
 
             // when & then


### PR DESCRIPTION
## 🌱 관련 이슈
- close #582

## 📌 작업 내용 및 특이사항
- 모집회차 생성과 수정 Dto를 하나로 사용하다보니 모집 기간이 시작된 후 수정하려고 하는 경우에 `@Future`가 막아버리는 현상이 발생합니다.
- 두 Dto 분리하고 수정 Dto의 시작시간 필드에서는 검증 제거했습니다.
## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 채용 라운드를 생성하고 업데이트하기 위한 별도의 요청 클래스를 도입하여 API의 명확성을 향상시켰습니다.
  
- **버그 수정**
	- 요청 클래스의 이름 변경으로 인한 오류를 수정하여 메소드의 가독성을 개선했습니다.

- **문서화**
	- 새로운 요청 클래스를 사용하도록 테스트 케이스를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->