### PR TITLE
fix: 로그아웃 API가 쿠키를 삭제하지 못하는 문제 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/auth/api/AuthController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/auth/api/AuthController.java
@@ -6,6 +6,7 @@ import com.gdschongik.gdsc.global.util.CookieUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -25,9 +26,10 @@ public class AuthController {
     @GetMapping("/logout")
     public ResponseEntity<Void> logout(
             @CookieValue(ACCESS_TOKEN_COOKIE_NAME) Cookie accessToken,
-            @CookieValue(REFRESH_TOKEN_COOKIE_NAME) Cookie refreshToken) {
-        cookieUtil.deleteCookie(accessToken);
-        cookieUtil.deleteCookie(refreshToken);
+            @CookieValue(REFRESH_TOKEN_COOKIE_NAME) Cookie refreshToken,
+            HttpServletResponse response) {
+        cookieUtil.deleteCookie(accessToken, response);
+        cookieUtil.deleteCookie(refreshToken, response);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/util/CookieUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/CookieUtil.java
@@ -32,9 +32,10 @@ public class CookieUtil {
                 .build();
     }
 
-    public void deleteCookie(jakarta.servlet.http.Cookie cookie) {
+    public void deleteCookie(jakarta.servlet.http.Cookie cookie, HttpServletResponse response) {
         cookie.setPath("/");
         cookie.setValue("");
         cookie.setMaxAge(0);
+        response.addCookie(cookie);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #595

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 로그아웃 기능이 개선되어 HTTP 응답을 통해 쿠키를 정확하게 삭제할 수 있게 되었습니다.
  
- **변경 사항**
  - `deleteCookie` 메소드가 HTTP 응답을 지원하도록 수정되어 클라이언트에게 쿠키 삭제 상태를 전달합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->