### PR TITLE
fix: objectMapper에 JavaTimeModule 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/global/config/ObjectMapperConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/ObjectMapperConfig.java
@@ -1,0 +1,16 @@
+package com.gdschongik.gdsc.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        return mapper;
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #650 

## 📌 작업 내용 및 특이사항
- Jackson이 LocalTime필드를 requestBody로 받을때 매핑이 안되는 에러가 있다고 합니다
- 그래서 ObjectMapper을 커스텀하여 JavaTimeModule추가했습니다

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- 시간 필드에 대한 JSON 직렬화 형식을 `"HH:mm:ss"`로 지정하여 API의 사용성과 일관성을 향상시켰습니다.
	- 새로운 정규 표현식 상수 `TIME`을 추가하여 표준 시간 형식을 정의했습니다.
  
- **Bug Fixes**
	- 날짜 및 시간 형식의 정규 표현식 수정으로 API 문서의 정확성을 개선했습니다.
	- 수정된 날짜 및 시간 표현식에서 발생할 수 있는 오류를 해결하기 위한 조치를 취했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->