### PR TITLE
fix: Time관련 필드 Deserializer 맵퍼에 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/global/config/ObjectMapperConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/ObjectMapperConfig.java
@@ -3,11 +3,14 @@ package com.gdschongik.gdsc.global.config;
 import static com.gdschongik.gdsc.global.common.constant.RegexConstant.DATE;
 import static com.gdschongik.gdsc.global.common.constant.RegexConstant.DATETIME;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.IOException;
 import java.time.LocalDate;
@@ -23,38 +26,85 @@ public class ObjectMapperConfig {
     public ObjectMapper objectMapper() {
         ObjectMapper mapper = new ObjectMapper();
         SimpleModule module = new SimpleModule();
-        module.addDeserializer(LocalDate.class, new JsonDeserializer<LocalDate>() {
-            @Override
-            public LocalDate deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
-                    throws IOException {
-                return LocalDate.parse(jsonParser.getValueAsString(), DateTimeFormatter.ofPattern(DATE));
-            }
-        });
 
-        module.addDeserializer(LocalTime.class, new JsonDeserializer<LocalTime>() {
-            @Override
-            public LocalTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
-                    throws IOException {
-                JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+        // LocalDate
+        module.addSerializer(LocalDate.class, new LocalDateSerializer());
+        module.addDeserializer(LocalDate.class, new LocalDateDeserializer());
 
-                int hour = node.get("hour").asInt();
-                int minute = node.get("minute").asInt();
-                int second = node.get("second").asInt();
-                int nano = node.get("nano").asInt();
+        // LocalDateTime
+        module.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer());
+        module.addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer());
 
-                return LocalTime.of(hour, minute, second, nano);
-            }
-        });
-
-        module.addDeserializer(LocalDateTime.class, new JsonDeserializer<LocalDateTime>() {
-            @Override
-            public LocalDateTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
-                    throws IOException {
-                return LocalDateTime.parse(jsonParser.getValueAsString(), DateTimeFormatter.ofPattern(DATETIME));
-            }
-        });
+        // LocalTime
+        module.addSerializer(LocalTime.class, new LocalTimeSerializer());
+        module.addDeserializer(LocalTime.class, new LocalTimeDeserializer());
 
         mapper.registerModule(module);
         return mapper;
+    }
+
+    public class LocalDateSerializer extends JsonSerializer<LocalDate> {
+
+        @Override
+        public void serialize(LocalDate value, JsonGenerator generator, SerializerProvider serializers)
+                throws IOException {
+            generator.writeString(value.format(DateTimeFormatter.ofPattern(DATE)));
+        }
+    }
+
+    public class LocalDateDeserializer extends JsonDeserializer<LocalDate> {
+        @Override
+        public LocalDate deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+                throws IOException {
+            return LocalDate.parse(jsonParser.getValueAsString(), DateTimeFormatter.ofPattern(DATE));
+        }
+    }
+
+    public class LocalDateTimeSerializer extends JsonSerializer<LocalDateTime> {
+
+        @Override
+        public void serialize(LocalDateTime value, JsonGenerator generator, SerializerProvider serializers)
+                throws IOException {
+            generator.writeString(value.format(DateTimeFormatter.ofPattern(DATETIME)));
+        }
+    }
+
+    public class LocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
+        @Override
+        public LocalDateTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+                throws IOException {
+            return LocalDateTime.parse(jsonParser.getValueAsString(), DateTimeFormatter.ofPattern(DATETIME));
+        }
+    }
+
+    public class LocalTimeSerializer extends JsonSerializer<LocalTime> {
+
+        @Override
+        public void serialize(LocalTime value, JsonGenerator generator, SerializerProvider serializers)
+                throws IOException {
+            generator.writeStartObject();
+
+            generator.writeNumberField("hour", value.getHour());
+            generator.writeNumberField("minute", value.getMinute());
+            generator.writeNumberField("second", value.getSecond());
+            generator.writeNumberField("nano", value.getNano());
+
+            generator.writeEndObject();
+        }
+    }
+
+    public class LocalTimeDeserializer extends JsonDeserializer<LocalTime> {
+        @Override
+        public LocalTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+                throws IOException {
+            JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+
+            int hour = node.get("hour").asInt();
+            int minute = node.get("minute").asInt();
+            int second = node.get("second").asInt();
+            int nano = node.get("nano").asInt();
+
+            return LocalTime.of(hour, minute, second, nano);
+        }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/config/ObjectMapperConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/ObjectMapperConfig.java
@@ -35,16 +35,13 @@ public class ObjectMapperConfig {
             @Override
             public LocalTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
                     throws IOException {
-                // JSON 객체를 읽어들여 JsonNode로 변환
                 JsonNode node = jsonParser.getCodec().readTree(jsonParser);
 
-                // JsonNode에서 값을 추출
                 int hour = node.get("hour").asInt();
                 int minute = node.get("minute").asInt();
                 int second = node.get("second").asInt();
                 int nano = node.get("nano").asInt();
 
-                // LocalTime 객체 생성
                 return LocalTime.of(hour, minute, second, nano);
             }
         });

