### PR TITLE
feat: 스터디 공지 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -350,7 +350,11 @@ public class Member extends BaseEntity {
         return manageRole.equals(ADMIN);
     }
 
-    public boolean isMentor() { return studyRole.equals(MENTOR); }
+    public boolean isMentor() {
+        return studyRole.equals(MENTOR);
+    }
 
-    public boolean isStudent() { return studyRole.equals(STUDENT); }
+    public boolean isStudent() {
+        return studyRole.equals(STUDENT);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -350,7 +350,7 @@ public class Member extends BaseEntity {
         return manageRole.equals(ADMIN);
     }
 
-    public boolean isMentor() {
-        return studyRole.equals(MENTOR);
-    }
+    public boolean isMentor() { return studyRole.equals(MENTOR); }
+
+    public boolean isStudent() { return studyRole.equals(STUDENT); }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/CommonStudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/CommonStudyController.java
@@ -2,8 +2,10 @@ package com.gdschongik.gdsc.domain.study.api;
 
 import com.gdschongik.gdsc.domain.study.application.CommonStudyService;
 import com.gdschongik.gdsc.domain.study.dto.response.CommonStudyResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyAnnouncementResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,6 +25,13 @@ public class CommonStudyController {
     @GetMapping("/{studyId}")
     public ResponseEntity<CommonStudyResponse> getStudyInformation(@PathVariable Long studyId) {
         CommonStudyResponse response = commonStudyService.getStudyInformation(studyId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "스터디 공지 목록 조회", description = "스터디 공지 목록을 조회합니다.")
+    @GetMapping("/{studyId}/announcements")
+    public ResponseEntity<List<StudyAnnouncementResponse>> getStudyAnnouncements(@PathVariable Long studyId) {
+        List<StudyAnnouncementResponse> response = commonStudyService.getStudyAnnouncements(studyId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/CommonStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/CommonStudyService.java
@@ -47,7 +47,7 @@ public class CommonStudyService {
         studyValidator.validateStudyMentorOrStudent(currentMember, study, studyHistory);
 
         final List<StudyAnnouncement> studyAnnouncements =
-                studyAnnouncementRepository.findAllByStudyIdOOrderByCreatedAtDesc(studyId);
+                studyAnnouncementRepository.findAllByStudyIdOrderByCreatedAtDesc(studyId);
 
         return studyAnnouncements.stream().map(StudyAnnouncementResponse::from).toList();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/CommonStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/CommonStudyService.java
@@ -2,10 +2,20 @@ package com.gdschongik.gdsc.domain.study.application;
 
 import static com.gdschongik.gdsc.global.exception.ErrorCode.STUDY_NOT_FOUND;
 
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.study.dao.StudyAnnouncementRepository;
+import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyRepository;
 import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.domain.study.domain.StudyAnnouncement;
+import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
+import com.gdschongik.gdsc.domain.study.domain.StudyValidator;
 import com.gdschongik.gdsc.domain.study.dto.response.CommonStudyResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyAnnouncementResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.util.MemberUtil;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,10 +27,29 @@ import org.springframework.transaction.annotation.Transactional;
 public class CommonStudyService {
 
     private final StudyRepository studyRepository;
+    private final StudyHistoryRepository studyHistoryRepository;
+    private final StudyAnnouncementRepository studyAnnouncementRepository;
+    private final MemberUtil memberUtil;
+    private final StudyValidator studyValidator;
 
     @Transactional(readOnly = true)
     public CommonStudyResponse getStudyInformation(Long studyId) {
         Study study = studyRepository.findById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
         return CommonStudyResponse.from(study);
+    }
+
+    @Transactional(readOnly = true)
+    public List<StudyAnnouncementResponse> getStudyAnnouncements(Long studyId) {
+        Member currentMember = memberUtil.getCurrentMember();
+        final Study study = studyRepository.findById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
+        Optional<StudyHistory> studyHistory = studyHistoryRepository
+                .findByMenteeAndStudyId(currentMember, studyId);
+
+        studyValidator.validateStudyMentorOrStudent(currentMember, study, studyHistory);
+
+        final List<StudyAnnouncement> studyAnnouncements =
+                studyAnnouncementRepository.findAllByStudyIdOOrderByCreatedAtDesc(studyId);
+
+        return studyAnnouncements.stream().map(StudyAnnouncementResponse::from).toList();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/CommonStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/CommonStudyService.java
@@ -42,8 +42,7 @@ public class CommonStudyService {
     public List<StudyAnnouncementResponse> getStudyAnnouncements(Long studyId) {
         Member currentMember = memberUtil.getCurrentMember();
         final Study study = studyRepository.findById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
-        Optional<StudyHistory> studyHistory = studyHistoryRepository
-                .findByMenteeAndStudyId(currentMember, studyId);
+        Optional<StudyHistory> studyHistory = studyHistoryRepository.findByMenteeAndStudyId(currentMember, studyId);
 
         studyValidator.validateStudyMentorOrStudent(currentMember, study, studyHistory);
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAnnouncementRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAnnouncementRepository.java
@@ -4,6 +4,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.STUDY_ANNOUNCEMENT_
 
 import com.gdschongik.gdsc.domain.study.domain.StudyAnnouncement;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudyAnnouncementRepository extends JpaRepository<StudyAnnouncement, Long> {
@@ -11,4 +12,6 @@ public interface StudyAnnouncementRepository extends JpaRepository<StudyAnnounce
     default StudyAnnouncement getById(Long id) {
         return findById(id).orElseThrow(() -> new CustomException(STUDY_ANNOUNCEMENT_NOT_FOUND));
     }
+
+    List<StudyAnnouncement> findAllByStudyIdOOrderByCreatedAtDesc(Long studyId);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAnnouncementRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAnnouncementRepository.java
@@ -13,5 +13,5 @@ public interface StudyAnnouncementRepository extends JpaRepository<StudyAnnounce
         return findById(id).orElseThrow(() -> new CustomException(STUDY_ANNOUNCEMENT_NOT_FOUND));
     }
 
-    List<StudyAnnouncement> findAllByStudyIdOOrderByCreatedAtDesc(Long studyId);
+    List<StudyAnnouncement> findAllByStudyIdOrderByCreatedAtDesc(Long studyId);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyValidator.java
@@ -5,7 +5,6 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
-import jakarta.annotation.Nullable;
 import java.util.Optional;
 
 @DomainService

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyValidator.java
@@ -5,6 +5,8 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import jakarta.annotation.Nullable;
+import java.util.Optional;
 
 @DomainService
 public class StudyValidator {
@@ -14,8 +16,25 @@ public class StudyValidator {
             return;
         }
 
-        // 어드민이 아니고 멘토 역할도 아니면 예외가 밸생합니다.
+        // 멘토인지 검증
         if (!currentMember.isMentor()) {
+            throw new CustomException(STUDY_ACCESS_NOT_ALLOWED);
+        }
+
+        // 해당 스터디의 담당 멘토인지 검증
+        if (!currentMember.getId().equals(study.getMentor().getId())) {
+            throw new CustomException(STUDY_MENTOR_INVALID);
+        }
+    }
+
+    public void validateStudyMentorOrStudent(Member currentMember, Study study, Optional<StudyHistory> studyHistory) {
+        // 어드민인 경우 검증 통과
+        if (currentMember.isAdmin()) {
+            return;
+        }
+
+        // 해당 스터디의 수강생인지 검증
+        if (currentMember.isStudent() && studyHistory.isEmpty()) {
             throw new CustomException(STUDY_ACCESS_NOT_ALLOWED);
         }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyAnnouncementResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyAnnouncementResponse.java
@@ -1,0 +1,20 @@
+package com.gdschongik.gdsc.domain.study.dto.response;
+
+import com.gdschongik.gdsc.domain.study.domain.StudyAnnouncement;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+public record StudyAnnouncementResponse(
+        Long studyAnnounceId,
+        @Schema(description = "제목") String title,
+        @Schema(description = "링크") String link,
+        @Schema(description = "생성 일자") LocalDate createdDate) {
+
+    public static StudyAnnouncementResponse from(StudyAnnouncement studyAnnouncement) {
+        return new StudyAnnouncementResponse(
+                studyAnnouncement.getId(),
+                studyAnnouncement.getTitle(),
+                studyAnnouncement.getLink(),
+                studyAnnouncement.getCreatedAt().toLocalDate());
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyValidatorTest.java
@@ -8,6 +8,7 @@ import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.FixtureHelper;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +31,7 @@ public class StudyValidatorTest {
     }
 
     @Nested
-    class 스터디_검증시 {
+    class 스터디_멘토역할_검증시 {
 
         @Test
         void 멘토역할이_아니라면_실패한다() {
@@ -86,6 +87,47 @@ public class StudyValidatorTest {
             // when & then
             assertThatCode(() -> studyValidator.validateStudyMentor(admin, study))
                     .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    class 스터디_멘토_또는_학생역할_검증시 {
+
+        @Test
+        void 수강하지않는_스터디가_아니라면_실패한다() {
+            // given
+            Member student = createMember(1L);
+            Member mentor = createMentor(2L);
+            LocalDateTime assignmentCreatedDate = LocalDateTime.now().minusDays(1);
+            Study study = fixtureHelper.createStudy(
+                    mentor,
+                    Period.createPeriod(assignmentCreatedDate.plusDays(5), assignmentCreatedDate.plusDays(10)),
+                    Period.createPeriod(assignmentCreatedDate.minusDays(5), assignmentCreatedDate));
+            StudyHistory studyHistory = null;
+
+            // when & then
+            assertThatThrownBy(() -> studyValidator.validateStudyMentorOrStudent(
+                            student, study, Optional.ofNullable(studyHistory)))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(STUDY_ACCESS_NOT_ALLOWED.getMessage());
+        }
+
+        @Test
+        void 멘토이지만_자신이_맡은_스터디가_아니라면_실패한다() {
+            // given
+            Member currentMember = createMentor(1L);
+            Member mentor = createMentor(2L);
+            LocalDateTime assignmentCreatedDate = LocalDateTime.now().minusDays(1);
+            Study study = fixtureHelper.createStudy(
+                    mentor,
+                    Period.createPeriod(assignmentCreatedDate.plusDays(5), assignmentCreatedDate.plusDays(10)),
+                    Period.createPeriod(assignmentCreatedDate.minusDays(5), assignmentCreatedDate));
+
+            // when & then
+            assertThatThrownBy(
+                            () -> studyValidator.validateStudyMentorOrStudent(currentMember, study, Optional.empty()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(STUDY_MENTOR_INVALID.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #643

## 📌 작업 내용 및 특이사항
- 스터디 공지 목록 조회 APi입니다
- 해당 API는 수강생 혹은 멘토 모두 접근 가능하여서 새로운 검증 로직을 구현하였습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **신규 기능**
	- 멤버 역할 확인을 위한 `isStudent()` 메소드 추가.
	- 특정 스터디 ID에 대한 스터디 공지사항을 가져오는 API 엔드포인트 추가.
	- 스터디 공지사항을 처리하기 위한 새로운 서비스 메소드 추가.
	- 스터디 공지사항을 위한 데이터 전송 객체(DTO) 정의.
	- 스터디 멘토 또는 학생 검증을 위한 새로운 검증 메소드 추가.

- **버그 수정**
	- 멘토 및 학생 역할 검증 로직 개선.

- **테스트**
	- 스터디 역할에 대한 검증 로직을 위한 테스트 케이스 추가 및 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->