### PR TITLE
feat: 수강생 스터디 커리큘럼 조회 API 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyDetailController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyDetailController.java
@@ -34,7 +34,7 @@ public class StudentStudyDetailController {
     @GetMapping("/sessions")
     public ResponseEntity<List<StudyStudentSessionResponse>> getStudySessions(
             @RequestParam(name = "studyId") Long studyId) {
-        List<StudyStudentSessionResponse> response = studentStudyDetailService.getSessions(studyId);
+        List<StudyStudentSessionResponse> response = studentStudyDetailService.getStudySessions(studyId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyDetailController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyDetailController.java
@@ -2,8 +2,10 @@ package com.gdschongik.gdsc.domain.study.api;
 
 import com.gdschongik.gdsc.domain.study.application.StudentStudyDetailService;
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentDashboardResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyStudentSessionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,6 +26,15 @@ public class StudentStudyDetailController {
     public ResponseEntity<AssignmentDashboardResponse> getSubmittableAssignments(
             @RequestParam(name = "studyId") Long studyId) {
         AssignmentDashboardResponse response = studentStudyDetailService.getSubmittableAssignments(studyId);
+        return ResponseEntity.ok(response);
+    }
+
+    // TODO 스터디 세션 워딩을 커리큘럼으로 변경해야함
+    @Operation(summary = "스터디 커리큘럼 조회", description = "해당 스터디의 커리큘럼들을 조회합니다.")
+    @GetMapping("/sessions")
+    public ResponseEntity<List<StudyStudentSessionResponse>> getStudySessions(
+            @RequestParam(name = "studyId") Long studyId) {
+        List<StudyStudentSessionResponse> response = studentStudyDetailService.getSessions(studyId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
@@ -28,7 +28,7 @@ public class MentorStudyDetailService {
 
     @Transactional(readOnly = true)
     public List<AssignmentResponse> getWeeklyAssignments(Long studyId) {
-        List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyId(studyId);
+        List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyIdOrderByWeekAsc(studyId);
         return studyDetails.stream().map(AssignmentResponse::from).toList();
     }
 
@@ -87,7 +87,7 @@ public class MentorStudyDetailService {
 
     @Transactional(readOnly = true)
     public List<StudySessionResponse> getSessions(Long studyId) {
-        List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyId(studyId);
+        List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyIdOrderByWeekAsc(studyId);
         return studyDetails.stream().map(StudySessionResponse::from).toList();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
@@ -108,7 +108,7 @@ public class MentorStudyService {
         Study study = studyRepository.findById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
         studyValidator.validateStudyMentor(currentMember, study);
 
-        List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyId(studyId);
+        List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyIdOrderByWeekAsc(studyId);
         // StudyDetail ID를 추출하여 Set으로 저장
         Set<Long> studyDetailIds = studyDetails.stream().map(StudyDetail::getId).collect(Collectors.toSet());
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
@@ -52,11 +52,11 @@ public class StudentStudyDetailService {
     }
 
     @Transactional(readOnly = true)
-    public List<StudyStudentSessionResponse> getSessions(Long studyId) {
+    public List<StudyStudentSessionResponse> getStudySessions(Long studyId) {
         Member member = memberUtil.getCurrentMember();
         final List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyIdOrderByWeekAsc(studyId);
         final List<AssignmentHistory> assignmentHistories =
-                assignmentHistoryRepository.findAssignmentHistoriesByMenteeAndStudy(member, studyId);
+                assignmentHistoryRepository.findAssignmentHistoriesByStudentAndStudy(member, studyId);
         final List<Attendance> attendances = attendanceRepository.findByMemberAndStudyId(member, studyId);
 
         return studyDetails.stream()

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
@@ -2,14 +2,21 @@ package com.gdschongik.gdsc.domain.study.application;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.dao.AssignmentHistoryRepository;
+import com.gdschongik.gdsc.domain.study.dao.AttendanceRepository;
+import com.gdschongik.gdsc.domain.study.dao.StudyDetailRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;
+import com.gdschongik.gdsc.domain.study.dao.StudyRepository;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
+import com.gdschongik.gdsc.domain.study.domain.Attendance;
+import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentDashboardResponse;
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentSubmittableDto;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyStudentSessionResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.global.util.MemberUtil;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,8 +27,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class StudentStudyDetailService {
 
     private final MemberUtil memberUtil;
+    private final StudyRepository studyRepository;
     private final StudyHistoryRepository studyHistoryRepository;
     private final AssignmentHistoryRepository assignmentHistoryRepository;
+    private final StudyDetailRepository studyDetailRepository;
+    private final AttendanceRepository attendanceRepository;
 
     @Transactional(readOnly = true)
     public AssignmentDashboardResponse getSubmittableAssignments(Long studyId) {
@@ -39,5 +49,36 @@ public class StudentStudyDetailService {
                 .toList();
 
         return AssignmentDashboardResponse.of(studyHistory.getRepositoryLink(), isAnySubmitted, submittableAssignments);
+    }
+
+    @Transactional(readOnly = true)
+    public List<StudyStudentSessionResponse> getSessions(Long studyId) {
+        Member member = memberUtil.getCurrentMember();
+        final List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyIdOrderByWeekAsc(studyId);
+        final List<AssignmentHistory> assignmentHistories =
+                assignmentHistoryRepository.findAssignmentHistoriesByMenteeAndStudy(member, studyId);
+        final List<Attendance> attendances = attendanceRepository.findByMemberAndStudyId(member, studyId);
+
+        return studyDetails.stream()
+                .map(studyDetail -> StudyStudentSessionResponse.of(
+                        studyDetail,
+                        getSubmittedAssignment(assignmentHistories, studyDetail),
+                        isAttended(attendances, studyDetail),
+                        LocalDateTime.now()))
+                .toList();
+    }
+
+    private AssignmentHistory getSubmittedAssignment(
+            List<AssignmentHistory> assignmentHistories, StudyDetail studyDetail) {
+        return assignmentHistories.stream()
+                .filter(assignmentHistory ->
+                        assignmentHistory.getStudyDetail().getId().equals(studyDetail.getId()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private boolean isAttended(List<Attendance> attendances, StudyDetail studyDetail) {
+        return attendances.stream()
+                .anyMatch(attendance -> attendance.getStudyDetail().getId().equals(studyDetail.getId()));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepository.java
@@ -1,0 +1,9 @@
+package com.gdschongik.gdsc.domain.study.dao;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.study.domain.Attendance;
+import java.util.List;
+
+public interface AttendanceCustomRepository {
+    List<Attendance> findByMemberAndStudyId(Member member, Long studyId);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepositoryImpl.java
@@ -26,8 +26,8 @@ public class AttendanceCustomRepositoryImpl implements AttendanceCustomRepositor
                 .fetch();
     }
 
-    private BooleanExpression eqMemberId(Long studyId) {
-        return studyId != null ? attendance.student.id.eq(studyId) : null;
+    private BooleanExpression eqMemberId(Long memberId) {
+        return memberId != null ? attendance.student.id.eq(memberId) : null;
     }
 
     private BooleanExpression eqStudyId(Long studyId) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.gdschongik.gdsc.domain.study.dao;
+
+import static com.gdschongik.gdsc.domain.member.domain.QMember.member;
+import static com.gdschongik.gdsc.domain.study.domain.QAttendance.attendance;
+import static com.gdschongik.gdsc.domain.study.domain.QStudyDetail.studyDetail;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.study.domain.Attendance;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class AttendanceCustomRepositoryImpl implements AttendanceCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Attendance> findByMemberAndStudyId(Member member, Long studyId) {
+        return queryFactory
+                .selectFrom(attendance)
+                .leftJoin(attendance.studyDetail, studyDetail)
+                .fetchJoin()
+                .where(eqMemberId(member.getId()), eqStudyId(studyId))
+                .fetch();
+    }
+
+    private BooleanExpression eqMemberId(Long studyId) {
+        return studyId != null ? attendance.student.id.eq(studyId) : null;
+    }
+
+    private BooleanExpression eqStudyId(Long studyId) {
+        return studyId != null ? attendance.studyDetail.study.id.eq(studyId) : null;
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceRepository.java
@@ -3,4 +3,4 @@ package com.gdschongik.gdsc.domain.study.dao;
 import com.gdschongik.gdsc.domain.study.domain.Attendance;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AttendanceRepository extends JpaRepository<Attendance, Long> {}
+public interface AttendanceRepository extends JpaRepository<Attendance, Long>, AttendanceCustomRepository {}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyDetailRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyDetailRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudyDetailRepository extends JpaRepository<StudyDetail, Long> {
 
-    List<StudyDetail> findAllByStudyId(Long studyId);
+    List<StudyDetail> findAllByStudyIdOrderByWeekAsc(Long studyId);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
@@ -87,10 +87,6 @@ public class AssignmentHistory extends BaseEntity {
         return submissionStatus == SUCCESS;
     }
 
-    public boolean isFailure() {
-        return submissionStatus == FAILURE;
-    }
-
     // 데이터 변경 로직
 
     public void success(String submissionLink, String commitHash, Integer contentLength, LocalDateTime committedAt) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
@@ -83,6 +83,14 @@ public class AssignmentHistory extends BaseEntity {
         return submissionFailureType != NOT_SUBMITTED;
     }
 
+    public boolean isSuccess() {
+        return submissionStatus == SUCCESS;
+    }
+
+    public boolean isFailure() {
+        return submissionStatus == FAILURE;
+    }
+
     // 데이터 변경 로직
 
     public void success(String submissionLink, String commitHash, Long contentLength, LocalDateTime committedAt) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentSubmissionStatus.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum AssignmentSubmissionStatus {
-    // TODO: 클라이언트 응답에는 PENDING 상태 필요하므로, 추후 응답용 enum 클래스 생성 구현
     FAILURE("제출 실패"),
     SUCCESS("제출 성공");
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
@@ -87,6 +87,10 @@ public class Assignment {
         return status == CANCELLED;
     }
 
+    public boolean isNone() {
+        return status == NONE;
+    }
+
     public boolean isDeadlineRemaining() {
         LocalDateTime now = LocalDateTime.now();
         return now.isBefore(deadline);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmissionStatusResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmissionStatusResponse.java
@@ -1,39 +1,26 @@
 package com.gdschongik.gdsc.domain.study.dto.response;
 
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
-import com.gdschongik.gdsc.domain.study.domain.vo.Assignment;
-import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
-// 응답용 enum
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public enum AssignmentSubmissionStatusResponse {
-    SUCCESS("제출완료"),
-    FAILURE("제출실패"),
     NOT_SUBMITTED("미제출"),
-    // 제출기한이 아님 or 과제가 개설되지 않음 or 과제 휴강
-    CANNOT_SUBMIT("제출불가");
+    FAILURE("제출 실패"),
+    SUCCESS("제출 성공");
 
     private final String value;
 
-    public static AssignmentSubmissionStatusResponse of(
-            Assignment assignment, AssignmentHistory assignmentHistory, LocalDateTime now) {
-        // 과제를 제출완료한 경우
-        if (assignmentHistory != null && assignmentHistory.isSubmitted() && assignmentHistory.isSuccess()) {
-            return SUCCESS;
+    public static AssignmentSubmissionStatusResponse from(AssignmentHistory assignmentHistory) {
+        if (assignmentHistory == null) {
+            return NOT_SUBMITTED;
         }
-        // 과제를 제출실패한 경우
-        if (assignmentHistory != null && assignmentHistory.isSubmitted() && assignmentHistory.isFailure()) {
+        if (assignmentHistory.isSuccess()) {
+            return SUCCESS;
+        } else {
             return FAILURE;
         }
-
-        // 과제가 개설되지 않음 or 제출기한이 아님 or 과제 휴강
-        if (assignment.isNone() || now.isAfter(assignment.getDeadline()) || assignment.isCancelled()) {
-            return CANNOT_SUBMIT;
-        }
-
-        return NOT_SUBMITTED;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmissionStatusResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmissionStatusResponse.java
@@ -1,0 +1,39 @@
+package com.gdschongik.gdsc.domain.study.dto.response;
+
+import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
+import com.gdschongik.gdsc.domain.study.domain.vo.Assignment;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// 응답용 enum
+@Getter
+@AllArgsConstructor
+public enum AssignmentSubmissionStatusResponse {
+    SUCCESS("제출완료"),
+    FAILURE("제출실패"),
+    NOT_SUBMITTED("미제출"),
+    // 제출기한이 아님 or 과제가 개설되지 않음 or 과제 휴강
+    CANNOT_SUBMIT("제출불가");
+
+    private final String value;
+
+    public static AssignmentSubmissionStatusResponse of(
+            Assignment assignment, AssignmentHistory assignmentHistory, LocalDateTime now) {
+        // 과제를 제출완료한 경우
+        if (assignmentHistory != null && assignmentHistory.isSubmitted() && assignmentHistory.isSuccess()) {
+            return SUCCESS;
+        }
+        // 과제를 제출실패한 경우
+        if (assignmentHistory != null && assignmentHistory.isSubmitted() && assignmentHistory.isFailure()) {
+            return FAILURE;
+        }
+
+        // 과제가 개설되지 않음 or 제출기한이 아님 or 과제 휴강
+        if (assignment.isNone() || now.isAfter(assignment.getDeadline()) || assignment.isCancelled()) {
+            return CANNOT_SUBMIT;
+        }
+
+        return NOT_SUBMITTED;
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AttendanceStatusResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AttendanceStatusResponse.java
@@ -1,0 +1,29 @@
+package com.gdschongik.gdsc.domain.study.dto.response;
+
+import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// 응답용 enum
+@Getter
+@AllArgsConstructor
+public enum AttendanceStatusResponse {
+    ATTENDED("출석"),
+    NOT_ATTENDED("미출석"),
+    BEFORE_ATTENDANCE("출석전");
+
+    private final String value;
+
+    public static AttendanceStatusResponse of(StudyDetail studyDetail, LocalDate now, boolean isAttended) {
+        if (studyDetail.getAttendanceDay().isAfter(now)) {
+            return BEFORE_ATTENDANCE;
+        }
+
+        if (isAttended) {
+            return ATTENDED;
+        } else {
+            return NOT_ATTENDED;
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AttendanceStatusResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AttendanceStatusResponse.java
@@ -2,12 +2,12 @@ package com.gdschongik.gdsc.domain.study.dto.response;
 
 import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import java.time.LocalDate;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 // 응답용 enum
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public enum AttendanceStatusResponse {
     ATTENDED("출석"),
     NOT_ATTENDED("미출석"),

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentSessionResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentSessionResponse.java
@@ -1,0 +1,35 @@
+package com.gdschongik.gdsc.domain.study.dto.response;
+
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
+import com.gdschongik.gdsc.domain.study.domain.Difficulty;
+import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
+import com.gdschongik.gdsc.domain.study.domain.StudyStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record StudyStudentSessionResponse(
+        Long studyDetailId,
+        @Schema(description = "기간") Period period,
+        @Schema(description = "주차수") Long week,
+        @Schema(description = "제목") String title,
+        @Schema(description = "설명") String description,
+        @Schema(description = "세션 상태") StudyStatus sessionStatus,
+        @Schema(description = "난이도") Difficulty difficulty,
+        @Schema(description = "출석 상태") AttendanceStatusResponse attendanceStatus,
+        @Schema(description = "과제 제출 상태") AssignmentSubmissionStatusResponse assignmentSubmissionStatus) {
+
+    public static StudyStudentSessionResponse of(
+            StudyDetail studyDetail, AssignmentHistory assignmentHistory, boolean isAttended, LocalDateTime now) {
+        return new StudyStudentSessionResponse(
+                studyDetail.getId(),
+                studyDetail.getPeriod(),
+                studyDetail.getWeek(),
+                studyDetail.getSession().getTitle(),
+                studyDetail.getSession().getDescription(),
+                studyDetail.getSession().getStatus(),
+                studyDetail.getSession().getDifficulty(),
+                AttendanceStatusResponse.of(studyDetail, now.toLocalDate(), isAttended),
+                AssignmentSubmissionStatusResponse.of(studyDetail.getAssignment(), assignmentHistory, now));
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentSessionResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentSessionResponse.java
@@ -1,10 +1,13 @@
 package com.gdschongik.gdsc.domain.study.dto.response;
 
+import static com.gdschongik.gdsc.domain.study.domain.SubmissionFailureType.NOT_SUBMITTED;
+
 import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
 import com.gdschongik.gdsc.domain.study.domain.Difficulty;
 import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import com.gdschongik.gdsc.domain.study.domain.StudyStatus;
+import com.gdschongik.gdsc.domain.study.domain.SubmissionFailureType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
@@ -17,7 +20,9 @@ public record StudyStudentSessionResponse(
         @Schema(description = "세션 상태") StudyStatus sessionStatus,
         @Schema(description = "난이도") Difficulty difficulty,
         @Schema(description = "출석 상태") AttendanceStatusResponse attendanceStatus,
-        @Schema(description = "과제 제출 상태") AssignmentSubmissionStatusResponse assignmentSubmissionStatus) {
+        @Schema(description = "과제 개설 상태") StudyStatus assignmentStatus,
+        @Schema(description = "과제 제출 상태") AssignmentSubmissionStatusResponse assignmentSubmissionStatus,
+        @Schema(description = "과제 실패 타입") SubmissionFailureType submissionFailureType) {
 
     public static StudyStudentSessionResponse of(
             StudyDetail studyDetail, AssignmentHistory assignmentHistory, boolean isAttended, LocalDateTime now) {
@@ -30,6 +35,8 @@ public record StudyStudentSessionResponse(
                 studyDetail.getSession().getStatus(),
                 studyDetail.getSession().getDifficulty(),
                 AttendanceStatusResponse.of(studyDetail, now.toLocalDate(), isAttended),
-                AssignmentSubmissionStatusResponse.of(studyDetail.getAssignment(), assignmentHistory, now));
+                studyDetail.getAssignment().getStatus(),
+                AssignmentSubmissionStatusResponse.from(assignmentHistory),
+                assignmentHistory != null ? assignmentHistory.getSubmissionFailureType() : NOT_SUBMITTED);
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyServiceTest.java
@@ -62,7 +62,7 @@ public class MentorStudyServiceTest extends IntegrationTest {
             Study savedStudy = studyRepository.findById(study.getId()).get();
             assertThat(savedStudy.getNotionLink()).isEqualTo(request.notionLink());
 
-            List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyId(1L);
+            List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyIdOrderByWeekAsc(1L);
             for (int i = 0; i < studyDetails.size(); i++) {
                 StudyDetail studyDetail = studyDetails.get(i);
                 Long expectedId = studyDetail.getId();


### PR DESCRIPTION
## 🌱 관련 이슈
- close #645

## 📌 작업 내용 및 특이사항
- 수강생 전용커리큘럼 조회 API입니다 
- 주차별 출석상태, 과제제출상태 값에대한 enum response도 추가했습니다
- 이 enum값들 유심히 봐주시고 명명이나 이런거 변경의견있으면 남겨주세요!

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- 새로운 API 엔드포인트 추가로 학습 세션 정보를 요청할 수 있는 기능 제공.
	- 학습 세션 데이터 관리 및 조회 기능 확장.
	- `AssignmentSubmissionStatusResponse` 및 `AttendanceStatusResponse` 열거형 추가로 제출 상태 및 출석 상태 표현 방안 개선.
	- `StudyStudentSessionResponse` 클래스 도입으로 학생 세션 데이터 구조화.

- **버그 수정**
	- 주간 순서에 따라 학습 세부정보 정렬 기능 개선.

- **문서화**
	- OpenAPI 문서화 추가로 API 사용 안내 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->