### PR TITLE
feat: 사용자 과제 히스토리 조회 응답 필드에 제출 실패 사유 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentHistoryResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentHistoryResponse.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.domain.study.dto.response;
 
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionStatus;
+import com.gdschongik.gdsc.domain.study.domain.SubmissionFailureType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
@@ -12,6 +13,7 @@ public record AssignmentHistoryResponse(
         @Schema(description = "과제 명세 링크") String descriptionLink,
         @Schema(description = "과제 제출 링크") String submissionLink,
         @Schema(description = "과제 제출 상태") AssignmentSubmissionStatus assignmentSubmissionStatus,
+        @Schema(description = "과제 제출 실패 사유") SubmissionFailureType submissionFailureType,
         @Schema(description = "주차") Long week) {
     public static AssignmentHistoryResponse from(AssignmentHistory assignmentHistory) {
         return new AssignmentHistoryResponse(
@@ -21,6 +23,7 @@ public record AssignmentHistoryResponse(
                 assignmentHistory.getStudyDetail().getAssignment().getDescriptionLink(),
                 assignmentHistory.getSubmissionLink(),
                 assignmentHistory.getSubmissionStatus(),
+                assignmentHistory.getSubmissionFailureType(),
                 assignmentHistory.getStudyDetail().getWeek());
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #664 

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 제출 실패 유형 정보를 포함하는 새로운 필드를 `AssignmentHistoryResponse`에 추가하여 API 응답의 데이터 표현력을 향상시켰습니다.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->