--- a/src/main/java/com/gdschongik/gdsc/global/config/ObjectMapperConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/ObjectMapperConfig.java
@@ -1,7 +1,19 @@
 package com.gdschongik.gdsc.global.config;
 
+import static com.gdschongik.gdsc.global.common.constant.RegexConstant.DATE;
+import static com.gdschongik.gdsc.global.common.constant.RegexConstant.DATETIME;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,7 +22,42 @@ public class ObjectMapperConfig {
     @Bean
     public ObjectMapper objectMapper() {
         ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(LocalDate.class, new JsonDeserializer<LocalDate>() {
+            @Override
+            public LocalDate deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+                    throws IOException {
+                return LocalDate.parse(jsonParser.getValueAsString(), DateTimeFormatter.ofPattern(DATE));
+            }
+        });
+
+        module.addDeserializer(LocalTime.class, new JsonDeserializer<LocalTime>() {
+            @Override
+            public LocalTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+                    throws IOException {
+                // JSON 객체를 읽어들여 JsonNode로 변환
+                JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+
+                // JsonNode에서 값을 추출
+                int hour = node.get("hour").asInt();
+                int minute = node.get("minute").asInt();
+                int second = node.get("second").asInt();
+                int nano = node.get("nano").asInt();
+
+                // LocalTime 객체 생성
+                return LocalTime.of(hour, minute, second, nano);
+            }
+        });
+
+        module.addDeserializer(LocalDateTime.class, new JsonDeserializer<LocalDateTime>() {
+            @Override
+            public LocalDateTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+                    throws IOException {
+                return LocalDateTime.parse(jsonParser.getValueAsString(), DateTimeFormatter.ofPattern(DATETIME));
+            }
+        });
+
+        mapper.registerModule(module);
         return mapper;
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #657

## 📌 작업 내용 및 특이사항
제가 테스팅 잘못했었습니다.. 죄송합니다.
LocalTime필드가 JavaTimeModule넣어도 인식이 안되더라구요 그래서 LocalTime을 따로 Deserializer하도록 구현했습니다
다만 저렇게 할 시 다른 Time관련 필드들도 추가하지않으면 기존 잘되던 LocalDate, LocalDateTime필드들이 인식되지않아 저렇게 추가하였습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **버그 수정**
	- 날짜 및 시간 유형에 대한 맞춤형 직렬화 및 역직렬화 로직이 추가되어 날짜 문자열의 해석 유연성 향상.
- **기능 개선**
	- `LocalDate`, `LocalTime`, `LocalDateTime`의 사용자 정의 직렬화 및 역직렬화 방법을 도입하여 특정 형식에 맞춘 입력 처리가 가능해짐.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->