### PR TITLE
refactor: 승급조건 상태 enum 값을 UNSATISFIED로 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/common/model/RequirementStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/model/RequirementStatus.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum RequirementStatus {
-    PENDING("PENDING"),
+    UNSATISFIED("UNSATISFIED"),
     SATISFIED("SATISFIED");
 
     private final String value;

--- a/src/main/java/com/gdschongik/gdsc/domain/email/domain/EmailVerificationStatusService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/email/domain/EmailVerificationStatusService.java
@@ -15,7 +15,7 @@ public class EmailVerificationStatusService {
         } else {
             return univEmailVerification.isPresent()
                     ? UnivVerificationStatus.IN_PROGRESS
-                    : UnivVerificationStatus.PENDING;
+                    : UnivVerificationStatus.UNSATISFIED;
         }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/TestMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/TestMemberController.java
@@ -39,7 +39,7 @@ public class TestMemberController {
     @Operation(summary = "게스트로 강등", description = "테스트용 API입니다. 현재 멤버 역할을 게스트로 강등시키기 위해 사용합니다.")
     @PatchMapping("/demotion")
     public ResponseEntity<Void> demoteToGuest() {
-        adminMemberService.demoteToGuestAndRegularRequirementToPending();
+        adminMemberService.demoteToGuestAndRegularRequirementToUnsatisfied();
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -88,11 +88,8 @@ public class AdminMemberService {
                 regularMembers.stream().map(Member::getId).toList());
     }
 
-    /**
-     * 정회원 조건 PENDING으로 변경, 준회원 조건 PENDING으로 변경
-     */
     @Transactional
-    public void demoteToGuestAndRegularRequirementToPending() {
+    public void demoteToGuestAndRegularRequirementToUnsatisfied() {
         validateProfile();
         Member member = memberUtil.getCurrentMember();
         member.demoteToGuest();

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/AssociateRequirement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/AssociateRequirement.java
@@ -46,10 +46,10 @@ public class AssociateRequirement {
 
     public static AssociateRequirement createRequirement() {
         return AssociateRequirement.builder()
-                .univStatus(PENDING)
-                .discordStatus(PENDING)
-                .bevyStatus(PENDING)
-                .infoStatus(PENDING)
+                .univStatus(UNSATISFIED)
+                .discordStatus(UNSATISFIED)
+                .bevyStatus(UNSATISFIED)
+                .infoStatus(UNSATISFIED)
                 .build();
     }
 
@@ -119,9 +119,9 @@ public class AssociateRequirement {
      * 모든 준회원 조건을 강등합니다.
      */
     public void demoteAssociateRequirement() {
-        bevyStatus = PENDING;
-        discordStatus = PENDING;
-        infoStatus = PENDING;
-        univStatus = PENDING;
+        bevyStatus = UNSATISFIED;
+        discordStatus = UNSATISFIED;
+        infoStatus = UNSATISFIED;
+        univStatus = UNSATISFIED;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/UnivVerificationStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/UnivVerificationStatus.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum UnivVerificationStatus {
-    PENDING("PENDING"),
+    UNSATISFIED("UNSATISFIED"),
     IN_PROGRESS("IN_PROGRESS"),
     SATISFIED("SATISFIED");
 

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
@@ -78,7 +78,7 @@ public class Membership extends BaseEntity {
     public void revokePaymentStatus() {
         validatePaymentStatusRevocable();
 
-        regularRequirement.updatePaymentStatus(PENDING);
+        regularRequirement.updatePaymentStatus(UNSATISFIED);
 
         registerEvent(new MembershipPaymentRevokedEvent(id));
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/RegularRequirement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/RegularRequirement.java
@@ -29,7 +29,7 @@ public class RegularRequirement {
 
     public static RegularRequirement createUnsatisfiedRequirement() {
         return RegularRequirement.builder()
-                .paymentStatus(RequirementStatus.PENDING)
+                .paymentStatus(RequirementStatus.UNSATISFIED)
                 .build();
     }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -50,10 +50,10 @@ class MemberTest {
             AssociateRequirement requirement = member.getAssociateRequirement();
 
             // then
-            assertThat(requirement.getUnivStatus()).isEqualTo(PENDING);
-            assertThat(requirement.getDiscordStatus()).isEqualTo(PENDING);
-            assertThat(requirement.getBevyStatus()).isEqualTo(PENDING);
-            assertThat(requirement.getInfoStatus()).isEqualTo(PENDING);
+            assertThat(requirement.getUnivStatus()).isEqualTo(UNSATISFIED);
+            assertThat(requirement.getDiscordStatus()).isEqualTo(UNSATISFIED);
+            assertThat(requirement.getBevyStatus()).isEqualTo(UNSATISFIED);
+            assertThat(requirement.getInfoStatus()).isEqualTo(UNSATISFIED);
         }
     }
 
@@ -370,7 +370,7 @@ class MemberTest {
                             AssociateRequirement::getInfoStatus,
                             AssociateRequirement::getBevyStatus,
                             AssociateRequirement::getUnivStatus)
-                    .containsExactly(PENDING, PENDING, PENDING, PENDING);
+                    .containsExactly(UNSATISFIED, UNSATISFIED, UNSATISFIED, UNSATISFIED);
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #596

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- `PENDING` 상태를 `UNSATISFIED`로 변경하여 요구사항 상태를 보다 명확하게 표현.
	- 이메일 인증 상태의 변경 로직을 개선하여, 인증 프로세스가 없을 때 상태를 `UNSATISFIED`로 설정.
  
- **Bug Fixes**
	- 역할 강등 기능에서 요구사항 상태를 `UNSATISFIED`로 업데이트하여 로직을 정교화.
  
- **Tests**
	- `AssociateRequirement` 상태 체크 테스트를 수정하여 `UNSATISFIED` 상태를 반영.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->