### PR TITLE
feat: 과제 제출하기 채점 로직 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyHistoryController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyHistoryController.java
@@ -35,4 +35,11 @@ public class StudentStudyHistoryController {
         List<AssignmentHistoryResponse> response = studentStudyHistoryService.getAllAssignmentHistories(studyId);
         return ResponseEntity.ok(response);
     }
+
+    @Operation(summary = "과제 제출하기", description = "과제를 제출합니다. 제출된 과제는 채점되어 제출내역에 반영됩니다.")
+    @PostMapping("/submit")
+    public ResponseEntity<Void> submitAssignment(@RequestParam(name = "studyDetailId") Long studyDetailId) {
+        studentStudyHistoryService.submitAssignment(studyDetailId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryService.java
@@ -56,6 +56,7 @@ public class StudentStudyHistoryService {
                 assignmentHistoryRepository.existsSubmittedAssignmentByMemberAndStudy(currentMember, study);
         String ownerRepo = getOwnerRepo(request.repositoryLink());
         GHRepository repository = githubClient.getRepository(ownerRepo);
+        // TODO: GHRepository 등을 wrapper로 감싸서 테스트 가능하도록 변경
         studyHistoryValidator.validateUpdateRepository(
                 isAnyAssignmentSubmitted, String.valueOf(repository.getOwner().getId()), currentMember.getOauthId());
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryService.java
@@ -104,6 +104,13 @@ public class StudentStudyHistoryService {
         assignmentHistoryGrader.judge(fetcher, assignmentHistory);
 
         assignmentHistoryRepository.save(assignmentHistory);
+
+        log.info(
+                "[StudyHistoryService] 과제 제출: studyDetailId={}, menteeId={}, submissionStatus={}, submissionFailureType={}",
+                studyDetailId,
+                currentMember.getId(),
+                assignmentHistory.getSubmissionStatus(),
+                assignmentHistory.getSubmissionFailureType());
     }
 
     private AssignmentHistory findOrCreate(Member currentMember, StudyDetail studyDetail) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
@@ -46,7 +46,7 @@ public class AssignmentHistory extends BaseEntity {
 
     private String commitHash;
 
-    private Long contentLength;
+    private Integer contentLength;
 
     private LocalDateTime committedAt;
 
@@ -85,7 +85,7 @@ public class AssignmentHistory extends BaseEntity {
 
     // 데이터 변경 로직
 
-    public void success(String submissionLink, String commitHash, Long contentLength, LocalDateTime committedAt) {
+    public void success(String submissionLink, String commitHash, Integer contentLength, LocalDateTime committedAt) {
         this.submissionLink = submissionLink;
         this.commitHash = commitHash;
         this.contentLength = contentLength;

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGrader.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGrader.java
@@ -1,0 +1,52 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import static com.gdschongik.gdsc.domain.study.domain.SubmissionFailureType.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.global.annotation.DomainService;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.exception.ErrorCode;
+import java.util.function.Supplier;
+
+@DomainService
+public class AssignmentHistoryGrader {
+
+    public void judge(
+            Supplier<AssignmentSubmission> assignmentSubmissionSupplier, AssignmentHistory assignmentHistory) {
+        try {
+            AssignmentSubmission assignmentSubmission = assignmentSubmissionSupplier.get();
+            judgeAssignmentSubmission(assignmentSubmission, assignmentHistory);
+        } catch (CustomException e) {
+            SubmissionFailureType failureType = translateException(e);
+            assignmentHistory.fail(failureType);
+        }
+    }
+
+    private void judgeAssignmentSubmission(
+            AssignmentSubmission assignmentSubmission, AssignmentHistory assignmentHistory) {
+        if (assignmentSubmission.contentLength() < 300) {
+            assignmentHistory.fail(WORD_COUNT_INSUFFICIENT);
+            return;
+        }
+
+        assignmentHistory.success(
+                assignmentSubmission.url(),
+                assignmentSubmission.commitHash(),
+                assignmentSubmission.contentLength(),
+                assignmentSubmission.committedAt());
+    }
+
+    private SubmissionFailureType translateException(CustomException e) {
+        ErrorCode errorCode = e.getErrorCode();
+
+        if (errorCode == GITHUB_CONTENT_NOT_FOUND) {
+            return LOCATION_UNIDENTIFIABLE;
+        }
+
+        if (errorCode == GITHUB_FILE_READ_FAILED || errorCode == GITHUB_COMMIT_DATE_FETCH_FAILED) {
+            return UNKNOWN;
+        }
+
+        throw e;
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGrader.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGrader.java
@@ -11,6 +11,8 @@ import java.util.function.Supplier;
 @DomainService
 public class AssignmentHistoryGrader {
 
+    public static final int MINIMUM_ASSIGNMENT_CONTENT_LENGTH = 300;
+
     public void judge(
             Supplier<AssignmentSubmission> assignmentSubmissionSupplier, AssignmentHistory assignmentHistory) {
         try {
@@ -24,7 +26,7 @@ public class AssignmentHistoryGrader {
 
     private void judgeAssignmentSubmission(
             AssignmentSubmission assignmentSubmission, AssignmentHistory assignmentHistory) {
-        if (assignmentSubmission.contentLength() < 300) {
+        if (assignmentSubmission.contentLength() < MINIMUM_ASSIGNMENT_CONTENT_LENGTH) {
             assignmentHistory.fail(WORD_COUNT_INSUFFICIENT);
             return;
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGrader.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGrader.java
@@ -12,7 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 @DomainService
 public class AssignmentHistoryGrader {
 
-    public static final int MINIMUM_ASSIGNMENT_CONTENT_LENGTH = 300;
+    private static final int MINIMUM_ASSIGNMENT_CONTENT_LENGTH = 300;
 
     public void judge(AssignmentSubmissionFetcher assignmentSubmissionFetcher, AssignmentHistory assignmentHistory) {
         try {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGrader.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGrader.java
@@ -12,9 +12,9 @@ public class AssignmentHistoryGrader {
 
     public static final int MINIMUM_ASSIGNMENT_CONTENT_LENGTH = 300;
 
-    public void judge(AssignmentSubmissionFetcher assignmentSubmissionFetcher, AssignmentHistory assignmentHistory) {
+    public void judge(
+            AssignmentSubmissionFetchExecutor assignmentSubmissionFetchExecutor, AssignmentHistory assignmentHistory) {
         try {
-            AssignmentSubmission assignmentSubmission = assignmentSubmissionFetcher.fetch();
             judgeAssignmentSubmission(assignmentSubmission, assignmentHistory);
         } catch (CustomException e) {
             SubmissionFailureType failureType = translateException(e);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGrader.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGrader.java
@@ -12,9 +12,9 @@ public class AssignmentHistoryGrader {
 
     public static final int MINIMUM_ASSIGNMENT_CONTENT_LENGTH = 300;
 
-    public void judge(
-            AssignmentSubmissionFetchExecutor assignmentSubmissionFetchExecutor, AssignmentHistory assignmentHistory) {
+    public void judge(AssignmentSubmissionFetcher assignmentSubmissionFetcher, AssignmentHistory assignmentHistory) {
         try {
+            AssignmentSubmission assignmentSubmission = assignmentSubmissionFetcher.fetch();
             judgeAssignmentSubmission(assignmentSubmission, assignmentHistory);
         } catch (CustomException e) {
             SubmissionFailureType failureType = translateException(e);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGrader.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGrader.java
@@ -3,7 +3,6 @@ package com.gdschongik.gdsc.domain.study.domain;
 import static com.gdschongik.gdsc.domain.study.domain.SubmissionFailureType.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
-import com.gdschongik.gdsc.domain.study.domain.vo.AssignmentSubmissionFetcher;
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGrader.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGrader.java
@@ -43,10 +43,6 @@ public class AssignmentHistoryGrader {
             return LOCATION_UNIDENTIFIABLE;
         }
 
-        if (errorCode == GITHUB_FILE_READ_FAILED || errorCode == GITHUB_COMMIT_DATE_FETCH_FAILED) {
-            return UNKNOWN;
-        }
-
-        throw e;
+        return UNKNOWN;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGrader.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGrader.java
@@ -6,7 +6,9 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @DomainService
 public class AssignmentHistoryGrader {
 
@@ -42,6 +44,8 @@ public class AssignmentHistoryGrader {
         if (errorCode == GITHUB_CONTENT_NOT_FOUND) {
             return LOCATION_UNIDENTIFIABLE;
         }
+
+        log.warn("[AssignmentHistoryGrader] 과제 제출정보 조회 중 알 수 없는 오류 발생: {}", e.getMessage());
 
         return UNKNOWN;
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGrader.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGrader.java
@@ -3,20 +3,19 @@ package com.gdschongik.gdsc.domain.study.domain;
 import static com.gdschongik.gdsc.domain.study.domain.SubmissionFailureType.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
+import com.gdschongik.gdsc.domain.study.domain.vo.AssignmentSubmissionFetcher;
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
-import java.util.function.Supplier;
 
 @DomainService
 public class AssignmentHistoryGrader {
 
     public static final int MINIMUM_ASSIGNMENT_CONTENT_LENGTH = 300;
 
-    public void judge(
-            Supplier<AssignmentSubmission> assignmentSubmissionSupplier, AssignmentHistory assignmentHistory) {
+    public void judge(AssignmentSubmissionFetcher assignmentSubmissionFetcher, AssignmentHistory assignmentHistory) {
         try {
-            AssignmentSubmission assignmentSubmission = assignmentSubmissionSupplier.get();
+            AssignmentSubmission assignmentSubmission = assignmentSubmissionFetcher.fetch();
             judgeAssignmentSubmission(assignmentSubmission, assignmentHistory);
         } catch (CustomException e) {
             SubmissionFailureType failureType = translateException(e);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmission.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmission.java
@@ -1,0 +1,5 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import java.time.LocalDateTime;
+
+public record AssignmentSubmission(String url, String commitHash, Integer contentLength, LocalDateTime committedAt) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionFetchExecutor.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionFetchExecutor.java
@@ -1,0 +1,7 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+@FunctionalInterface
+public interface AssignmentSubmissionFetchExecutor {
+
+    AssignmentSubmission execute(String repo, int week);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionFetchExecutor.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionFetchExecutor.java
@@ -1,7 +1,8 @@
 package com.gdschongik.gdsc.domain.study.domain;
 
+import com.gdschongik.gdsc.global.exception.CustomException;
+
 @FunctionalInterface
 public interface AssignmentSubmissionFetchExecutor {
-
-    AssignmentSubmission execute(String repo, int week);
+    AssignmentSubmission execute(String repo, int week) throws CustomException;
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionFetcher.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionFetcher.java
@@ -1,7 +1,9 @@
 package com.gdschongik.gdsc.domain.study.domain;
 
+import com.gdschongik.gdsc.global.exception.CustomException;
+
 public record AssignmentSubmissionFetcher(String repo, int week, AssignmentSubmissionFetchExecutor fetchExecutor) {
-    public AssignmentSubmission fetch() {
+    public AssignmentSubmission fetch() throws CustomException {
         return fetchExecutor.execute(repo, week);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionFetcher.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionFetcher.java
@@ -1,6 +1,5 @@
-package com.gdschongik.gdsc.domain.study.domain.vo;
+package com.gdschongik.gdsc.domain.study.domain;
 
-import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmission;
 import com.gdschongik.gdsc.global.exception.CustomException;
 
 @FunctionalInterface

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionFetcher.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionFetcher.java
@@ -1,9 +1,7 @@
 package com.gdschongik.gdsc.domain.study.domain;
 
-import com.gdschongik.gdsc.global.exception.CustomException;
-
-@FunctionalInterface
-public interface AssignmentSubmissionFetcher {
-
-    AssignmentSubmission fetch() throws CustomException;
+public record AssignmentSubmissionFetcher(String repo, int week, AssignmentSubmissionFetchExecutor fetchExecutor) {
+    public AssignmentSubmission fetch() {
+        return fetchExecutor.execute(repo, week);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
@@ -31,7 +31,7 @@ public class StudyDetail extends BaseEntity {
     private Study study;
 
     @Comment("현 주차수")
-    private Long week;
+    private Long week; // TODO: Integer로 변경
 
     private String attendanceNumber;
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/SubmissionFailureType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/SubmissionFailureType.java
@@ -9,7 +9,9 @@ public enum SubmissionFailureType {
     NONE("실패 없음"), // 제출상태 성공 시 사용
     NOT_SUBMITTED("미제출"), // 기본값
     WORD_COUNT_INSUFFICIENT("글자수 부족"),
-    LOCATION_UNIDENTIFIABLE("위치 확인불가");
+    LOCATION_UNIDENTIFIABLE("위치 확인불가"),
+    UNKNOWN("알 수 없음"),
+    ;
 
     private final String value;
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/AssignmentSubmissionFetcher.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/AssignmentSubmissionFetcher.java
@@ -1,0 +1,10 @@
+package com.gdschongik.gdsc.domain.study.domain.vo;
+
+import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmission;
+import com.gdschongik.gdsc.global.exception.CustomException;
+
+@FunctionalInterface
+public interface AssignmentSubmissionFetcher {
+
+    AssignmentSubmission fetch() throws CustomException;
+}

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -163,7 +163,6 @@ public enum ErrorCode {
     GITHUB_CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 파일입니다."),
     GITHUB_FILE_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "깃허브 파일 읽기에 실패했습니다."),
     GITHUB_COMMIT_DATE_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "깃허브 커밋 날짜 조회에 실패했습니다."),
-    GITHUB_ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 과제 파일입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
@@ -4,12 +4,12 @@ import static com.gdschongik.gdsc.global.common.constant.GithubConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmission;
+import com.gdschongik.gdsc.domain.study.domain.vo.AssignmentSubmissionFetcher;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHContent;
@@ -31,7 +31,7 @@ public class GithubClient {
         }
     }
 
-    public Supplier<AssignmentSubmission> getLatestAssignmentSubmission(String repo, int week) {
+    public AssignmentSubmissionFetcher getLatestAssignmentSubmission(String repo, int week) {
         GHRepository ghRepository = getRepository(repo);
         String assignmentPath = GITHUB_ASSIGNMENT_PATH.formatted(week);
 

--- a/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
@@ -32,10 +32,10 @@ public class GithubClient {
     }
 
     public AssignmentSubmissionFetcher getLatestAssignmentSubmissionFetcher(String repo, int week) {
-        return () -> getAssignmentSubmissionFetcher(repo, week);
+        return new AssignmentSubmissionFetcher(repo, week, this::getLatestAssignmentSubmission);
     }
 
-    private AssignmentSubmission getAssignmentSubmissionFetcher(String repo, int week) {
+    private AssignmentSubmission getLatestAssignmentSubmission(String repo, int week) {
         GHRepository ghRepository = getRepository(repo);
         String assignmentPath = GITHUB_ASSIGNMENT_PATH.formatted(week);
 

--- a/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
@@ -4,7 +4,7 @@ import static com.gdschongik.gdsc.global.common.constant.GithubConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmission;
-import com.gdschongik.gdsc.domain.study.domain.vo.AssignmentSubmissionFetcher;
+import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionFetcher;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
@@ -31,7 +31,11 @@ public class GithubClient {
         }
     }
 
-    public AssignmentSubmissionFetcher getLatestAssignmentSubmission(String repo, int week) {
+    public AssignmentSubmissionFetcher getLatestAssignmentSubmissionFetcher(String repo, int week) {
+        return () -> getAssignmentSubmissionFetcher(repo, week);
+    }
+
+    private AssignmentSubmission getAssignmentSubmissionFetcher(String repo, int week) {
         GHRepository ghRepository = getRepository(repo);
         String assignmentPath = GITHUB_ASSIGNMENT_PATH.formatted(week);
 
@@ -49,7 +53,7 @@ public class GithubClient {
 
         LocalDateTime committedAt = getCommitDate(ghLatestCommit);
 
-        return () -> new AssignmentSubmission(
+        return new AssignmentSubmission(
                 ghContent.getHtmlUrl(), ghLatestCommit.getSHA1(), content.length(), committedAt);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
@@ -3,13 +3,14 @@ package com.gdschongik.gdsc.infra.github.client;
 import static com.gdschongik.gdsc.global.common.constant.GithubConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
+import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmission;
 import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.infra.github.dto.response.GithubAssignmentSubmissionResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHContent;
@@ -31,7 +32,7 @@ public class GithubClient {
         }
     }
 
-    public GithubAssignmentSubmissionResponse getLatestAssignmentSubmission(String repo, int week) {
+    public Supplier<AssignmentSubmission> getLatestAssignmentSubmission(String repo, int week) {
         GHRepository ghRepository = getRepository(repo);
         String assignmentPath = GITHUB_ASSIGNMENT_PATH.formatted(week);
 
@@ -52,7 +53,8 @@ public class GithubClient {
                 .atZone(ZoneId.systemDefault())
                 .toLocalDateTime();
 
-        return new GithubAssignmentSubmissionResponse(ghLatestCommit.getSHA1(), content.length(), committedAt);
+        return () -> new AssignmentSubmission(
+                ghContent.getHtmlUrl(), ghLatestCommit.getSHA1(), content.length(), committedAt);
     }
 
     private GHContent getFileContent(GHRepository ghRepository, String filePath) {

--- a/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
@@ -4,6 +4,7 @@ import static com.gdschongik.gdsc.global.common.constant.GithubConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmission;
+import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionFetchExecutor;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionFetcher;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import java.io.IOException;
@@ -31,6 +32,12 @@ public class GithubClient {
         }
     }
 
+    /**
+     * 직접 요청을 수행하는 대신, fetcher를 통해 요청을 수행합니다.
+     * 요청 수행 시 발생하는 예외의 경우 과제 채점에 사용되므로, 실제 요청은 채점 로직 내부에서 수행되어야 합니다.
+     * 따라서 지연 평가가 가능하도록 {@link AssignmentSubmissionFetchExecutor}를 인자로 받습니다.
+     * 또한, 인자로 전달된 repo와 week가 closure로 캡쳐되지 않도록 fetcher 내부에 컨텍스트로 저장합니다.
+     */
     public AssignmentSubmissionFetcher getLatestAssignmentSubmissionFetcher(String repo, int week) {
         return new AssignmentSubmissionFetcher(repo, week, this::getLatestAssignmentSubmission);
     }

--- a/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Date;
 import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import org.kohsuke.github.GHCommit;
@@ -48,10 +47,7 @@ public class GithubClient {
                 .iterator()
                 .next();
 
-        LocalDateTime committedAt = getCommitDate(ghLatestCommit)
-                .toInstant()
-                .atZone(ZoneId.systemDefault())
-                .toLocalDateTime();
+        LocalDateTime committedAt = getCommitDate(ghLatestCommit);
 
         return () -> new AssignmentSubmission(
                 ghContent.getHtmlUrl(), ghLatestCommit.getSHA1(), content.length(), committedAt);
@@ -73,9 +69,13 @@ public class GithubClient {
         }
     }
 
-    private Date getCommitDate(GHCommit ghLatestCommit) {
+    private LocalDateTime getCommitDate(GHCommit ghLatestCommit) {
         try {
-            return ghLatestCommit.getCommitDate();
+            return ghLatestCommit
+                    .getCommitDate()
+                    .toInstant()
+                    .atZone(ZoneId.systemDefault())
+                    .toLocalDateTime();
         } catch (IOException e) {
             throw new CustomException(GITHUB_COMMIT_DATE_FETCH_FAILED);
         }

--- a/src/main/java/com/gdschongik/gdsc/infra/github/dto/response/GithubAssignmentSubmissionResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/dto/response/GithubAssignmentSubmissionResponse.java
@@ -1,5 +1,0 @@
-package com.gdschongik.gdsc.infra.github.dto.response;
-
-import java.time.LocalDateTime;
-
-public record GithubAssignmentSubmissionResponse(String commitHash, Integer size, LocalDateTime committedAt) {}

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryServiceTest.java
@@ -1,0 +1,88 @@
+package com.gdschongik.gdsc.domain.study.application;
+
+import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.domain.study.dao.AssignmentHistoryRepository;
+import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;
+import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
+import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmission;
+import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionFetcher;
+import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionStatus;
+import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
+import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
+import com.gdschongik.gdsc.helper.IntegrationTest;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class StudentStudyHistoryServiceTest extends IntegrationTest {
+
+    @Autowired
+    private StudentStudyHistoryService studentStudyHistoryService;
+
+    @Autowired
+    private StudyHistoryRepository studyHistoryRepository;
+
+    @Autowired
+    private AssignmentHistoryRepository assignmentHistoryRepository;
+
+    private void setCurrentTime(LocalDateTime now) {
+        try (MockedStatic<LocalDateTime> mock = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+            mock.when(LocalDateTime::now).thenReturn(now);
+        }
+    }
+
+    @Nested
+    class 과제_제출할때 {
+
+        @Test
+        void 성공한다() {
+            // given
+            Member mentor = createAssociateMember();
+            // TODO: LocalDateTime.now() 관련 테스트 정책 논의 필요
+            LocalDateTime now = LocalDateTime.now(); // 통합 테스트에서는 LocalDateTime.now()를 사용해야 함
+            Study study = createStudy(
+                    mentor,
+                    Period.createPeriod(now.minusWeeks(1), now.plusWeeks(7)), // 스터디 기간: 1주 전 ~ 7주 후
+                    Period.createPeriod(now.minusWeeks(2), now.minusWeeks(1))); // 수강신청 기간: 2주 전 ~ 1주 전
+            StudyDetail studyDetail =
+                    createStudyDetail(study, now.minusDays(6), now.plusDays(1)); // 1주차 기간: 6일 전 ~ 1일 후
+            publishAssignment(studyDetail);
+
+            Member student = createRegularMember();
+            logoutAndReloginAs(student.getId(), MemberRole.REGULAR);
+
+            // 수강신청 valiadtion 로직이 LocalDateTime.now() 기준으로 동작하기 때문에 직접 수강신청 생성
+            StudyHistory studyHistory = StudyHistory.create(student, study);
+            studyHistory.updateRepositoryLink(REPOSITORY_LINK);
+            studyHistoryRepository.save(studyHistory);
+
+            // 제출정보 조회 fetcher stubbing
+            AssignmentSubmissionFetcher mockFetcher = mock(AssignmentSubmissionFetcher.class);
+            when(mockFetcher.fetch())
+                    .thenReturn(new AssignmentSubmission(REPOSITORY_LINK, COMMIT_HASH, 500, COMMITTED_AT));
+            when(githubClient.getLatestAssignmentSubmissionFetcher(anyString(), anyInt()))
+                    .thenReturn(mockFetcher);
+
+            // when
+            studentStudyHistoryService.submitAssignment(studyDetail.getId());
+
+            // then
+            AssignmentHistory assignmentHistory =
+                    assignmentHistoryRepository.findById(1L).orElseThrow();
+            assertThat(assignmentHistory.getSubmissionStatus()).isEqualTo(AssignmentSubmissionStatus.SUCCESS);
+            assertThat(assignmentHistory.getSubmissionLink()).isEqualTo(REPOSITORY_LINK);
+            assertThat(assignmentHistory.getCommitHash()).isEqualTo(COMMIT_HASH);
+            assertThat(assignmentHistory.getContentLength()).isEqualTo(500);
+        }
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGraderTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGraderTest.java
@@ -1,0 +1,100 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.exception.ErrorCode;
+import com.gdschongik.gdsc.helper.FixtureHelper;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class AssignmentHistoryGraderTest {
+
+    FixtureHelper fixtureHelper = new FixtureHelper();
+    AssignmentHistoryGrader grader = new AssignmentHistoryGrader();
+
+    AssignmentSubmissionFetcher mockFetcher = mock(AssignmentSubmissionFetcher.class);
+
+    // FixtureHelper 래핑 메서드
+    private AssignmentHistory createAssignmentHistory() {
+        Study study = createStudyWithMentor(1L);
+        StudyDetail studyDetail = fixtureHelper.createStudyDetail(
+                study, LocalDateTime.now(), LocalDateTime.now().plusDays(7));
+        return AssignmentHistory.create(studyDetail, fixtureHelper.createAssociateMember(2L));
+    }
+
+    private Study createStudyWithMentor(Long mentorId) {
+        Period period = Period.createPeriod(STUDY_START_DATETIME, STUDY_END_DATETIME);
+        Period applicationPeriod =
+                Period.createPeriod(STUDY_START_DATETIME.minusDays(7), STUDY_START_DATETIME.minusDays(1));
+        return fixtureHelper.createStudyWithMentor(mentorId, period, applicationPeriod);
+    }
+
+    @Nested
+    class 과제_채점시 {
+
+        @Test
+        void 과제내용이_최소길이_이상이면_성공_처리된다() {
+            // given
+            AssignmentHistory history = createAssignmentHistory();
+            AssignmentSubmission validSubmission = new AssignmentSubmission("url", "hash", 500, LocalDateTime.now());
+            when(mockFetcher.fetch()).thenReturn(validSubmission);
+
+            // when
+            grader.judge(mockFetcher, history);
+
+            // then
+            assertThat(history.getSubmissionStatus()).isEqualTo(AssignmentSubmissionStatus.SUCCESS);
+            assertThat(history.getSubmissionLink()).isEqualTo("url");
+            assertThat(history.getCommitHash()).isEqualTo("hash");
+            assertThat(history.getContentLength()).isEqualTo(500);
+        }
+
+        @Test
+        void 과제내용이_최소길이_미만이면_실패_처리된다() {
+            // given
+            AssignmentHistory history = createAssignmentHistory();
+            AssignmentSubmission shortSubmission = new AssignmentSubmission("url", "hash", 200, LocalDateTime.now());
+            when(mockFetcher.fetch()).thenReturn(shortSubmission);
+
+            // when
+            grader.judge(mockFetcher, history);
+
+            // then
+            assertThat(history.getSubmissionStatus()).isEqualTo(AssignmentSubmissionStatus.FAILURE);
+            assertThat(history.getSubmissionFailureType()).isEqualTo(SubmissionFailureType.WORD_COUNT_INSUFFICIENT);
+        }
+
+        @Test
+        void 해당_위치에_과제파일_미존재시_위치확인불가로_실패_처리된다() {
+            // given
+            AssignmentHistory history = createAssignmentHistory();
+            when(mockFetcher.fetch()).thenThrow(new CustomException(ErrorCode.GITHUB_CONTENT_NOT_FOUND));
+
+            // when
+            grader.judge(mockFetcher, history);
+
+            // then
+            assertThat(history.getSubmissionStatus()).isEqualTo(AssignmentSubmissionStatus.FAILURE);
+            assertThat(history.getSubmissionFailureType()).isEqualTo(SubmissionFailureType.LOCATION_UNIDENTIFIABLE);
+        }
+
+        @Test
+        void 그외_Github_문제인경우_알수없는오류로_실패_처리된다() {
+            // given
+            AssignmentHistory history = createAssignmentHistory();
+            when(mockFetcher.fetch()).thenThrow(new CustomException(ErrorCode.GITHUB_FILE_READ_FAILED));
+
+            // when
+            grader.judge(mockFetcher, history);
+
+            // then
+            assertThat(history.getSubmissionStatus()).isEqualTo(AssignmentSubmissionStatus.FAILURE);
+            assertThat(history.getSubmissionFailureType()).isEqualTo(SubmissionFailureType.UNKNOWN);
+        }
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/StudyConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/StudyConstant.java
@@ -37,4 +37,7 @@ public class StudyConstant {
     public static final String COMMIT_HASH = "aa11bb22cc33";
     public static final Integer CONTENT_LENGTH = 2000;
     public static final LocalDateTime COMMITTED_AT = LocalDateTime.of(2024, 9, 8, 0, 0);
+
+    // StudyHistory
+    public static final String REPOSITORY_LINK = "ownername/reponame";
 }

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/StudyConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/StudyConstant.java
@@ -35,6 +35,6 @@ public class StudyConstant {
     // AssignmentHistory
     public static final String SUBMISSION_LINK = "https://github.com/ownername/reponame/blob/main/week1/WIL.md";
     public static final String COMMIT_HASH = "aa11bb22cc33";
-    public static final Long CONTENT_LENGTH = 2000L;
+    public static final Integer CONTENT_LENGTH = 2000;
     public static final LocalDateTime COMMITTED_AT = LocalDateTime.of(2024, 9, 8, 0, 0);
 }

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -36,6 +36,7 @@ import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import com.gdschongik.gdsc.global.security.PrincipalDetails;
 import com.gdschongik.gdsc.infra.feign.payment.client.PaymentClient;
+import com.gdschongik.gdsc.infra.github.client.GithubClient;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -85,6 +86,9 @@ public abstract class IntegrationTest {
 
     @MockBean
     protected PaymentClient paymentClient;
+
+    @MockBean
+    protected GithubClient githubClient;
 
     @MockBean
     protected DelegateMemberDiscordEventHandler delegateMemberDiscordEventHandler;

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -232,4 +232,9 @@ public abstract class IntegrationTest {
                 StudyDetail.createStudyDetail(study, 1L, ATTENDANCE_NUMBER, Period.createPeriod(startDate, endDate));
         return studyDetailRepository.save(studyDetail);
     }
+
+    protected StudyDetail publishAssignment(StudyDetail studyDetail) {
+        studyDetail.publishAssignment(ASSIGNMENT_TITLE, studyDetail.getPeriod().getEndDate(), DESCRIPTION_LINK);
+        return studyDetailRepository.save(studyDetail);
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #640

## 📌 작업 내용 및 특이사항

### 기존 컨텍스트
- 기존에는 깃허브 클라이언트에서 과제 파일을 조회해올 때, `GithubAssignmentSubmission` 으로 응답을 받아오도록 했습니다.
- 하지만 조회 과정에서, 이런저런 이유로 예외가 발생할 수 있습니다. 사용자가 과제 제출을 할 때 잘못된 디렉토리에 파일을 위치시킬 수도 있고, 아니면 서버가 제출정보를 github api에 요청하는 과정에서 네트워크 예외가 발생할 수도 있고요.
- Github API Wrapper 라이브러리에서는 이러한 가능성이 있는 경우 method call마다 `IOException`을 발생시키는 방식으로 처리하고 있습니다. 저희는 이를 받아서 CustomException 및 적절한 에러코드로 변환하는 작업을 수행했었습니다. 대충 이런 느낌입니다.
```java
private GHContent getFileContent(GHRepository ghRepository, String filePath) {
    try {
        return ghRepository.getFileContent(filePath);
    } catch (IOException e) {
        throw new CustomException(GITHUB_CONTENT_NOT_FOUND);
    }
}
```

### 조회 과정에서의 예외, 그리고 실패 사유
- 여기서 발생하는 예외는 두 가지로 나뉠 수 있습니다.
    - 사용자의 잘못으로 인한 예외 -> `GITHUB_CONTENT_NOT_FOUND`
    - 서버 에러, 네트워크 에러 등등 사용자의 잘못이 아닌데도 발생한 예외 -> `GITHUB_FILE_READ_FAILED` 외 다수
- 한편, 제출된 과제를 채점할 때, 실패 처리하는 경우 사유를 적도록 되어있습니다.
- 사용자가 잘못한 경우, 그 사유를 실패 사유로 적어줘야 합니다,.
- 서버가 잘못한 경우, 그 사유를 구체적으로 적을 필요는 없지만 어쨌든 내부 문제로 인해 제출 실패 처리되었다는 것을 알려줄 필요가 있습니다.
- 이러한 이유로, 실패사유 중 `UNKNOWN("알 수 없음")` 을 추가하게 되었습니다.

### (1) - 예외를 실패사유로 변환하는 비즈니스 로직의 노출 
- 위의 핵심은, '발생한 예외'가 '실패 사유'로 변환되어야 한다는 것입니다.
- 이를 위해서는, `gihubClient.getLatestAssignmentSubmission` 을 호출하여 github api와의 통신을 시도할 때, 이를 `try-catch`로 감싸서, catch 절에서 `에러코드` 를 `실패사유` 로 변환하는 과정이 필요합니다
- 문제는, `에러코드`를 `실패사유` 로 변환하는 것이 일종의 비즈니스 로직이라는 것에 있습니다.

### (1) - 예외가 발생하는 시점
- 저희는 응용 레이어에 비즈니스 로직이 노출되기를 원하지 않기 때문에, 도메인 서비스를 도입했습니다.
- 그러므로, `try-catch` 로 `githubClient.getX` 로직을 감싸는 부분도 응용 레이어가 아닌 도메인 레이어에서 이루어져야 합니다. 
- 엄밀하게는, catch 절에서 발생한 예외를 실패사유로 변환하는 부분이 도메인 레이어에서 수행되어야 합니다.
- 하지만 이렇게 할 수가 없습니다... 현재 콜스택에서 발생한 예외를 위로 던지는 건 봤어도 아래로 던진다는 이야긴 들어본 적이 없습니다.

### (1) - 해결책?
- 가장 간단한 해결책은, `AssignmentHistoryGrader`, 즉 과제 채점 도메인 서비스의 내부에 `GithubClient` 를 DI하는 것입니다.
- 그러면 도메인 레이어에서 `githubClient.getX` 를 호출하여, 예외를 실패사유로 변환할 수 있게 되니, 문제를 해결할 수 있습니다.
- 애초에 '실패사유'를 결정하는 것 역시 Grader, 채점 서비스의 책임이니 이 역시 적절한 처사라고 볼 수 있습니다.
```java
@DomainService
@RequiredArgsConstructor
public class AssignmentHistoryGrader {
    
    private final GithubClient githubClient;
    ...
}
```

### (1) - 도메인 서비스의 정의와 부합하지 않는다
- 하지만 이러면 도메인 서비스가 아니라고 했었죠?
- 도메인 서비스는 행위만을 가지고, 여기에 필요한 상태는 외부에서 공급받습니다.
- 또한, 도메인 서비스는 '도메인 레이어'에 속하기 때문에, 기본적으로 POJO여야 하고, 스프링의 DI 기능에 의존하지 않고 순수하게 유지해야 합니다.
- 물론 `@DomainService` 내부에는 `@Component`가 있어 스프링 빈으로 등록되긴 합니다만, 이건 응용 레이어에서 도메인 서비스를 쉽게 사용하기 위함이지 의존객체의 DI를 위한 것이 아닙니다 (애초에 의존객체를 만들지 말아야 합니다).

### (2) 람다식과 지연평가
- 따라서 문제 상황을 다시 정리해보면, `GithubClient` 에 대한 의존성은 응용 레이어에 위치하면서도, 실제 조회 및 예외 발생은 도메인 레이어에서 이루어져야 한다는 것입니다.
- 이걸 해결할 수 있는 좋은 방법은, 람다의 지연 평가 특성을 활용하는 것입니다.
- 즉 `GithubClient#getXXX`는 호출되면 바로 github api를 통해 `GithubAssignmentSubmissionResponse` 로 가져오는 것이 아니라...
- `() -> new Response()` 와 같이`Supplier<XResponse>` 타입의 람다식으로 만들어서 리턴한 뒤, 이를 Grader의 인자로 받아서, Grader 내부에서 `supplier.get()` 을 호출하면 위 문제를 해결할 수 있습니다. 

### (2) - 행위의 객체화
- 람다식은 '함수형 인터페이스를, 익명 클래스로 구현하여, 이에 대한 인스턴스를 만든 것'입니다. 간단하게 말하면, 행위의 객체화입니다.
- 사실 `() -> new Response()` 와 같은 표현은 적절하지 않습니다. 이건 그냥 응답을 반환하는 람다식일 뿐입니다. 우리가 원하는 것은, `github api로 요청을 보내서 응답으로 가져오는` 행위를 객체화시키는 것입니다.
- 그러면 `getLatest...` 로직 자체를 람다식으로 만들어버려야 합니다.
```java
public Supplier<AssignmentSubmissionResponse> getLatestAssignmentSubmissionSupplier(String repo, int week) {
    return () -> {
        GHRepository ghRepository = getRepository(repo);
        String assignmentPath = GITHUB_ASSIGNMENT_PATH.formatted(week);
        ...
        return new AssignmentSubmissionResponse(...);
    };
}
```
- 이렇게 하면 모든 문제가 해결됐습니다!

### (2) - 그런데 repo와 week는 어디로...?
- 여기서 궁금한 점이 생깁니다.
- 저 Supplier는 `Grader` 내부에서 호출될 것이고. 그러면 `GHRepository ghRepository = getRepository(repo);` 부터 쭉 한 줄씩 코드가 실행될 것입니다.
- 그렇다면 해당 코드의 `repo` 는 어디서 온 것인가요?
- 원래였다면 메서드의 인자로 받아서 넘겨줬을 것입니다.
- 그게 아니라 `(repo, week) -> { GHRepository ghRepository = getRepository(repo); }` 같은 식으로 람다식을 구성했다면, '아, 람다식 파라미터로 넘겨진 repo를 받아서 처리했겠구나' 라는 것을 알 수 있었을 겁니다.
- `getLatestAssignmentSubmissionSupplier(String repo, int week)` 에서 전달받은 repo 변수의 경우, 해당 supplier가 사용되는 `grader.judge()` 가 호출되는 스코프에서는 접근할 수 없는 상태일 것입니다.
- 실제로 이렇게 구현하더라도, 해당 람다식은 `getLatestAssignmentSubmissionSupplier(String repo, int week)` 에서 전달받은 repo와 week 정보를 기억해서 실행합니다. 어떻게 이런 것이 가능할까요?

### (2) - 람다식과 클로저
- 여기서는 repo가 상위 콜스택으로부터 전달받은 값이기 때문에 소멸되지 않지만, 만약 repo가 지역변수라서 `getLatestAssignmentSubmissionSupplier(String repo, int week)` 를 벗어나는 순간 소멸된다 하더라도, 이 람다식은 정상적으로 실행됩니다.
- 이유는 간단한데요, 람다식이 저장될 때 람다식 내부에서 외부 변수인 `repo`를 참조하는 경우, 이를 복사해서 같이 저장하기 때문입니다. 이걸 variable capture라고 하고, 이러한 람다식을 closure라고 부릅니다.
- 람다와 클로저는 각기 장단이 있는데요, 필요한 경우에는 클로저에 묶인 컨텍스트를 파라미터로 추출해내야 합니다. 이를 람다 리프팅이라고 합니다(https://en.wikipedia.org/wiki/Lambda_lifting).
- 람다 리프팅을 통해서 캡쳐된 값을 유지하도록 하는 비용을 줄이고, 메모리 사용이나 재사용성 등을 강화시킬 수 있습니다.
- 기존에도 잘 되는데 왜 굳이 여기서 복잡하게 이걸 해야 하느냐! 하면 이거까지 설명하려면 너무 길어질 것 같아서... 적당히 그런 이유가 있다 하고 이 부분은 스킵하도록 하겠습니다
- 아무튼, `() -> { GHRepository ghRepository = getRepository(repo); }` 같은 클로저에서 `(repo, week) -> { GHRepository ghRepository = getRepository(repo); }` 와 같이 추출해냈습니다.
- 물론 `Github` 빈에 대한 의존성은 그대로 있지만, 이것마저 파라미터로 뺄 필요는 없기 때문에... 넘어갑니다.
- 그리고, 기존에 캡쳐된 repo와 week를 대신해줄 수 있도록, 1) repo 2) week 3) 람다식을 하나로 묶어주는 클래스를 만들어줍니다.
```java
public record AssignmentSubmissionFetcher(String repo, int week, AssignmentSubmissionFetchExecutor fetchExecutor) {
    public AssignmentSubmission fetch() throws CustomException {
        return fetchExecutor.execute(repo, week);
    }
}


@FunctionalInterface
public interface AssignmentSubmissionFetchExecutor {
    AssignmentSubmission execute(String repo, int week) throws CustomException;
}
```
- ...그래서 기존 Fetcher를 FetchExecutor로 변경하고, 이 FetchExecutor를 실행하는데 필요한 컨텍스트를 Fetcher에서 같이 저장하도록 했습니다. (이게 사실상 핵심입니다)

### 마무리
아무튼 여기까지가 끝이고...
갑자기 등장한 `Fetcher`와 `FetchExecutor`에 대해 궁금해할 것 같아 해결과정을 쭉 적어봤습니다.
클라이언트 내부에도 javadoc 등으로 이러한 컨텍스트를 기록해두었으니 체크 부탁드립니다.

너무 새로운 방식이라 거부감이 있으실 수도 있겠지만,
테스트 코드 보시면 이렇게 하면 테스트 작성이 정말 쉬워진다는걸 체감하실 수 있으실 겁니다
(그리고 테스트하기 쉬운 코드는 좋은 코드일 가능성이 높습니다)


## 📝 참고사항
- https://velog.io/@janeljs/Java-Closure

## 📚 레퍼런스
- https://coding-start.tistory.com/370
- https://jaeyeong951.medium.com/java-%ED%81%B4%EB%A1%9C%EC%A0%80-vs-kotlin-%ED%81%B4%EB%A1%9C%EC%A0%80-c6c12da97f94
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
	- 과제 제출을 위한 새로운 API 엔드포인트(`/submit`)가 추가되었습니다.
	- 과제 제출 및 평가를 위한 새로운 클래스가 도입되었습니다.
	- 과제 제출을 위한 새로운 데이터 구조가 생성되었습니다.
	- 과제 평가를 위한 최소 콘텐츠 길이 상수가 추가되었습니다.

- **버그 수정**
	- 제출 상태 및 오류 처리에 대한 테스트가 추가되었습니다.

- **문서화**
	- `StudyDetail` 클래스의 주석을 업데이트하여 향후 변경 계획을 반영했습니다. 

- **기타 변경 사항**
	- 여러 상수 및 데이터 타입이 변경되었습니다.
	- 새로운 오류 처리 상수가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->