### PR TITLE
fix: 로그아웃 API에서 쿠키가 삭제되지 않는 문제

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/global/util/CookieUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/CookieUtil.java
@@ -36,6 +36,7 @@ public class CookieUtil {
         cookie.setPath("/");
         cookie.setValue("");
         cookie.setMaxAge(0);
+        cookie.setDomain(ROOT_DOMAIN);
         response.addCookie(cookie);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #618

## 📌 작업 내용 및 특이사항

### 문제의 원인
- 쿠키는 도메인 속성이 다른 경우 다른 쿠키로 취급됩니다. 즉 동일한 키-값을 가졌더라도 도메인이 다르면 중복된 쿠키가 존재할 수 있습니다.
<img width="805" alt="image" src="https://github.com/user-attachments/assets/2e3f4328-af54-4b2d-a2f4-f08788136cf2">

- 현재 로그아웃에서 사용되는 쿠키 삭제 로직을 보면 이렇습니다.
```java
public void deleteCookie(jakarta.servlet.http.Cookie cookie, HttpServletResponse response) {
    cookie.setPath("/");
    cookie.setValue("");
    cookie.setMaxAge(0);
    response.addCookie(cookie);
}
```
- 요청에 담긴 쿠키를 `@CookieValue` 로 가져와서 응답에 실어보내는 식입니다.
- 실제로 삭제 요청에는 이렇게 `Set-Cookie`가 나갑니다.
    - `accessToken=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:10 GMT; Path=/`
- 그렇다면 쿠키가 심길 때는 어떻게 나갈까요?
    - `accessToken={엑세스_토큰_값}; Path=/; Domain=gdschongik.com; Secure; HttpOnly; SameSite=Lax`
- 대략 여기까지 보고 감이 오실 수도 있겠습니다... 도메인이 다르기 때문에 삭제가 되지 않는 것입니다.

### 실제로는 이러지 않을까?
1. 로그인 후 브라우저에는 AT(엑세스 토큰), RT(리프레시 토큰)가 저장됩니다. 이를 AT-1, RT-1이라 하겠습니다.
2. 로그아웃을 위해서 브라우저가 서버에 로그아웃 API를 요청합니다.
3. 서버에서는 AT, RT를 읽어들여서, 해당 AT와 RT의 값을 없애고, 즉시 만료되도록 합니다. 하지만 이것은 사실이 아닙니다.
4. 서버에서는 쿠키를 읽어서 -> 수정했다고 생각하지만, 실제로는 `Set-Cookie`를 통해 중복된 키의 쿠키를 실어보내서 -> 브라우저가 같은 쿠키를 덮어쓰도록 만들게 됩니다.
5. 만약 서버에서 변경된 AT-1 쿠키를 보냈다면, 브라우저에서는 새로운 AT-1의 쿠키로 덮어쓰도록 합니다 이 덮어쓴 AT-1 쿠키는 즉시 만료되도록 되어있으므로, 바로 제거됩니다.
6. 하지만 같은 키를 가졌더라도 도메인이 다르면 다른 쿠키로 취급됩니다. 서버가 실어보낸 AT-1은 사실 AT-2입니다.
7. 브라우저에는 AT-2를 받고, 저장합니다. AT-2는 즉시 만료되도록 되어있으므로 제거됩니다. AT-1는 이와 무관하므로, 그대로 존재합니다.

이러한 이유로 쿠키 값들이 살아있던 것이라는 가설을 세울 수 있습니다.

### 
- 제 가설이 맞다는 것을 증명하기 위해 쿠키 무효화 로직을 다음과 같이 수정하겠습니다.
```java
public void deleteCookie(jakarta.servlet.http.Cookie cookie, HttpServletResponse response) {
    cookie.setPath("/");
    cookie.setValue(".");
    cookie.setMaxAge(100000); // 만료되지 않도록 설정
    response.addCookie(cookie);
}
```
- 원래는 maxAge를 0으로 설정하여 바로 만료되도록 했습니다. 하지만 변경된 로직에서는 maxAge가 0이 아니므로, 바로 만료되지 않습니다.
- 원래였다면, `AT-1` 및 `RT-1` 은 그대로 존재하고, 서버에서는 `AT-2`와 `RT-2`를 보내며, 이 `AT-2` 와 `RT-2`는 즉시 만료되므로, 브라우저 상에서는 마치 `AT-1`과 `RT-1`이 제거되지 않는 것처럼 보였을 것입니다.
- 제 가설이 맞다면, 변경된 로직에서는 `AT-2`와 `RT-2`가 즉시 만료되지 않으므로, 두 쌍의 쿠키가 공존하는 상황이 만들어질 것입니다.
- 로그인 후
<img width="758" alt="image" src="https://github.com/user-attachments/assets/f4e15b8b-67eb-4bee-99cf-47ff535f0f27">

- 로그아웃 후
<img width="916" alt="image" src="https://github.com/user-attachments/assets/093fea6b-a5c3-4a8d-9fc0-90a8ad815532">

- 가설이 맞았다는 것을 확인할 수 있습니다.

### 해결책
```java
public void deleteCookie(jakarta.servlet.http.Cookie cookie, HttpServletResponse response) {
    cookie.setPath("/");
    cookie.setValue("");
    cookie.setMaxAge(0);
    cookie.setDomain(ROOT_DOMAIN);
    response.addCookie(cookie);
}
```
- 우리가 덮어쓰려고 하는 쿠키를 제대로 식별할 수 있게 도메인을 넣어주면 됩니다.
<img width="1114" alt="image" src="https://github.com/user-attachments/assets/3b3b5896-8d13-4dc6-b4f1-79b70fdc2f7d">

- 로그아웃 후에는 쿠키가 잘 지워지는 것을 보실 수 있습니다.

## 📝 참고사항
-

## 📚 기타
-
