### PR TITLE
feat: 과제 히스토리 도메인 로직 및 깃허브 클라이언트 로직 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
@@ -5,6 +5,8 @@ import static com.gdschongik.gdsc.domain.study.domain.SubmissionFailureType.*;
 
 import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.global.exception.CustomException;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -93,8 +95,11 @@ public class AssignmentHistory extends BaseEntity {
     }
 
     public void fail(SubmissionFailureType submissionFailureType) {
+        if (submissionFailureType == NOT_SUBMITTED) {
+            throw new CustomException()
+        }
+
         this.submissionStatus = FAILURE;
         this.submissionFailureType = submissionFailureType;
-        this.committedAt = null;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
@@ -89,6 +89,7 @@ public class AssignmentHistory extends BaseEntity {
         this.contentLength = contentLength;
         this.committedAt = committedAt;
         this.submissionStatus = SUCCESS;
+        this.submissionFailureType = NONE;
     }
 
     public void fail(SubmissionFailureType submissionFailureType) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
@@ -2,11 +2,11 @@ package com.gdschongik.gdsc.domain.study.domain;
 
 import static com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionStatus.*;
 import static com.gdschongik.gdsc.domain.study.domain.SubmissionFailureType.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.global.exception.CustomException;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -95,10 +95,14 @@ public class AssignmentHistory extends BaseEntity {
     }
 
     public void fail(SubmissionFailureType submissionFailureType) {
-        if (submissionFailureType == NOT_SUBMITTED) {
-            throw new CustomException()
+        if (submissionFailureType == NOT_SUBMITTED || submissionFailureType == NONE) {
+            throw new CustomException(ASSIGNMENT_INVALID_FAILURE_TYPE);
         }
 
+        this.submissionLink = null;
+        this.commitHash = null;
+        this.contentLength = null;
+        this.committedAt = null;
         this.submissionStatus = FAILURE;
         this.submissionFailureType = submissionFailureType;
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
@@ -57,15 +57,9 @@ public class AssignmentHistory extends BaseEntity {
     private AssignmentHistory(
             StudyDetail studyDetail,
             Member member,
-            String submissionLink,
-            String commitHash,
-            Long contentLength,
             AssignmentSubmissionStatus submissionStatus) {
         this.studyDetail = studyDetail;
         this.member = member;
-        this.submissionLink = submissionLink;
-        this.commitHash = commitHash;
-        this.contentLength = contentLength;
         this.submissionStatus = submissionStatus;
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
@@ -78,7 +78,7 @@ public class AssignmentHistory extends BaseEntity {
     // 데이터 조회 로직
 
     public boolean isSubmitted() {
-        return submissionStatus == SUCCESS || submissionStatus == FAILURE;
+        return submissionFailureType != NOT_SUBMITTED;
     }
 
     // 데이터 변경 로직

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
@@ -87,8 +87,8 @@ public class AssignmentHistory extends BaseEntity {
         this.submissionLink = submissionLink;
         this.commitHash = commitHash;
         this.contentLength = contentLength;
-        this.submissionStatus = SUCCESS;
         this.committedAt = committedAt;
+        this.submissionStatus = SUCCESS;
     }
 
     public void fail(SubmissionFailureType submissionFailureType) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.study.domain;
 
 import static com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionStatus.*;
+import static com.gdschongik.gdsc.domain.study.domain.SubmissionFailureType.*;
 
 import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.member.domain.Member;
@@ -57,10 +58,12 @@ public class AssignmentHistory extends BaseEntity {
     private AssignmentHistory(
             StudyDetail studyDetail,
             Member member,
-            AssignmentSubmissionStatus submissionStatus) {
+            AssignmentSubmissionStatus submissionStatus,
+            SubmissionFailureType submissionFailureType) {
         this.studyDetail = studyDetail;
         this.member = member;
         this.submissionStatus = submissionStatus;
+        this.submissionFailureType = submissionFailureType;
     }
 
     public static AssignmentHistory create(StudyDetail studyDetail, Member member) {
@@ -68,6 +71,7 @@ public class AssignmentHistory extends BaseEntity {
                 .studyDetail(studyDetail)
                 .member(member)
                 .submissionStatus(FAILURE)
+                .submissionFailureType(NOT_SUBMITTED)
                 .build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
@@ -14,6 +14,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -43,6 +44,8 @@ public class AssignmentHistory extends BaseEntity {
     private String commitHash;
 
     private Long contentLength;
+
+    private LocalDateTime committedAt;
 
     @Enumerated(EnumType.STRING)
     private AssignmentSubmissionStatus submissionStatus;
@@ -74,7 +77,25 @@ public class AssignmentHistory extends BaseEntity {
                 .build();
     }
 
+    // 데이터 조회 로직
+
     public boolean isSubmitted() {
         return submissionStatus == SUCCESS || submissionStatus == FAILURE;
+    }
+
+    // 데이터 변경 로직
+
+    public void success(String submissionLink, String commitHash, Long contentLength, LocalDateTime committedAt) {
+        this.submissionLink = submissionLink;
+        this.commitHash = commitHash;
+        this.contentLength = contentLength;
+        this.submissionStatus = SUCCESS;
+        this.committedAt = committedAt;
+    }
+
+    public void fail(SubmissionFailureType submissionFailureType) {
+        this.submissionStatus = FAILURE;
+        this.submissionFailureType = submissionFailureType;
+        this.committedAt = null;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
@@ -67,7 +67,7 @@ public class AssignmentHistory extends BaseEntity {
         return AssignmentHistory.builder()
                 .studyDetail(studyDetail)
                 .member(member)
-                .submissionStatus(AssignmentSubmissionStatus.PENDING)
+                .submissionStatus(FAILURE)
                 .build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionStatus.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum AssignmentSubmissionStatus {
+    // TODO: 클라이언트 응답에는 PENDING 상태 필요하므로, 추후 응답용 enum 클래스 생성 구현
     FAILURE("제출 실패"),
     SUCCESS("제출 성공");
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionStatus.java
@@ -8,8 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum AssignmentSubmissionStatus {
     PENDING("제출 전"),
     FAILURE("제출 실패"),
-    SUCCESS("제출 성공"),
-    CANCELLED("과제 휴강"); // TODO: 제거 및 DB에서 삭제
+    SUCCESS("제출 성공");
 
     private final String value;
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionStatus.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum AssignmentSubmissionStatus {
-    PENDING("제출 전"),
     FAILURE("제출 실패"),
     SUCCESS("제출 성공");
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/SubmissionFailureType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/SubmissionFailureType.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum SubmissionFailureType {
-    NOT_SUBMITTED("미제출"),
+    NONE("실패 없음"), // 제출상태 성공 시 사용
+    NOT_SUBMITTED("미제출"), // 기본값
     WORD_COUNT_INSUFFICIENT("글자수 부족"),
     LOCATION_UNIDENTIFIABLE("위치 확인불가");
 

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -158,6 +158,9 @@ public enum ErrorCode {
 
     // Github
     GITHUB_REPOSITORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 레포지토리입니다."),
+    GITHUB_CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 파일입니다."),
+    GITHUB_FILE_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "깃허브 파일 읽기에 실패했습니다."),
+    GITHUB_COMMIT_DATE_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "깃허브 커밋 날짜 조회에 실패했습니다."),
     GITHUB_ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 과제 파일입니다."),
     ;
 

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -148,6 +148,7 @@ public enum ErrorCode {
     ORDER_FINAL_PAYMENT_AMOUNT_MISMATCH(HttpStatus.CONFLICT, "주문 최종결제금액은 주문총액에서 할인금액을 뺀 값이어야 합니다."),
 
     // Assignment
+    ASSIGNMENT_INVALID_FAILURE_TYPE(HttpStatus.CONFLICT, "유효하지 않은 제출 실패사유입니다."),
     ASSIGNMENT_DEADLINE_INVALID(HttpStatus.CONFLICT, "과제 마감 기한이 현재보다 빠릅니다."),
     ASSIGNMENT_STUDY_NOT_APPLIED(HttpStatus.CONFLICT, "해당 스터디에 대한 수강신청 기록이 존재하지 않습니다."),
     ASSIGNMENT_SUBMIT_NOT_STARTED(HttpStatus.CONFLICT, "아직 과제가 시작되지 않았습니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -148,7 +148,6 @@ public enum ErrorCode {
     ORDER_FINAL_PAYMENT_AMOUNT_MISMATCH(HttpStatus.CONFLICT, "주문 최종결제금액은 주문총액에서 할인금액을 뺀 값이어야 합니다."),
 
     // Assignment
-    ASSIGNMENT_CAN_NOT_BE_UPDATED(HttpStatus.CONFLICT, "휴강인 과제는 수정할 수 없습니다."),
     ASSIGNMENT_DEADLINE_INVALID(HttpStatus.CONFLICT, "과제 마감 기한이 현재보다 빠릅니다."),
     ASSIGNMENT_STUDY_NOT_APPLIED(HttpStatus.CONFLICT, "해당 스터디에 대한 수강신청 기록이 존재하지 않습니다."),
     ASSIGNMENT_SUBMIT_NOT_STARTED(HttpStatus.CONFLICT, "아직 과제가 시작되지 않았습니다."),

--- a/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
@@ -1,13 +1,15 @@
 package com.gdschongik.gdsc.infra.github.client;
 
 import static com.gdschongik.gdsc.global.common.constant.GithubConstant.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.infra.github.dto.response.GithubAssignmentSubmissionResponse;
 import java.io.IOException;
+import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHContent;
@@ -25,7 +27,7 @@ public class GithubClient {
         try {
             return github.getRepository(ownerRepo);
         } catch (IOException e) {
-            throw new CustomException(ErrorCode.GITHUB_REPOSITORY_NOT_FOUND);
+            throw new CustomException(GITHUB_REPOSITORY_NOT_FOUND);
         }
     }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryTest.java
@@ -1,0 +1,165 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.helper.FixtureHelper;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class AssignmentHistoryTest {
+
+    FixtureHelper fixtureHelper = new FixtureHelper();
+
+    private Member createMember(Long id) {
+        return fixtureHelper.createAssociateMember(id);
+    }
+
+    private Study createStudyWithMentor(Long mentorId) {
+        Period period = Period.createPeriod(STUDY_START_DATETIME, STUDY_END_DATETIME);
+        Period applicationPeriod =
+                Period.createPeriod(STUDY_START_DATETIME.minusDays(7), STUDY_START_DATETIME.minusDays(1));
+        return fixtureHelper.createStudyWithMentor(mentorId, period, applicationPeriod);
+    }
+
+    private StudyDetail createStudyDetailWithAssignment(Study study) {
+        return fixtureHelper.createStudyDetailWithAssignment(
+                study, STUDY_DETAIL_START_DATETIME, STUDY_DETAIL_END_DATETIME, STUDY_ASSIGNMENT_DEADLINE_DATETIME);
+    }
+
+    @Nested
+    class 빈_과제이력_생성할때 {
+
+        @Test
+        void 제출상태는_FAILURE이다() {
+            // given
+            Member member = createMember(1L);
+            Study study = createStudyWithMentor(1L);
+            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
+
+            // when
+            AssignmentHistory assignmentHistory = AssignmentHistory.create(studyDetail, member);
+
+            // then
+            assertThat(assignmentHistory.getSubmissionStatus()).isEqualTo(AssignmentSubmissionStatus.FAILURE);
+        }
+
+        @Test
+        void 실패사유는_NOT_SUBMITTED이다() {
+            // given
+            Member member = createMember(1L);
+            Study study = createStudyWithMentor(1L);
+            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
+
+            // when
+            AssignmentHistory assignmentHistory = AssignmentHistory.create(studyDetail, member);
+
+            // then
+            assertThat(assignmentHistory.getSubmissionFailureType()).isEqualTo(SubmissionFailureType.NOT_SUBMITTED);
+        }
+    }
+
+    @Nested
+    class 과제이력_제출_성공할때 {
+
+        @Test
+        void 제출상태는_SUCCESS이다() {
+            // given
+            Member member = createMember(1L);
+            Study study = createStudyWithMentor(1L);
+            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
+            AssignmentHistory assignmentHistory = AssignmentHistory.create(studyDetail, member);
+
+            // when
+            assignmentHistory.success(SUBMISSION_LINK, COMMIT_HASH, CONTENT_LENGTH, COMMITTED_AT);
+        }
+
+        @Test
+        void 실패사유는_NONE이다() {
+            // given
+            Member member = createMember(1L);
+            Study study = createStudyWithMentor(1L);
+            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
+            AssignmentHistory assignmentHistory = AssignmentHistory.create(studyDetail, member);
+
+            // when
+            assignmentHistory.success(SUBMISSION_LINK, COMMIT_HASH, CONTENT_LENGTH, COMMITTED_AT);
+
+            // then
+            assertThat(assignmentHistory.getSubmissionFailureType()).isEqualTo(SubmissionFailureType.NONE);
+        }
+    }
+
+    @Nested
+    class 과제이력_제출_실패할때 {
+
+        @Test
+        void 제출상태는_FAILURE이다() {
+            // given
+            Member member = createMember(1L);
+            Study study = createStudyWithMentor(1L);
+            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
+            AssignmentHistory assignmentHistory = AssignmentHistory.create(studyDetail, member);
+            assignmentHistory.success(SUBMISSION_LINK, COMMIT_HASH, CONTENT_LENGTH, COMMITTED_AT);
+
+            // when
+            assignmentHistory.fail(SubmissionFailureType.WORD_COUNT_INSUFFICIENT);
+
+            // then
+            assertThat(assignmentHistory.getSubmissionStatus()).isEqualTo(AssignmentSubmissionStatus.FAILURE);
+        }
+
+        @Test
+        void 실패사유는_NOT_SUBMITTED가_될수없다() {
+            // given
+            Member member = createMember(1L);
+            Study study = createStudyWithMentor(1L);
+            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
+            AssignmentHistory assignmentHistory = AssignmentHistory.create(studyDetail, member);
+            assignmentHistory.success(SUBMISSION_LINK, COMMIT_HASH, CONTENT_LENGTH, COMMITTED_AT);
+
+            // when, then
+            assertThatThrownBy(() -> assignmentHistory.fail(SubmissionFailureType.NOT_SUBMITTED))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ASSIGNMENT_INVALID_FAILURE_TYPE.getMessage());
+        }
+
+        @Test
+        void 실패사유는_NONE이_될수없다() {
+            // given
+            Member member = createMember(1L);
+            Study study = createStudyWithMentor(1L);
+            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
+            AssignmentHistory assignmentHistory = AssignmentHistory.create(studyDetail, member);
+            assignmentHistory.success(SUBMISSION_LINK, COMMIT_HASH, CONTENT_LENGTH, COMMITTED_AT);
+
+            // when, then
+            assertThatThrownBy(() -> assignmentHistory.fail(SubmissionFailureType.NONE))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ASSIGNMENT_INVALID_FAILURE_TYPE.getMessage());
+        }
+
+        @Test
+        void 기존_제출정보는_삭제된다() {
+            // given
+            Member member = createMember(1L);
+            Study study = createStudyWithMentor(1L);
+            StudyDetail studyDetail = createStudyDetailWithAssignment(study);
+            AssignmentHistory assignmentHistory = AssignmentHistory.create(studyDetail, member);
+            assignmentHistory.success(SUBMISSION_LINK, COMMIT_HASH, CONTENT_LENGTH, COMMITTED_AT);
+
+            // when
+            assignmentHistory.fail(SubmissionFailureType.WORD_COUNT_INSUFFICIENT);
+
+            // then
+            assertThat(assignmentHistory.getSubmissionLink()).isNull();
+            assertThat(assignmentHistory.getCommitHash()).isNull();
+            assertThat(assignmentHistory.getContentLength()).isNull();
+            assertThat(assignmentHistory.getCommittedAt()).isNull();
+        }
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/StudyConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/StudyConstant.java
@@ -31,4 +31,10 @@ public class StudyConstant {
     public static final LocalDateTime STUDY_DETAIL_START_DATETIME = STUDY_START_DATETIME;
     public static final LocalDateTime STUDY_DETAIL_END_DATETIME = STUDY_DETAIL_START_DATETIME.plusWeeks(1);
     public static final LocalDateTime STUDY_ASSIGNMENT_DEADLINE_DATETIME = STUDY_DETAIL_END_DATETIME;
+
+    // AssignmentHistory
+    public static final String SUBMISSION_LINK = "https://github.com/ownername/reponame/blob/main/week1/WIL.md";
+    public static final String COMMIT_HASH = "aa11bb22cc33";
+    public static final Long CONTENT_LENGTH = 2000L;
+    public static final LocalDateTime COMMITTED_AT = LocalDateTime.of(2024, 9, 8, 0, 0);
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #637

## 📌 작업 내용 및 특이사항
- 과제 채점 로직을 구현하기 전에 과제 채점 후 성공 / 실패 / 실패사유 등을 업데이트할 과제 히스토리 도메인 로직들을 업데이트했습니다.
- 실제 채점 로직은 #640 에서 구현합니다
- 추가로, 깃허브 클라이언트에서 다양한 예외 케이스에 대한 에러코드를 추가했습니다.

### 로직 변경사항
- `PENDING` 상태가 제거되며 제출상태의 경우 `실패` 및 `성공` 상태만 존재합니다.
    - 이로 인해 제출여부 상태 조회 로직이 변경되었습니다. 
- 초기 제출상태는 `실패`입니다.
- 제출 실패사유의 경우 `NONE` 이 추가되었습니다. 제출상태가 `성공` 인 경우 이 상태를 사용합니다.
- 초기 제출 실패사유는 `NOT_SUBMITTED`가 됩니다. (기존에는 null)
- 제출 실패처리 시, 기존에 성공처리로 저장된 제출정보가 있는 경우 제거됩니다.

### `PENDING` 제거 및 분리
- 먼저, 제출상태 중 `PENDING`의 경우 DB 상에서만 제거되며, 클라이언트 응답을 내려줄 때 별도의 `SubmissionDisplayStatus` 와 같은 enum 클래스를 통해 변환되는 과정을 거치게 됩니다.
- 이렇게 한 이유가 있는데요... 먼저 기존에 초기값 `PENDING` 을 사용하는 경우, 마감기한 이후에는 `FAIL` 로 설정해줘야 합니다.
- 이를 위해서는 스케쥴러나 배치를 사용할 수 있습니다.
- 하지만 이러한 비즈니스 상태 관리를 외부 의존성인 스케쥴러나 배치에 의존하는 것은 바람직하지 못하다고 봤습니다. 배치 도입 비용도 있고, 우연히 스케쥴러가 도는 시간에 배포가 발생하여 무결성이 깨지는 상황 등이 생길 수 있습니다.
- 따라서 `PENDING` -> `FAIL` 배치가 필요하지 않도록 초기에 `FAIL` 로 시작하도록 하고, 대신 제출기한 도중에는 `PENDING`으로 조회되어야 하므로, DB에서 사용되는 enum과 클라이언트 응답에 사용되는 enum을 분리하기로 했습니다 (#638 에서 처리 예정)

### 깃허브 클라이언트 로직 관련
- 기존에는 모든 예외를 하나의 에러코드로 받았지만, 지금은 각각의 `IOException` 케이스를 잡아서 각기 다른 에러코드로 변환합니다.
- 이렇게 하면 문제 원인을 더 원할하게 파악할 수 있을 것으로 기대됩니다.

그 외 자세한 내용은 테스트로 확인 부탁드립니다

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 제출 상태를 관리하기 위한 `success` 및 `fail` 메서드 추가.
	- `committedAt` 필드를 통해 제출 타임스탬프 저장.
	- `AssignmentSubmissionStatus`에서 `PENDING` 및 `CANCELLED` 상태 제거, `NONE` 상태 추가.

- **버그 수정**
	- 제출 실패 유형에 대한 오류 코드 업데이트 및 추가.

- **테스트**
	- `AssignmentHistory` 클래스에 대한 유닛 테스트 추가로 커버리지 향상.

- **문서화**
	- `StudyConstant` 클래스에 새로운 상수 추가로 과제 제출 관련 메타데이터 제공.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->