### PR TITLE
fix: 다른 슬래시 커맨드 사용시 호출되지 않도록 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/DiscordIdBatchCommandListener.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/DiscordIdBatchCommandListener.java
@@ -1,5 +1,7 @@
 package com.gdschongik.gdsc.domain.discord.application.listener;
 
+import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.*;
+
 import com.gdschongik.gdsc.domain.discord.application.handler.DiscordIdBatchCommandHandler;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
@@ -15,6 +17,8 @@ public class DiscordIdBatchCommandListener extends ListenerAdapter {
     private final DiscordIdBatchCommandHandler discordIdBatchCommandHandler;
 
     public void onSlashCommandInteraction(@NotNull SlashCommandInteractionEvent event) {
-        discordIdBatchCommandHandler.delegate(event);
+        if (event.getName().equals(COMMAND_NAME_BATCH_DISCORD_ID)) {
+            discordIdBatchCommandHandler.delegate(event);
+        }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #586

## 📌 작업 내용 및 특이사항
- 다른 슬래시 커맨드 사용시 같이 호출되는 문제가 있어서,디스코드 id 배치 명령 리스너에 if 조건 추가했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 특정 명령어에 대한 조건부 체크를 추가하여 Discord 명령 처리 로직을 개선했습니다. 이제 명령어의 이름이 지정된 상수와 일치하는 경우에만 이벤트가 처리됩니다.

- **버그 수정**
  - 의도하지 않은 명령의 호출을 방지하기 위해 명령 처리의 흐름을 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->