### PR TITLE
feat: 대시보드 API에 신규 역할 필드 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/MemberFullDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/MemberFullDto.java
@@ -3,7 +3,9 @@ package com.gdschongik.gdsc.domain.member.dto;
 import com.gdschongik.gdsc.domain.common.model.RequirementStatus;
 import com.gdschongik.gdsc.domain.member.domain.Department;
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberManageRole;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.domain.member.domain.MemberStudyRole;
 import com.gdschongik.gdsc.global.util.formatter.PhoneFormatter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Optional;
@@ -11,6 +13,8 @@ import java.util.Optional;
 public record MemberFullDto(
         Long memberId,
         @Schema(description = "멤버 역할", implementation = MemberRole.class) MemberRole role,
+        @Schema(description = "멤버 관리자 역할", implementation = MemberManageRole.class) MemberManageRole manageRole,
+        @Schema(description = "멤버 스터디 역할", implementation = MemberStudyRole.class) MemberStudyRole studyRole,
         @Schema(description = "회원정보", implementation = MemberBasicInfoDto.class) MemberBasicInfoDto basicInfo,
         @Schema(description = "인증상태정보", implementation = MemberAssociateRequirementDto.class)
                 MemberAssociateRequirementDto associateRequirement) {
@@ -18,6 +22,8 @@ public record MemberFullDto(
         return new MemberFullDto(
                 member.getId(),
                 member.getRole(),
+                member.getManageRole(),
+                member.getStudyRole(),
                 MemberBasicInfoDto.from(member),
                 MemberAssociateRequirementDto.of(member, univVerificationStatus));
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #571

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
	- 멤버의 관리 및 스터디 역할을 추가하여 더욱 상세한 역할 관리 기능 제공.
	- API 문서화를 위한 새로운 필드 `manageRole` 및 `studyRole` 추가.
  
- **변경 사항**
	- `MemberFullDto`의 생성자 및 정적 메서드를 수정하여 새로운 필드 값 처리.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->