### PR TITLE
feat: 가장 최신 깃허브 과제 제출이력 조회 기능 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryService.java
@@ -13,7 +13,7 @@ import com.gdschongik.gdsc.domain.study.dto.request.RepositoryUpdateRequest;
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentHistoryResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
-import com.gdschongik.gdsc.infra.client.github.GithubClient;
+import com.gdschongik.gdsc.infra.github.client.GithubClient;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionStatus.java
@@ -9,7 +9,7 @@ public enum AssignmentSubmissionStatus {
     PENDING("제출 전"),
     FAILURE("제출 실패"),
     SUCCESS("제출 성공"),
-    CANCELLED("과제 휴강");
+    CANCELLED("과제 휴강"); // TODO: 제거 및 DB에서 삭제
 
     private final String value;
 }

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/GithubConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/GithubConstant.java
@@ -3,6 +3,7 @@ package com.gdschongik.gdsc.global.common.constant;
 public class GithubConstant {
 
     public static final String GITHUB_DOMAIN = "github.com/";
+    public static final String GITHUB_ASSIGNMENT_PATH = "week%d/WIL.md";
 
     private GithubConstant() {}
 }

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -148,7 +148,9 @@ public enum ErrorCode {
     ASSIGNMENT_DEADLINE_INVALID(HttpStatus.CONFLICT, "과제 마감 기한이 현재보다 빠릅니다."),
 
     // Github
-    GITHUB_REPOSITORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 레포지토리입니다.");
+    GITHUB_REPOSITORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 레포지토리입니다."),
+    GITHUB_ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 과제 파일입니다."),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
@@ -1,4 +1,4 @@
-package com.gdschongik.gdsc.infra.client.github;
+package com.gdschongik.gdsc.infra.github.client;
 
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;

--- a/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
@@ -1,9 +1,16 @@
 package com.gdschongik.gdsc.infra.github.client;
 
+import static com.gdschongik.gdsc.global.common.constant.GithubConstant.*;
+
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
+import com.gdschongik.gdsc.infra.github.dto.response.GithubAssignmentSubmissionResponse;
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
+import org.kohsuke.github.GHCommit;
+import org.kohsuke.github.GHContent;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 import org.springframework.stereotype.Component;
@@ -19,6 +26,33 @@ public class GithubClient {
             return github.getRepository(ownerRepo);
         } catch (IOException e) {
             throw new CustomException(ErrorCode.GITHUB_REPOSITORY_NOT_FOUND);
+        }
+    }
+
+    public GithubAssignmentSubmissionResponse getLatestAssignmentSubmission(String repo, int week) {
+        try {
+            GHRepository ghRepository = getRepository(repo);
+            String assignmentPath = GITHUB_ASSIGNMENT_PATH.formatted(week);
+
+            GHContent ghContent = ghRepository.getFileContent(assignmentPath);
+            String content = new String(ghContent.read().readAllBytes());
+
+            GHCommit ghLatestCommit = ghRepository
+                    .queryCommits()
+                    .path(assignmentPath)
+                    .list()
+                    .toList()
+                    .get(0);
+
+            LocalDateTime committedAt = ghLatestCommit
+                    .getCommitDate()
+                    .toInstant()
+                    .atZone(ZoneId.systemDefault())
+                    .toLocalDateTime();
+
+            return new GithubAssignmentSubmissionResponse(content.length(), committedAt);
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.GITHUB_ASSIGNMENT_NOT_FOUND);
         }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
@@ -51,7 +51,7 @@ public class GithubClient {
                     .atZone(ZoneId.systemDefault())
                     .toLocalDateTime();
 
-            return new GithubAssignmentSubmissionResponse(content.length(), committedAt);
+            return new GithubAssignmentSubmissionResponse(ghLatestCommit.getSHA1(), content.length(), committedAt);
         } catch (IOException e) {
             throw new CustomException(ErrorCode.GITHUB_ASSIGNMENT_NOT_FOUND);
         }

--- a/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
@@ -34,6 +34,7 @@ public class GithubClient {
             GHRepository ghRepository = getRepository(repo);
             String assignmentPath = GITHUB_ASSIGNMENT_PATH.formatted(week);
 
+            // GHContent#getSize() 의 경우 한글 문자열을 byte 단위로 계산하기 때문에, 직접 content를 읽어서 길이를 계산
             GHContent ghContent = ghRepository.getFileContent(assignmentPath);
             String content = new String(ghContent.read().readAllBytes());
 

--- a/src/main/java/com/gdschongik/gdsc/infra/github/dto/response/GithubAssignmentSubmissionResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/dto/response/GithubAssignmentSubmissionResponse.java
@@ -1,0 +1,5 @@
+package com.gdschongik.gdsc.infra.github.dto.response;
+
+import java.time.LocalDateTime;
+
+public record GithubAssignmentSubmissionResponse(Integer size, LocalDateTime committedAt) {}

--- a/src/main/java/com/gdschongik/gdsc/infra/github/dto/response/GithubAssignmentSubmissionResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/dto/response/GithubAssignmentSubmissionResponse.java
@@ -2,4 +2,4 @@ package com.gdschongik.gdsc.infra.github.dto.response;
 
 import java.time.LocalDateTime;
 
-public record GithubAssignmentSubmissionResponse(Integer size, LocalDateTime committedAt) {}
+public record GithubAssignmentSubmissionResponse(String commitHash, Integer size, LocalDateTime committedAt) {}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,3 +17,4 @@ logging:
   level:
     org.springframework.orm.jpa: DEBUG
     org.springframework.transaction: DEBUG
+    org.kohsuke.github: debug


### PR DESCRIPTION
## 🌱 관련 이슈
- close #625

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - GitHub 클라이언트를 통해 GitHub 리포지토리와 과제 제출 정보를 조회하는 기능 추가.
  - 주차별 과제 경로를 위한 새로운 상수 `GITHUB_ASSIGNMENT_PATH` 추가.
  - GitHub 과제 제출 정보를 포함하는 새로운 데이터 클래스 `GithubAssignmentSubmissionResponse` 도입.
  - 새로운 오류 코드 `GITHUB_ASSIGNMENT_NOT_FOUND` 추가로 과제 파일 누락 처리 향상.

- **Bug Fixes**
  - `CANCELLED` 상태를 향후 삭제할 예정이라는 주석 추가.

- **Chores**
  - GitHub API 관련 로그 레벨을 `debug`로 설정하여 디버깅 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->