### PR TITLE
feat: 멘토 스터디 커리큘럼 조회

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyDetailController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyDetailController.java
@@ -3,6 +3,7 @@ package com.gdschongik.gdsc.domain.study.api;
 import com.gdschongik.gdsc.domain.study.application.MentorStudyDetailService;
 import com.gdschongik.gdsc.domain.study.dto.request.AssignmentCreateUpdateRequest;
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.SessionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -61,5 +62,13 @@ public class MentorStudyDetailController {
     public ResponseEntity<Void> cancelStudyAssignment(@PathVariable Long studyDetailId) {
         mentorStudyDetailService.cancelStudyAssignment(studyDetailId);
         return ResponseEntity.noContent().build();
+    }
+
+    // TODO 스터디 세션 워딩을 커리큘럼으로 변경해야함
+    @Operation(summary = "스터디 주차별 커리큘럼 목록 조회", description = "멘토가 자신의 스터디 커리큘럼 목록을 조회합니다")
+    @GetMapping("/sessions")
+    public ResponseEntity<List<SessionResponse>> getStudySession(@RequestParam(name = "studyId") Long studyId) {
+        List<SessionResponse> response = mentorStudyDetailService.getSession(studyId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
@@ -8,6 +8,7 @@ import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import com.gdschongik.gdsc.domain.study.domain.StudyDetailValidator;
 import com.gdschongik.gdsc.domain.study.dto.request.AssignmentCreateUpdateRequest;
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.SessionResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.util.List;
@@ -82,5 +83,11 @@ public class MentorStudyDetailService {
         studyDetailRepository.save(studyDetail);
 
         log.info("[MentorStudyDetailService] 과제 수정 완료: studyDetailId={}", studyDetailId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SessionResponse> getSession(Long studyId) {
+        List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyId(studyId);
+        return studyDetails.stream().map(SessionResponse::from).toList();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/SessionResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/SessionResponse.java
@@ -1,0 +1,20 @@
+package com.gdschongik.gdsc.domain.study.dto.response;
+
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.domain.study.domain.Difficulty;
+import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
+import com.gdschongik.gdsc.domain.study.domain.vo.Session;
+
+public record SessionResponse(
+        Long studyDetailId, Period period, Long week, String title, String description, Difficulty difficulty) {
+    public static SessionResponse from(StudyDetail studyDetail) {
+        Session session = studyDetail.getSession();
+        return new SessionResponse(
+                studyDetail.getId(),
+                studyDetail.getPeriod(),
+                studyDetail.getWeek(),
+                session.getTitle(),
+                session.getDescription(),
+                session.getDifficulty());
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #602 

## 📌 작업 내용 및 특이사항
-https://www.notion.so/API-6e2d0e4c4a084fa1a745eda665607368?p=671592fa2a134a39b2d1e3f71e4aa08e&pm=s

<img width="356" alt="image" src="https://github.com/user-attachments/assets/8521f52e-52d7-4f8f-ac9d-afa0e83003b5">


이 화면에 대한 스터디 커리큘럼(세션) 목록 조회 api구현했습니다

## 📝 참고사항
- 서버 워딩 세션을 커리큘럼으로 바꿔야 할 것 같습니다 TODO주석처리 해놓았습니다

## 📚 기타
-
