### PR TITLE
feat: 내 담당 스터디 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyController.java
@@ -21,8 +21,8 @@ public class MentorStudyController {
 
     @Operation(summary = "내 스터디 조회", description = "내가 멘토로 있는 스터디를 조회합니다.")
     @GetMapping("/me")
-    public ResponseEntity<List<MentorStudyResponse>> getMyStudies() {
-        List<MentorStudyResponse> response = mentorStudyService.getMyStudies();
+    public ResponseEntity<List<MentorStudyResponse>> getStudiesInCharge() {
+        List<MentorStudyResponse> response = mentorStudyService.getStudiesInCharge();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyController.java
@@ -1,0 +1,28 @@
+package com.gdschongik.gdsc.domain.study.api;
+
+import com.gdschongik.gdsc.domain.study.application.MentorStudyService;
+import com.gdschongik.gdsc.domain.study.dto.response.MentorStudyResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Mentor Study", description = "멘토 스터디 API입니다.")
+@RestController
+@RequestMapping("/mentor/studies")
+@RequiredArgsConstructor
+public class MentorStudyController {
+
+    private final MentorStudyService mentorStudyService;
+
+    @Operation(summary = "내 스터디 조회", description = "내가 멘토로 있는 스터디를 조회합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<List<MentorStudyResponse>> getMyStudies() {
+        List<MentorStudyResponse> response = mentorStudyService.getMyStudies();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
@@ -18,7 +18,7 @@ public class MentorStudyService {
     private final StudyRepository studyRepository;
 
     @Transactional(readOnly = true)
-    public List<MentorStudyResponse> getMyStudies() {
+    public List<MentorStudyResponse> getStudiesInCharge() {
         Member currentMember = memberUtil.getCurrentMember();
         List<Study> myStudies = studyRepository.findAllByMentor(currentMember);
         return myStudies.stream().map(MentorStudyResponse::from).toList();

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
@@ -1,0 +1,26 @@
+package com.gdschongik.gdsc.domain.study.application;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.study.dao.StudyRepository;
+import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.domain.study.dto.response.MentorStudyResponse;
+import com.gdschongik.gdsc.global.util.MemberUtil;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MentorStudyService {
+
+    private final MemberUtil memberUtil;
+    private final StudyRepository studyRepository;
+
+    @Transactional(readOnly = true)
+    public List<MentorStudyResponse> getMyStudies() {
+        Member currentMember = memberUtil.getCurrentMember();
+        List<Study> myStudies = studyRepository.findAllByMentor(currentMember);
+        return myStudies.stream().map(MentorStudyResponse::from).toList();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyRepository.java
@@ -1,6 +1,11 @@
 package com.gdschongik.gdsc.domain.study.dao;
 
+import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.Study;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StudyRepository extends JpaRepository<Study, Long> {}
+public interface StudyRepository extends JpaRepository<Study, Long> {
+
+    List<Study> findAllByMentor(Member mentor);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/MentorStudyResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/MentorStudyResponse.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.study.dto.response;
 
 import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.domain.study.domain.StudyType;
 import com.gdschongik.gdsc.global.util.formatter.SemesterFormatter;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -8,7 +9,7 @@ public record MentorStudyResponse(
         Long studyId,
         @Schema(description = "활동 학기") String semester,
         @Schema(description = "이름") String title,
-        @Schema(description = "종류") String studyType,
+        @Schema(description = "종류") StudyType studyType,
         @Schema(description = "상세설명 노션 링크") String notionLink,
         @Schema(description = "멘토 이름") String mentorName) {
 
@@ -17,7 +18,7 @@ public record MentorStudyResponse(
                 study.getId(),
                 SemesterFormatter.format(study.getAcademicYear(), study.getSemesterType()),
                 study.getTitle(),
-                study.getStudyType().getValue(),
+                study.getStudyType(),
                 study.getNotionLink(),
                 study.getMentor().getName());
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/MentorStudyResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/MentorStudyResponse.java
@@ -1,0 +1,24 @@
+package com.gdschongik.gdsc.domain.study.dto.response;
+
+import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.global.util.formatter.SemesterFormatter;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MentorStudyResponse(
+        Long studyId,
+        @Schema(description = "활동 학기") String semester,
+        @Schema(description = "이름") String title,
+        @Schema(description = "종류") String studyType,
+        @Schema(description = "상세설명 노션 링크") String notionLink,
+        @Schema(description = "멘토 이름") String mentorName) {
+
+    public static MentorStudyResponse from(Study study) {
+        return new MentorStudyResponse(
+                study.getId(),
+                SemesterFormatter.format(study.getAcademicYear(), study.getSemesterType()),
+                study.getTitle(),
+                study.getStudyType().getValue(),
+                study.getNotionLink(),
+                study.getMentor().getName());
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #612

## 📌 작업 내용 및 특이사항
- 멘토의 본인 담당 스터디 목록 조회 api입니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 멘토가 관련된 학습 자료를 조회할 수 있는 기능이 추가되었습니다.
	- 새로운 API 엔드포인트(`/mentor/studies/me`)를 통해 사용자가 멘토로서의 학습 자료를 쉽게 조회할 수 있습니다.
	- `MentorStudyResponse` 자료형이 추가되어 응답 데이터의 구조가 개선되었습니다. 

- **Bug Fixes**
	- 비즈니스 로직을 변경하여 멘토의 학습 자료를 정확하게 반환할 수 있도록 수정되었습니다. 

- **Documentation**
	- API 문서화가 개선되어 새로운 엔드포인트와 응답 자료형에 대한 설명이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->