### PR TITLE
feat: 과제 제출하기 1차 로직 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryService.java
@@ -90,7 +90,7 @@ public class StudentStudyHistoryService {
 
         AssignmentHistory assignmentHistory = findOrCreate(currentMember, studyDetail);
 
-        studyAssignmentHistoryValidator.validateSubmitAvailable(isAppliedToStudy, now, assignmentHistory);
+        studyAssignmentHistoryValidator.validateSubmitAvailable(isAppliedToStudy, now, studyDetail);
 
         // TODO: 과제 채점 및 과제이력 업데이트 로직 추가
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryService.java
@@ -90,7 +90,7 @@ public class StudentStudyHistoryService {
 
         AssignmentHistory assignmentHistory = findOrCreate(isAppliedToStudy, now, currentMember, studyDetail);
 
-        studyAssignmentHistoryValidator.validateSubmit(isAppliedToStudy, now, assignmentHistory);
+        studyAssignmentHistoryValidator.validateSubmitAvailable(isAppliedToStudy, now, assignmentHistory);
 
         // TODO: 과제 채점 및 과제이력 업데이트 로직 추가
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryService.java
@@ -88,7 +88,7 @@ public class StudentStudyHistoryService {
         boolean isAppliedToStudy = studyHistoryRepository.existsByMenteeAndStudy(currentMember, studyDetail.getStudy());
         LocalDateTime now = LocalDateTime.now();
 
-        AssignmentHistory assignmentHistory = findOrCreate(isAppliedToStudy, now, currentMember, studyDetail);
+        AssignmentHistory assignmentHistory = findOrCreate(currentMember, studyDetail);
 
         studyAssignmentHistoryValidator.validateSubmitAvailable(isAppliedToStudy, now, assignmentHistory);
 
@@ -97,16 +97,9 @@ public class StudentStudyHistoryService {
         assignmentHistoryRepository.save(assignmentHistory);
     }
 
-    private AssignmentHistory findOrCreate(
-            boolean isAppliedToStudy, LocalDateTime now, Member currentMember, StudyDetail studyDetail) {
+    private AssignmentHistory findOrCreate(Member currentMember, StudyDetail studyDetail) {
         return assignmentHistoryRepository
                 .findByMemberAndStudyDetail(currentMember, studyDetail)
-                .orElseGet(() -> createAssignmentHistory(isAppliedToStudy, now, studyDetail, currentMember));
-    }
-
-    private AssignmentHistory createAssignmentHistory(
-            boolean isAppliedToStudy, LocalDateTime now, StudyDetail studyDetail, Member currentMember) {
-        studyAssignmentHistoryValidator.validateCreateAssignmentHistory(isAppliedToStudy, now, studyDetail);
-        return AssignmentHistory.create(studyDetail, currentMember);
+                .orElseGet(() -> AssignmentHistory.create(studyDetail, currentMember));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryRepository.java
@@ -1,7 +1,12 @@
 package com.gdschongik.gdsc.domain.study.dao;
 
+import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
+import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AssignmentHistoryRepository
-        extends JpaRepository<AssignmentHistory, Long>, AssignmentHistoryCustomRepository {}
+        extends JpaRepository<AssignmentHistory, Long>, AssignmentHistoryCustomRepository {
+    public Optional<AssignmentHistory> findByMemberAndStudyDetail(Member member, StudyDetail studyDetail);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryRepository.java
@@ -13,4 +13,6 @@ public interface StudyHistoryRepository extends JpaRepository<StudyHistory, Long
     List<StudyHistory> findAllByMentee(Member member);
 
     Optional<StudyHistory> findByMenteeAndStudy(Member member, Study study);
+
+    boolean existsByMenteeAndStudy(Member member, Study study);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
@@ -64,14 +64,10 @@ public class AssignmentHistory extends BaseEntity {
         this.submissionStatus = submissionStatus;
     }
 
-    public static AssignmentHistory create(
-            StudyDetail studyDetail, Member member, String submissionLink, String commitHash, Long contentLength) {
+    public static AssignmentHistory create(StudyDetail studyDetail, Member member) {
         return AssignmentHistory.builder()
                 .studyDetail(studyDetail)
                 .member(member)
-                .submissionLink(submissionLink)
-                .commitHash(commitHash)
-                .contentLength(contentLength)
                 .submissionStatus(AssignmentSubmissionStatus.PENDING)
                 .build();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
@@ -12,13 +12,11 @@ public class StudyAssignmentHistoryValidator {
     /**
      * 채점을 수행하기 전, 과제 제출이 가능한지 검증합니다.
      */
-    public void validateSubmitAvailable(
-            boolean isAppliedToStudy, LocalDateTime now, AssignmentHistory assignmentHistory) {
+    public void validateSubmitAvailable(boolean isAppliedToStudy, LocalDateTime now, StudyDetail studyDetail) {
         if (!isAppliedToStudy) {
             throw new CustomException(ASSIGNMENT_STUDY_NOT_APPLIED);
         }
 
-        StudyDetail studyDetail = assignmentHistory.getStudyDetail();
         studyDetail.validateAssignmentSubmittable(now);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
@@ -12,4 +12,12 @@ public class StudyAssignmentHistoryValidator {
     public void validateCreateAssignmentHistory(LocalDateTime now, StudyDetail studyDetail) {
         studyDetail.validateAssignmentSubmittable(now);
     }
+
+    /**
+     * 채점을 수행하기 전, 과제 제출이 가능한지 검증합니다.
+     */
+    public void validateSubmit(LocalDateTime now, AssignmentHistory assignmentHistory) {
+        StudyDetail studyDetail = assignmentHistory.getStudyDetail();
+        studyDetail.validateAssignmentSubmittable(now);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
@@ -17,6 +17,8 @@ public class StudyAssignmentHistoryValidator {
             throw new CustomException(ASSIGNMENT_STUDY_NOT_APPLIED);
         }
 
+        // TODO: 과제 시작기간 이전에 생성하는 경우도 고려해야 함
+
         studyDetail.validateAssignmentSubmittable(now);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
@@ -19,7 +19,7 @@ public class StudyAssignmentHistoryValidator {
         }
 
         if (now.isBefore(assignmentHistory.getStudyDetail().getPeriod().getStartDate())) {
-            throw new CustomException(ASSIGNMENT_NOT_STARTED);
+            throw new CustomException(ASSIGNMENT_SUBMIT_NOT_STARTED);
         }
 
         StudyDetail studyDetail = assignmentHistory.getStudyDetail();

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
@@ -18,10 +18,6 @@ public class StudyAssignmentHistoryValidator {
             throw new CustomException(ASSIGNMENT_STUDY_NOT_APPLIED);
         }
 
-        if (now.isBefore(assignmentHistory.getStudyDetail().getPeriod().getStartDate())) {
-            throw new CustomException(ASSIGNMENT_SUBMIT_NOT_STARTED);
-        }
-
         StudyDetail studyDetail = assignmentHistory.getStudyDetail();
         studyDetail.validateAssignmentSubmittable(now);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
@@ -1,0 +1,15 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import com.gdschongik.gdsc.global.annotation.DomainService;
+import java.time.LocalDateTime;
+
+@DomainService
+public class StudyAssignmentHistoryValidator {
+
+    /**
+     * 과제 제출 전, 빈 제출이력 생성이 가능한지 검증합니다.
+     */
+    public void validateCreateAssignmentHistory(LocalDateTime now, StudyDetail studyDetail) {
+        studyDetail.validateAssignmentSubmittable(now);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
@@ -10,21 +10,6 @@ import java.time.LocalDateTime;
 public class StudyAssignmentHistoryValidator {
 
     /**
-     * 과제 제출 전, 빈 제출이력 생성이 가능한지 검증합니다.
-     */
-    public void validateCreateAssignmentHistory(boolean isAppliedToStudy, LocalDateTime now, StudyDetail studyDetail) {
-        if (!isAppliedToStudy) {
-            throw new CustomException(ASSIGNMENT_STUDY_NOT_APPLIED);
-        }
-
-        if (now.isBefore(studyDetail.getPeriod().getStartDate())) {
-            throw new CustomException(ASSIGNMENT_NOT_STARTED);
-        }
-
-        studyDetail.validateAssignmentSubmittable(now);
-    }
-
-    /**
      * 채점을 수행하기 전, 과제 제출이 가능한지 검증합니다.
      */
     public void validateSubmitAvailable(

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
@@ -25,7 +25,8 @@ public class StudyAssignmentHistoryValidator {
     /**
      * 채점을 수행하기 전, 과제 제출이 가능한지 검증합니다.
      */
-    public void validateSubmitAvailable(boolean isAppliedToStudy, LocalDateTime now, AssignmentHistory assignmentHistory) {
+    public void validateSubmitAvailable(
+            boolean isAppliedToStudy, LocalDateTime now, AssignmentHistory assignmentHistory) {
         if (!isAppliedToStudy) {
             throw new CustomException(ASSIGNMENT_STUDY_NOT_APPLIED);
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
@@ -1,6 +1,9 @@
 package com.gdschongik.gdsc.domain.study.domain;
 
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
 import com.gdschongik.gdsc.global.annotation.DomainService;
+import com.gdschongik.gdsc.global.exception.CustomException;
 import java.time.LocalDateTime;
 
 @DomainService
@@ -9,14 +12,21 @@ public class StudyAssignmentHistoryValidator {
     /**
      * 과제 제출 전, 빈 제출이력 생성이 가능한지 검증합니다.
      */
-    public void validateCreateAssignmentHistory(LocalDateTime now, StudyDetail studyDetail) {
+    public void validateCreateAssignmentHistory(boolean isAppliedToStudy, LocalDateTime now, StudyDetail studyDetail) {
+        if (!isAppliedToStudy) {
+            throw new CustomException(ASSIGNMENT_STUDY_NOT_APPLIED);
+        }
+
         studyDetail.validateAssignmentSubmittable(now);
     }
 
     /**
      * 채점을 수행하기 전, 과제 제출이 가능한지 검증합니다.
      */
-    public void validateSubmit(LocalDateTime now, AssignmentHistory assignmentHistory) {
+    public void validateSubmit(boolean isAppliedToStudy, LocalDateTime now, AssignmentHistory assignmentHistory) {
+        if (!isAppliedToStudy) {
+            throw new CustomException(ASSIGNMENT_STUDY_NOT_APPLIED);
+        }
         StudyDetail studyDetail = assignmentHistory.getStudyDetail();
         studyDetail.validateAssignmentSubmittable(now);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
@@ -23,7 +23,7 @@ public class StudyAssignmentHistoryValidator {
     /**
      * 채점을 수행하기 전, 과제 제출이 가능한지 검증합니다.
      */
-    public void validateSubmit(boolean isAppliedToStudy, LocalDateTime now, AssignmentHistory assignmentHistory) {
+    public void validateSubmitAvailable(boolean isAppliedToStudy, LocalDateTime now, AssignmentHistory assignmentHistory) {
         if (!isAppliedToStudy) {
             throw new CustomException(ASSIGNMENT_STUDY_NOT_APPLIED);
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidator.java
@@ -17,7 +17,9 @@ public class StudyAssignmentHistoryValidator {
             throw new CustomException(ASSIGNMENT_STUDY_NOT_APPLIED);
         }
 
-        // TODO: 과제 시작기간 이전에 생성하는 경우도 고려해야 함
+        if (now.isBefore(studyDetail.getPeriod().getStartDate())) {
+            throw new CustomException(ASSIGNMENT_NOT_STARTED);
+        }
 
         studyDetail.validateAssignmentSubmittable(now);
     }
@@ -30,6 +32,11 @@ public class StudyAssignmentHistoryValidator {
         if (!isAppliedToStudy) {
             throw new CustomException(ASSIGNMENT_STUDY_NOT_APPLIED);
         }
+
+        if (now.isBefore(assignmentHistory.getStudyDetail().getPeriod().getStartDate())) {
+            throw new CustomException(ASSIGNMENT_NOT_STARTED);
+        }
+
         StudyDetail studyDetail = assignmentHistory.getStudyDetail();
         studyDetail.validateAssignmentSubmittable(now);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
@@ -82,4 +82,8 @@ public class StudyDetail extends BaseEntity {
     public void updateAssignment(String title, LocalDateTime deadLine, String descriptionNotionLink) {
         assignment = Assignment.generateAssignment(title, deadLine, descriptionNotionLink);
     }
+
+    public void validateAssignmentSubmittable(LocalDateTime now) {
+        assignment.validateSubmittable(now);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
@@ -1,9 +1,12 @@
 package com.gdschongik.gdsc.domain.study.domain;
 
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
 import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.domain.study.domain.vo.Assignment;
 import com.gdschongik.gdsc.domain.study.domain.vo.Session;
+import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -93,6 +96,9 @@ public class StudyDetail extends BaseEntity {
     }
 
     public void validateAssignmentSubmittable(LocalDateTime now) {
+        if (now.isBefore(period.getStartDate())) {
+            throw new CustomException(ASSIGNMENT_SUBMIT_NOT_STARTED);
+        }
         assignment.validateSubmittable(now);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
@@ -6,6 +6,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.study.domain.Difficulty;
 import com.gdschongik.gdsc.domain.study.domain.StudyStatus;
+import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
@@ -64,5 +65,19 @@ public class Assignment {
                 .descriptionLink(descriptionLink)
                 .status(StudyStatus.OPEN)
                 .build();
+    }
+
+    public void validateSubmittable(LocalDateTime now) {
+        if (status == NONE) {
+            throw new CustomException(ASSIGNMENT_SUBMIT_NOT_PUBLISHED);
+        }
+
+        if (status == CANCELLED) {
+            throw new CustomException(ASSIGNMENT_SUBMIT_CANCELLED);
+        }
+
+        if (now.isAfter(deadline)) {
+            throw new CustomException(ASSIGNMENT_SUBMIT_DEADLINE_PASSED);
+        }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -115,6 +115,7 @@ public enum ErrorCode {
 
     // StudyHistory
     STUDY_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 수강 기록입니다."),
+    STUDY_HISTORY_NOT_APPLIED(HttpStatus.CONFLICT, "해당 스터디에 대한 수강신청 기록이 존재하지 않습니다."),
     STUDY_HISTORY_DUPLICATE(HttpStatus.CONFLICT, "이미 해당 스터디를 신청했습니다."),
     STUDY_HISTORY_ONGOING_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 진행중인 스터디가 있습니다."),
     STUDY_HISTORY_REPOSITORY_NOT_UPDATABLE_ASSIGNMENT_ALREADY_SUBMITTED(

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -147,6 +147,7 @@ public enum ErrorCode {
     ASSIGNMENT_CAN_NOT_BE_UPDATED(HttpStatus.CONFLICT, "휴강인 과제는 수정할 수 없습니다."),
     ASSIGNMENT_DEADLINE_INVALID(HttpStatus.CONFLICT, "과제 마감 기한이 현재보다 빠릅니다."),
     ASSIGNMENT_STUDY_NOT_APPLIED(HttpStatus.CONFLICT, "해당 스터디에 대한 수강신청 기록이 존재하지 않습니다."),
+    ASSIGNMENT_NOT_STARTED(HttpStatus.CONFLICT, "아직 과제가 시작되지 않았습니다."),
     ASSIGNMENT_SUBMIT_NOT_PUBLISHED(HttpStatus.CONFLICT, "아직 과제가 등록되지 않았습니다."),
     ASSIGNMENT_SUBMIT_CANCELLED(HttpStatus.CONFLICT, "과제 휴강 주간에는 과제를 제출할 수 없습니다."),
     ASSIGNMENT_SUBMIT_DEADLINE_PASSED(HttpStatus.CONFLICT, "과제 마감 기한이 지났습니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -146,6 +146,9 @@ public enum ErrorCode {
     // Assignment
     ASSIGNMENT_CAN_NOT_BE_UPDATED(HttpStatus.CONFLICT, "휴강인 과제는 수정할 수 없습니다."),
     ASSIGNMENT_DEADLINE_INVALID(HttpStatus.CONFLICT, "과제 마감 기한이 현재보다 빠릅니다."),
+    ASSIGNMENT_SUBMIT_NOT_PUBLISHED(HttpStatus.CONFLICT, "아직 과제가 등록되지 않았습니다."),
+    ASSIGNMENT_SUBMIT_CANCELLED(HttpStatus.CONFLICT, "과제 휴강 주간에는 과제를 제출할 수 없습니다."),
+    ASSIGNMENT_SUBMIT_DEADLINE_PASSED(HttpStatus.CONFLICT, "과제 마감 기한이 지났습니다."),
 
     // Github
     GITHUB_REPOSITORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 레포지토리입니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -151,7 +151,7 @@ public enum ErrorCode {
     ASSIGNMENT_CAN_NOT_BE_UPDATED(HttpStatus.CONFLICT, "휴강인 과제는 수정할 수 없습니다."),
     ASSIGNMENT_DEADLINE_INVALID(HttpStatus.CONFLICT, "과제 마감 기한이 현재보다 빠릅니다."),
     ASSIGNMENT_STUDY_NOT_APPLIED(HttpStatus.CONFLICT, "해당 스터디에 대한 수강신청 기록이 존재하지 않습니다."),
-    ASSIGNMENT_NOT_STARTED(HttpStatus.CONFLICT, "아직 과제가 시작되지 않았습니다."),
+    ASSIGNMENT_SUBMIT_NOT_STARTED(HttpStatus.CONFLICT, "아직 과제가 시작되지 않았습니다."),
     ASSIGNMENT_SUBMIT_NOT_PUBLISHED(HttpStatus.CONFLICT, "아직 과제가 등록되지 않았습니다."),
     ASSIGNMENT_SUBMIT_CANCELLED(HttpStatus.CONFLICT, "과제 휴강 주간에는 과제를 제출할 수 없습니다."),
     ASSIGNMENT_SUBMIT_DEADLINE_PASSED(HttpStatus.CONFLICT, "과제 마감 기한이 지났습니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -115,7 +115,6 @@ public enum ErrorCode {
 
     // StudyHistory
     STUDY_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 수강 기록입니다."),
-    STUDY_HISTORY_NOT_APPLIED(HttpStatus.CONFLICT, "해당 스터디에 대한 수강신청 기록이 존재하지 않습니다."),
     STUDY_HISTORY_DUPLICATE(HttpStatus.CONFLICT, "이미 해당 스터디를 신청했습니다."),
     STUDY_HISTORY_ONGOING_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 진행중인 스터디가 있습니다."),
     STUDY_HISTORY_REPOSITORY_NOT_UPDATABLE_ASSIGNMENT_ALREADY_SUBMITTED(
@@ -147,6 +146,7 @@ public enum ErrorCode {
     // Assignment
     ASSIGNMENT_CAN_NOT_BE_UPDATED(HttpStatus.CONFLICT, "휴강인 과제는 수정할 수 없습니다."),
     ASSIGNMENT_DEADLINE_INVALID(HttpStatus.CONFLICT, "과제 마감 기한이 현재보다 빠릅니다."),
+    ASSIGNMENT_STUDY_NOT_APPLIED(HttpStatus.CONFLICT, "해당 스터디에 대한 수강신청 기록이 존재하지 않습니다."),
     ASSIGNMENT_SUBMIT_NOT_PUBLISHED(HttpStatus.CONFLICT, "아직 과제가 등록되지 않았습니다."),
     ASSIGNMENT_SUBMIT_CANCELLED(HttpStatus.CONFLICT, "과제 휴강 주간에는 과제를 제출할 수 없습니다."),
     ASSIGNMENT_SUBMIT_DEADLINE_PASSED(HttpStatus.CONFLICT, "과제 마감 기한이 지났습니다."),

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
@@ -23,11 +23,10 @@ class StudyAssignmentHistoryValidatorTest {
     }
 
     private Study createStudyWithMentor(Long mentorId) {
-        Member mentor = createMember(mentorId);
         Period period = Period.createPeriod(STUDY_START_DATETIME, STUDY_END_DATETIME);
         Period applicationPeriod =
                 Period.createPeriod(STUDY_START_DATETIME.minusDays(7), STUDY_START_DATETIME.minusDays(1));
-        return fixtureHelper.createStudy(mentor, period, applicationPeriod);
+        return fixtureHelper.createStudyWithMentor(mentorId, period, applicationPeriod);
     }
 
     private StudyDetail createStudyDetailWithAssignment(Study study) {

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
@@ -36,67 +36,6 @@ class StudyAssignmentHistoryValidatorTest {
     }
 
     @Nested
-    class 과제_제출이력_생성_검증할때 {
-
-        @Test
-        void 스터디_수강신청_기록이_없다면_실패한다() {
-            // given
-            Study study = createStudyWithMentor(1L);
-            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
-            boolean isAppliedToStudy = false;
-
-            // when & then
-            assertThatThrownBy(() -> validator.validateCreateAssignmentHistory(
-                            isAppliedToStudy, STUDY_DETAIL_START_DATETIME, studyDetail))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(ASSIGNMENT_STUDY_NOT_APPLIED.getMessage());
-        }
-
-        @Test
-        void 과제가_시작되지_않았다면_실패한다() {
-            // given
-            Study study = createStudyWithMentor(1L);
-            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
-            boolean isAppliedToStudy = true;
-            LocalDateTime beforeStart = STUDY_DETAIL_START_DATETIME.minusDays(1);
-
-            // when & then
-            assertThatThrownBy(
-                            () -> validator.validateCreateAssignmentHistory(isAppliedToStudy, beforeStart, studyDetail))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(ASSIGNMENT_NOT_STARTED.getMessage());
-        }
-
-        @Test
-        void 과제_마감기한이_지났다면_실패한다() {
-            // given
-            Study study = createStudyWithMentor(1L);
-            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
-            boolean isAppliedToStudy = true;
-            LocalDateTime afterDeadline = STUDY_ASSIGNMENT_DEADLINE_DATETIME.plusDays(1);
-
-            // when & then
-            assertThatThrownBy(() ->
-                            validator.validateCreateAssignmentHistory(isAppliedToStudy, afterDeadline, studyDetail))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(ASSIGNMENT_SUBMIT_DEADLINE_PASSED.getMessage());
-        }
-
-        @Test
-        void 모든_조건을_만족하는_경우_성공한다() {
-            // given
-            Study study = createStudyWithMentor(1L);
-            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
-            boolean isAppliedToStudy = true;
-
-            // when & then
-            assertThatCode(() -> validator.validateCreateAssignmentHistory(
-                            isAppliedToStudy, STUDY_DETAIL_START_DATETIME, studyDetail))
-                    .doesNotThrowAnyException();
-        }
-    }
-
-    @Nested
     class 과제_제출가능_여부_검증할때 {
 
         @Test
@@ -124,8 +63,7 @@ class StudyAssignmentHistoryValidatorTest {
             LocalDateTime beforeStart = STUDY_DETAIL_START_DATETIME.minusDays(1);
 
             // when & then
-            assertThatThrownBy(
-                            () -> validator.validateCreateAssignmentHistory(isAppliedToStudy, beforeStart, studyDetail))
+            assertThatThrownBy(() -> validator.validateSubmitAvailable(isAppliedToStudy, beforeStart, studyDetail))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ASSIGNMENT_NOT_STARTED.getMessage());
         }

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
@@ -68,7 +68,7 @@ class StudyAssignmentHistoryValidatorTest {
             assertThatThrownBy(
                             () -> validator.validateSubmitAvailable(isAppliedToStudy, beforeStart, assignmentHistory))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(ASSIGNMENT_NOT_STARTED.getMessage());
+                    .hasMessage(ASSIGNMENT_SUBMIT_NOT_STARTED.getMessage());
         }
 
         @Test

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
@@ -41,14 +41,12 @@ class StudyAssignmentHistoryValidatorTest {
         void 스터디_수강신청_기록이_없다면_실패한다() {
             // given
             Study study = createStudyWithMentor(1L);
-            Member student = createMember(2L);
             StudyDetail studyDetail = createStudyDetailWithAssignment(study);
-            AssignmentHistory assignmentHistory = AssignmentHistory.create(studyDetail, student);
             boolean isAppliedToStudy = false;
 
             // when & then
             assertThatThrownBy(() -> validator.validateSubmitAvailable(
-                            isAppliedToStudy, STUDY_DETAIL_START_DATETIME, assignmentHistory))
+                            isAppliedToStudy, STUDY_DETAIL_START_DATETIME, studyDetail))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ASSIGNMENT_STUDY_NOT_APPLIED.getMessage());
         }
@@ -57,15 +55,12 @@ class StudyAssignmentHistoryValidatorTest {
         void 과제가_시작되지_않았다면_실패한다() {
             // given
             Study study = createStudyWithMentor(1L);
-            Member student = createMember(2L);
             StudyDetail studyDetail = createStudyDetailWithAssignment(study);
-            AssignmentHistory assignmentHistory = AssignmentHistory.create(studyDetail, student);
             boolean isAppliedToStudy = true;
             LocalDateTime beforeStart = STUDY_DETAIL_START_DATETIME.minusDays(1);
 
             // when & then
-            assertThatThrownBy(
-                            () -> validator.validateSubmitAvailable(isAppliedToStudy, beforeStart, assignmentHistory))
+            assertThatThrownBy(() -> validator.validateSubmitAvailable(isAppliedToStudy, beforeStart, studyDetail))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ASSIGNMENT_SUBMIT_NOT_STARTED.getMessage());
         }
@@ -74,15 +69,12 @@ class StudyAssignmentHistoryValidatorTest {
         void 과제_마감기한이_지났다면_실패한다() {
             // given
             Study study = createStudyWithMentor(1L);
-            Member student = createMember(2L);
             StudyDetail studyDetail = createStudyDetailWithAssignment(study);
-            AssignmentHistory assignmentHistory = AssignmentHistory.create(studyDetail, student);
             boolean isAppliedToStudy = true;
             LocalDateTime afterDeadline = STUDY_ASSIGNMENT_DEADLINE_DATETIME.plusDays(1);
 
             // when & then
-            assertThatThrownBy(
-                            () -> validator.validateSubmitAvailable(isAppliedToStudy, afterDeadline, assignmentHistory))
+            assertThatThrownBy(() -> validator.validateSubmitAvailable(isAppliedToStudy, afterDeadline, studyDetail))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ASSIGNMENT_SUBMIT_DEADLINE_PASSED.getMessage());
         }
@@ -91,14 +83,12 @@ class StudyAssignmentHistoryValidatorTest {
         void 모든_조건을_만족하는_경우_성공한다() {
             // given
             Study study = createStudyWithMentor(1L);
-            Member student = createMember(2L);
             StudyDetail studyDetail = createStudyDetailWithAssignment(study);
-            AssignmentHistory assignmentHistory = AssignmentHistory.create(studyDetail, student);
             boolean isAppliedToStudy = true;
 
             // when & then
             assertThatCode(() -> validator.validateSubmitAvailable(
-                            isAppliedToStudy, STUDY_DETAIL_START_DATETIME, assignmentHistory))
+                            isAppliedToStudy, STUDY_DETAIL_START_DATETIME, studyDetail))
                     .doesNotThrowAnyException();
         }
     }

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
@@ -1,0 +1,135 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.helper.FixtureHelper;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class StudyAssignmentHistoryValidatorTest {
+
+    private final FixtureHelper fixtureHelper = new FixtureHelper();
+    private final StudyAssignmentHistoryValidator validator = new StudyAssignmentHistoryValidator();
+
+    // FixtureHelper 래핑 메서드
+    private Member createMember(Long id) {
+        return fixtureHelper.createAssociateMember(id);
+    }
+
+    private Study createStudyWithMentor(Long mentorId) {
+        Member mentor = createMember(mentorId);
+        Period period = Period.createPeriod(STUDY_START_DATETIME, STUDY_END_DATETIME);
+        Period applicationPeriod =
+                Period.createPeriod(STUDY_START_DATETIME.minusDays(7), STUDY_START_DATETIME.minusDays(1));
+        return fixtureHelper.createStudy(mentor, period, applicationPeriod);
+    }
+
+    private StudyDetail createStudyDetailWithAssignment(Study study) {
+        return fixtureHelper.createStudyDetailWithAssignment(
+                study, STUDY_DETAIL_START_DATETIME, STUDY_DETAIL_END_DATETIME, STUDY_ASSIGNMENT_DEADLINE_DATETIME);
+    }
+
+    @Nested
+    class 과제_제출이력_생성_검증할때 {
+
+        @Test
+        void 스터디_수강신청_기록이_없다면_실패한다() {
+            // given
+            Study study = createStudyWithMentor(1L);
+            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
+            boolean isAppliedToStudy = false;
+
+            // when & then
+            assertThatThrownBy(() -> validator.validateCreateAssignmentHistory(
+                            isAppliedToStudy, STUDY_DETAIL_START_DATETIME, studyDetail))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ASSIGNMENT_STUDY_NOT_APPLIED.getMessage());
+        }
+
+        @Test
+        void 과제_마감기한이_지났다면_실패한다() {
+            // given
+            Study study = createStudyWithMentor(1L);
+            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
+            boolean isAppliedToStudy = true;
+            LocalDateTime afterDeadline = STUDY_ASSIGNMENT_DEADLINE_DATETIME.plusDays(1);
+
+            // when & then
+            assertThatThrownBy(() ->
+                            validator.validateCreateAssignmentHistory(isAppliedToStudy, afterDeadline, studyDetail))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ASSIGNMENT_SUBMIT_DEADLINE_PASSED.getMessage());
+        }
+
+        @Test
+        void 모든_조건을_만족하는_경우_성공한다() {
+            // given
+            Study study = createStudyWithMentor(1L);
+            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
+            boolean isAppliedToStudy = true;
+
+            // when & then
+            assertThatCode(() -> validator.validateCreateAssignmentHistory(
+                            isAppliedToStudy, STUDY_DETAIL_START_DATETIME, studyDetail))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    class 과제_제출가능_여부_검증할때 {
+
+        @Test
+        void 스터디에_신청하지_않은_경우_실패한다() {
+            // given
+            Study study = createStudyWithMentor(1L);
+            Member student = createMember(2L);
+            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
+            AssignmentHistory assignmentHistory = AssignmentHistory.create(studyDetail, student);
+            boolean isAppliedToStudy = false;
+
+            // when & then
+            assertThatThrownBy(() -> validator.validateSubmitAvailable(
+                            isAppliedToStudy, STUDY_DETAIL_START_DATETIME, assignmentHistory))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ASSIGNMENT_STUDY_NOT_APPLIED.getMessage());
+        }
+
+        @Test
+        void 과제_제출_기간이_지난_경우_실패한다() {
+            // given
+            Study study = createStudyWithMentor(1L);
+            Member student = createMember(2L);
+            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
+            AssignmentHistory assignmentHistory = AssignmentHistory.create(studyDetail, student);
+            boolean isAppliedToStudy = true;
+            LocalDateTime afterDeadline = STUDY_ASSIGNMENT_DEADLINE_DATETIME.plusDays(1);
+
+            // when & then
+            assertThatThrownBy(
+                            () -> validator.validateSubmitAvailable(isAppliedToStudy, afterDeadline, assignmentHistory))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ASSIGNMENT_SUBMIT_DEADLINE_PASSED.getMessage());
+        }
+
+        @Test
+        void 모든_조건을_만족하는_경우_성공한다() {
+            // given
+            Study study = createStudyWithMentor(1L);
+            Member student = createMember(2L);
+            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
+            AssignmentHistory assignmentHistory = AssignmentHistory.create(studyDetail, student);
+            boolean isAppliedToStudy = true;
+
+            // when & then
+            assertThatCode(() -> validator.validateSubmitAvailable(
+                            isAppliedToStudy, STUDY_DETAIL_START_DATETIME, assignmentHistory))
+                    .doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
@@ -100,7 +100,7 @@ class StudyAssignmentHistoryValidatorTest {
     class 과제_제출가능_여부_검증할때 {
 
         @Test
-        void 스터디에_신청하지_않은_경우_실패한다() {
+        void 스터디_수강신청_기록이_없다면_실패한다() {
             // given
             Study study = createStudyWithMentor(1L);
             Member student = createMember(2L);
@@ -131,7 +131,7 @@ class StudyAssignmentHistoryValidatorTest {
         }
 
         @Test
-        void 과제_제출_기간이_지난_경우_실패한다() {
+        void 과제_마감기한이_지났다면_실패한다() {
             // given
             Study study = createStudyWithMentor(1L);
             Member student = createMember(2L);

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
@@ -58,12 +58,15 @@ class StudyAssignmentHistoryValidatorTest {
         void 과제가_시작되지_않았다면_실패한다() {
             // given
             Study study = createStudyWithMentor(1L);
+            Member student = createMember(2L);
             StudyDetail studyDetail = createStudyDetailWithAssignment(study);
+            AssignmentHistory assignmentHistory = AssignmentHistory.create(studyDetail, student);
             boolean isAppliedToStudy = true;
             LocalDateTime beforeStart = STUDY_DETAIL_START_DATETIME.minusDays(1);
 
             // when & then
-            assertThatThrownBy(() -> validator.validateSubmitAvailable(isAppliedToStudy, beforeStart, studyDetail))
+            assertThatThrownBy(
+                            () -> validator.validateSubmitAvailable(isAppliedToStudy, beforeStart, assignmentHistory))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ASSIGNMENT_NOT_STARTED.getMessage());
         }

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
@@ -53,6 +53,21 @@ class StudyAssignmentHistoryValidatorTest {
         }
 
         @Test
+        void 과제가_시작되지_않았다면_실패한다() {
+            // given
+            Study study = createStudyWithMentor(1L);
+            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
+            boolean isAppliedToStudy = true;
+            LocalDateTime beforeStart = STUDY_DETAIL_START_DATETIME.minusDays(1);
+
+            // when & then
+            assertThatThrownBy(
+                            () -> validator.validateCreateAssignmentHistory(isAppliedToStudy, beforeStart, studyDetail))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ASSIGNMENT_NOT_STARTED.getMessage());
+        }
+
+        @Test
         void 과제_마감기한이_지났다면_실패한다() {
             // given
             Study study = createStudyWithMentor(1L);
@@ -98,6 +113,21 @@ class StudyAssignmentHistoryValidatorTest {
                             isAppliedToStudy, STUDY_DETAIL_START_DATETIME, assignmentHistory))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ASSIGNMENT_STUDY_NOT_APPLIED.getMessage());
+        }
+
+        @Test
+        void 과제가_시작되지_않았다면_실패한다() {
+            // given
+            Study study = createStudyWithMentor(1L);
+            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
+            boolean isAppliedToStudy = true;
+            LocalDateTime beforeStart = STUDY_DETAIL_START_DATETIME.minusDays(1);
+
+            // when & then
+            assertThatThrownBy(
+                            () -> validator.validateCreateAssignmentHistory(isAppliedToStudy, beforeStart, studyDetail))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ASSIGNMENT_NOT_STARTED.getMessage());
         }
 
         @Test

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/StudyConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/StudyConstant.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.global.common.constant;
 
 import com.gdschongik.gdsc.domain.study.domain.StudyType;
 import java.time.DayOfWeek;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public class StudyConstant {
@@ -20,4 +21,13 @@ public class StudyConstant {
     // Assignment
     public static final String ASSIGNMENT_TITLE = "testTitle";
     public static final String DESCRIPTION_LINK = "www.link.com";
+
+    // Study (2024-09-01 ~ 2024-10-27)
+    public static final LocalDateTime STUDY_START_DATETIME = LocalDateTime.of(2024, 9, 1, 0, 0);
+    public static final LocalDateTime STUDY_END_DATETIME = STUDY_START_DATETIME.plusWeeks(8);
+
+    // StudyDetail (1주차: 2024-09-01 ~ 2024-09-08)
+    public static final LocalDateTime STUDY_DETAIL_START_DATETIME = STUDY_START_DATETIME;
+    public static final LocalDateTime STUDY_DETAIL_END_DATETIME = STUDY_DETAIL_START_DATETIME.plusWeeks(1);
+    public static final LocalDateTime STUDY_ASSIGNMENT_DEADLINE_DATETIME = STUDY_DETAIL_END_DATETIME;
 }

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -1,7 +1,6 @@
 package com.gdschongik.gdsc.helper;
 
 import static com.gdschongik.gdsc.domain.member.domain.Department.*;
-import static com.gdschongik.gdsc.domain.member.domain.Member.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.SemesterConstant.*;
@@ -83,5 +82,12 @@ public class FixtureHelper {
 
     public StudyDetail createStudyDetail(Study study, LocalDateTime startDate, LocalDateTime endDate) {
         return StudyDetail.createStudyDetail(study, 1L, ATTENDANCE_NUMBER, Period.createPeriod(startDate, endDate));
+    }
+
+    public StudyDetail createStudyDetailWithAssignment(
+            Study study, LocalDateTime startDate, LocalDateTime endDate, LocalDateTime deadline) {
+        StudyDetail studyDetail = createStudyDetail(study, startDate, endDate);
+        studyDetail.publishAssignment(ASSIGNMENT_TITLE, deadline, DESCRIPTION_LINK);
+        return studyDetail;
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -81,6 +81,11 @@ public class FixtureHelper {
                 STUDY_END_TIME);
     }
 
+    public Study createStudyWithMentor(Long mentorId, Period period, Period applicationPeriod) {
+        Member mentor = createAssociateMember(mentorId);
+        return createStudy(mentor, period, applicationPeriod);
+    }
+
     public StudyDetail createStudyDetail(Study study, LocalDateTime startDate, LocalDateTime endDate) {
         return StudyDetail.createStudyDetail(study, 1L, ATTENDANCE_NUMBER, Period.createPeriod(startDate, endDate));
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #627

## 📌 작업 내용 및 특이사항
- 과제 제출하기 기능 중 validation 로직만 임시로 구현했습니다. (빈 과제이력 생성하기 + 과재 제출에 대한 검증)
- 채점 로직의 경우 PR 사이즈가 커질 것 같아 별도 브랜치에서 작업하려고 합니다.
- 아래는 PR에 대한 설명입니다.

### 빈 과제이력 생성
- 과제 제출의 경우 기본적으로 초기 제출 및 재제출 로직이 동일해야 합니다.
- 이를 위해서는 과제 이력이 '이미 존재한다'는 가정이 필요합니다.
- 따라서 `findOrCreate` 를 통해 존재하지 않는 경우 빈 과제이력을 생성하도록 했습니다.
- 이때 기존 `AssignmentHistory.create` 에서 과제 제출 관련 정보를 저장하기 않고 순수하게 빈 과제이력만을 만들도록 변경했습니다.

### 제출 관련 검증 유의사항
- 원래는 1) 빈 과제이력 생성 2) 과제 제출하기 두 가지 동작에 모두 validation을 수행하려고 했습니다.
- 하지만 어차피 빈 과제이력을 생성하고 나서 과제 제출하기를 거치기 때문에 중복하여 검증할 필요가 없다고 생각했고, 빈 과제이력은 별도의 검증을 거치지 않도록 했습니다.
- 단 여기서 문제가 생길 수 있는데요, 지금은 빈 과제이력을 생성하고 -> 제출하고 -> 저장하게 됩니다. 하지만 빈 과제이력을 생성하고 -> 저장하고 -> 제출한뒤 -> 다시 저장하게 되면 제출 시점에 validation이 실패하면 빈 과제이력이 생기는, 즉 무결성이 깨지는 상황이 발생합니다.
- 따라서 빈 과제이력을 생성하고 -> 제출하고 -> 모든 검증을 거친 뒤에 저장하도록 해야 합니다.

### 검증 로직 설명
- 스터디 수강신청 히스토리가 존재하지 않으면 실패합니다.
    - 정정기간에는 과제 수행한 후 -> 수강철회가 가능하기 때문에 매번 검증해야 합니다. (아주 중요한 고려사항입니다...!)
    - 만약 수강철회가 없다면... 빈 수강이력을 만들어놓고 이때만 수강신청 히스토리를 검증한 뒤 과제 제출 시에는 수강신청 검증은 제외했을 겁니다. 하지만 정정기간 케이스 때문에 이렇게 구현했습니다.
- 그 외에는 스터디상세 내부의 값과 관련된 검증이므로, 이는 스터디상세의 `validateSubmitAvailable(LocalDateTime)`을 통해 검증합니다.
    - 스터디상세의 `period`, 즉 해당 주차 시작 이전에 제출을 시도하는 경우 실패합니다. (시작시간 이전 제출)
    - 스터디상세 중 과제정보의 데드라인 이후에 제출을 시도하는 경우 실패합니다. (마감시간 이후 제출)

### 구현부에서 호출되는 `LocalDateTime.now()`를 지양하자
- 메서드 구현부에서 호출되는 `LocalDateTime.now()`는 사실 테스트를 어렵게 하는 주범입니다.
- 저는 어지간하면 도메인 레이어에서 이런 시간이 필요한 경우 `doSomething(LocalDateTime now)` 와 같이 해당 값을 인자로 받도록 구현합니다. 그리고 응용 레이어에서 `LocalDateTime.now()`를 선언하여 값을 전달하는 방식으로요.
- 이번에 validator 관련 테스트를 보시면 `LocalDateTime.now()` 를 전혀 사용하지 않고, `StudyConstant` 에서 2024년 9월 1일을 기준으로 테스트하는 것을 확인하실 수 있습니다.
- 만약 내부에서 `now()`를 호출하는 코드가 있었다면 이러한 방식의 테스트는 전혀 불가능했겠죠...?
- 다른 분들도 시간과 관련된 로직을 작성해야 하는 경우 이런 식으로 구현하시는 것을 추천드립니다...

### `FixtureHelper` 를 직접 호출하지 말자
- 다른 분들이 작성하시는 도메인 테스트를 보면 테스트 내부에서 직접 `fixtureHelper`를 호출하여 사용하고 계시더라고요.
- 어지간하면 해당 클래스에서 래핑하여 사용하는 것을 권장드립니다.
- 제가 작성한 `OrderValidatorTest` 나 이번에 작성한 `StudyAssignmentHistoryValidatorTest` 의 경우 이렇게 래핑하여 사용하고 있습니다.
- 래핑할 때의 이점은 '이 테스트 클래스'만의 픽스처를 생성해야 하는 경우 편리하다는 겁니다. 가령 A 테스트 클래스에서는 스터디 멘토를 변경해가며 테스트해야 하는 경우 헬퍼 내부에 하드코딩된 멘토 ID(가령 1L)을 지정하는 것이 어렵겠지만, 다른 B, C, D 케이스에서는 스터디 멘토가 1L 로 고정되어 있는 것이 편할 수도 있습니다.
- 이럴 때 각 테스트 클래스에서는 기본적으로 열려있는 픽스처 헬퍼를 불러오고, 각 상황마다 다르게 고정된 값을 인자로 전달하여 래핑함으로써 유연하게 테스트하실 수 있습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 과제 제출 기능이 추가되어, 학생이 특정 학습 세부정보에 따라 과제를 제출할 수 있습니다.
  - `AssignmentHistoryRepository`에서 멤버와 학습 세부정보에 따라 과제 이력을 검색할 수 있는 기능이 추가되었습니다.
  - `StudyAssignmentHistoryValidator`와 `StudyDetail` 클래스에 과제 제출 가능성을 검증하는 메서드가 추가되었습니다.
  - 다양한 오류 코드가 추가되어, 과제 제출 관련 오류를 보다 구체적으로 처리할 수 있습니다.

- **Bug Fixes**
  - 제출 가능성에 대한 검증 로직이 개선되어, 유효하지 않은 제출을 방지합니다. 

- **Tests**
  - `StudyAssignmentHistoryValidator`의 기능을 검증하는 단위 테스트가 추가되었습니다. 

- **Chores**
  - 새로운 상수 값이 추가되어, 학습 세션의 시작 및 종료 날짜를 명확히 정의하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->