### PR TITLE
feat: StudyResponse에 학년도와 학기 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyResponse.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.domain.study.dto.response;
 
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.study.domain.Study;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.DayOfWeek;
@@ -8,6 +9,8 @@ import java.time.LocalTime;
 
 public record StudyResponse(
         Long studyId,
+        @Schema(description = "학년도") Integer academicYear,
+        @Schema(description = "학기") SemesterType semesterType,
         @Schema(description = "이름") String title,
         @Schema(description = "종류") String studyType,
         @Schema(description = "상세설명 노션 링크") String notionLink,
@@ -21,6 +24,8 @@ public record StudyResponse(
     public static StudyResponse from(Study study) {
         return new StudyResponse(
                 study.getId(),
+                study.getAcademicYear(),
+                study.getSemesterType(),
                 study.getTitle(),
                 study.getStudyType().getValue(),
                 study.getNotionLink(),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #653

## 📌 작업 내용 및 특이사항
- 프론트팀 요청으로 StudyResponse에 학년도와 학기 필드 추가했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- `StudyResponse`에 학년도 및 학기 유형 필드 추가로 API 응답 데이터의 상세 정보 제공.
  
- **버그 수정**
	- `from` 메서드 업데이트로 `StudyResponse`가 새로운 필드를 정확히 반영하도록 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->