### PR TITLE
feat: 신청 가능한 스터디 조회 API에 이미 신청한 스터디 ID 필드 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyController.java
@@ -2,11 +2,10 @@ package com.gdschongik.gdsc.domain.study.api;
 
 import com.gdschongik.gdsc.domain.study.application.StudentStudyService;
 import com.gdschongik.gdsc.domain.study.dto.request.StudyAttendCreateRequest;
-import com.gdschongik.gdsc.domain.study.dto.response.StudyResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyApplicableResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -27,8 +26,8 @@ public class StudentStudyController {
 
     @Operation(summary = "신청 가능한 스터디 조회", description = "모집 기간 중에 있는 스터디를 조회합니다.")
     @GetMapping("/apply")
-    public ResponseEntity<List<StudyResponse>> getAllApplicableStudies() {
-        List<StudyResponse> response = studentStudyService.getAllApplicableStudies();
+    public ResponseEntity<StudyApplicableResponse> getAllApplicableStudies() {
+        StudyApplicableResponse response = studentStudyService.getAllApplicableStudies();
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
@@ -11,11 +11,13 @@ import com.gdschongik.gdsc.domain.study.domain.*;
 import com.gdschongik.gdsc.domain.study.domain.Attendance;
 import com.gdschongik.gdsc.domain.study.domain.AttendanceValidator;
 import com.gdschongik.gdsc.domain.study.dto.request.StudyAttendCreateRequest;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyApplicableResponse;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -35,11 +37,19 @@ public class StudentStudyService {
     private final AttendanceRepository attendanceRepository;
     private final AttendanceValidator attendanceValidator;
 
-    public List<StudyResponse> getAllApplicableStudies() {
-        return studyRepository.findAll().stream()
+    public StudyApplicableResponse getAllApplicableStudies() {
+        Member currentMember = memberUtil.getCurrentMember();
+        List<StudyHistory> studyHistories = studyHistoryRepository.findAllByMentee(currentMember);
+        Optional<Study> study = studyHistories.stream()
+                .map(StudyHistory::getStudy)
+                .filter(Study::isStudyOngoing)
+                .findFirst();
+        List<StudyResponse> studyResponses = studyRepository.findAll().stream()
                 .filter(Study::isApplicable)
                 .map(StudyResponse::from)
                 .toList();
+
+        return StudyApplicableResponse.of(study.orElse(null), studyResponses);
     }
 
     @Transactional

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
@@ -40,7 +40,7 @@ public class StudentStudyService {
     public StudyApplicableResponse getAllApplicableStudies() {
         Member currentMember = memberUtil.getCurrentMember();
         List<StudyHistory> studyHistories = studyHistoryRepository.findAllByMentee(currentMember);
-        Optional<Study> study = studyHistories.stream()
+        Optional<Study> appliedStudy = studyHistories.stream()
                 .map(StudyHistory::getStudy)
                 .filter(Study::isStudyOngoing)
                 .findFirst();
@@ -49,7 +49,7 @@ public class StudentStudyService {
                 .map(StudyResponse::from)
                 .toList();
 
-        return StudyApplicableResponse.of(study.orElse(null), studyResponses);
+        return StudyApplicableResponse.of(appliedStudy.orElse(null), studyResponses);
     }
 
     @Transactional
@@ -79,7 +79,7 @@ public class StudentStudyService {
                 .orElseThrow(() -> new CustomException(STUDY_HISTORY_NOT_FOUND));
         studyHistoryRepository.delete(studyHistory);
 
-        log.info("[StudyService] 스터디 수강신청 취소: studyId={}, memberId={}", study.getId(), currentMember.getId());
+        log.info("[StudyService] 스터디 수강신청 취소: appliedStudyId={}, memberId={}", study.getId(), currentMember.getId());
     }
 
     @Transactional

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyApplicableResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyApplicableResponse.java
@@ -4,7 +4,7 @@ import com.gdschongik.gdsc.domain.study.domain.Study;
 import jakarta.annotation.Nullable;
 import java.util.List;
 
-public record StudyApplicableResponse(@Nullable Long studyId, List<StudyResponse> studyResponses) {
+public record StudyApplicableResponse(@Nullable Long appliedStudyId, List<StudyResponse> studyResponses) {
     public static StudyApplicableResponse of(Study study, List<StudyResponse> studyResponses) {
         return new StudyApplicableResponse(study == null ? null : study.getId(), studyResponses);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyApplicableResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyApplicableResponse.java
@@ -1,0 +1,11 @@
+package com.gdschongik.gdsc.domain.study.dto.response;
+
+import com.gdschongik.gdsc.domain.study.domain.Study;
+import jakarta.annotation.Nullable;
+import java.util.List;
+
+public record StudyApplicableResponse(@Nullable Long studyId, List<StudyResponse> studyResponses) {
+    public static StudyApplicableResponse of(Study study, List<StudyResponse> studyResponses) {
+        return new StudyApplicableResponse(study == null ? null : study.getId(), studyResponses);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyApplicableResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyApplicableResponse.java
@@ -1,10 +1,12 @@
 package com.gdschongik.gdsc.domain.study.dto.response;
 
 import com.gdschongik.gdsc.domain.study.domain.Study;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 import java.util.List;
 
-public record StudyApplicableResponse(@Nullable Long appliedStudyId, List<StudyResponse> studyResponses) {
+public record StudyApplicableResponse(
+        @Nullable @Schema(description = "이미 신청한 스터디 id") Long appliedStudyId, List<StudyResponse> studyResponses) {
     public static StudyApplicableResponse of(Study study, List<StudyResponse> studyResponses) {
         return new StudyApplicableResponse(study == null ? null : study.getId(), studyResponses);
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #648

## 📌 작업 내용 및 특이사항
- 신청 가능한 스터디 목록 조회시 이미 신청한 스터디가 무엇인지 알 수 있도록, dto에 `appliedStudyId` 필드를 추가했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - `getAllApplicableStudies()` 메서드의 응답 형식을 변경하여 더 명확한 데이터 구조를 제공함.
  - `StudyApplicableResponse` 클래스를 도입하여 사용자가 지원한 연구와 관련된 정보를 구조화함.

- **버그 수정**
  - 응답 로깅 기능을 업데이트하여 새로운 기능에 맞게 일관성을 유지함.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->