### PR TITLE
feat: 내 할일 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyDetailController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyDetailController.java
@@ -2,8 +2,10 @@ package com.gdschongik.gdsc.domain.study.api;
 
 import com.gdschongik.gdsc.domain.study.application.StudentStudyDetailService;
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentDashboardResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,6 +26,13 @@ public class StudentStudyDetailController {
     public ResponseEntity<AssignmentDashboardResponse> getSubmittableAssignments(
             @RequestParam(name = "studyId") Long studyId) {
         AssignmentDashboardResponse response = studentStudyDetailService.getSubmittableAssignments(studyId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "내 할일 리스트 조회", description = "해당 스터디의 내 할일 리스트를 조회합니다")
+    @GetMapping("/todo")
+    public ResponseEntity<List<StudyTodoResponse>> getStudyTodoList(@RequestParam(name = "studyId") Long studyId) {
+        List<StudyTodoResponse> response = studentStudyDetailService.getStudyTodoList(studyId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyDetailController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyDetailController.java
@@ -2,8 +2,8 @@ package com.gdschongik.gdsc.domain.study.api;
 
 import com.gdschongik.gdsc.domain.study.application.StudentStudyDetailService;
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentDashboardResponse;
-import com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyStudentSessionResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
@@ -7,6 +7,7 @@ import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentDashboardResponse;
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentSubmittableDto;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.global.util.MemberUtil;
@@ -40,4 +41,7 @@ public class StudentStudyDetailService {
 
         return AssignmentDashboardResponse.of(studyHistory.getRepositoryLink(), isAnySubmitted, submittableAssignments);
     }
+
+    @Transactional(readOnly = true)
+    public List<StudyTodoResponse> getStudyTodoList(Long studyId) {}
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
@@ -64,18 +64,18 @@ public class StudentStudyDetailService {
                 assignmentHistoryRepository.findAssignmentHistoriesByStudentAndStudy(member, studyId);
         final List<Attendance> attendances = attendanceRepository.findByMemberAndStudyId(member, studyId);
 
-        LocalDate now = LocalDate.of(2024, 9, 4);
+        LocalDate now = LocalDate.now();
         List<StudyTodoResponse> response = new ArrayList<>();
         // 출석체크 정보 (개설 상태이고, 오늘이 출석체크날짜인 것)
         studyDetails.stream()
-                .filter(studyDetail -> studyDetail.getSession().isOpened()
+                .filter(studyDetail -> studyDetail.getSession().isOpen()
                         && studyDetail.getAttendanceDay().equals(now))
                 .forEach(studyDetail -> response.add(StudyTodoResponse.createAttendanceType(
                         studyDetail, now, isAttended(attendances, studyDetail))));
 
         // 과제 정보 (오늘이 과제 제출 기간에 포함된 과제 정보)
         studyDetails.stream()
-                .filter(studyDetail -> studyDetail.getAssignment().isOpened()
+                .filter(studyDetail -> studyDetail.getAssignment().isOpen()
                         && studyDetail.getAssignment().isDeadlineRemaining())
                 .forEach(studyDetail -> response.add(StudyTodoResponse.createAssignmentType(
                         studyDetail, getSubmittedAssignment(assignmentHistories, studyDetail))));

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
@@ -12,12 +12,14 @@ import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentDashboardResponse;
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentSubmittableDto;
-import com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyStudentSessionResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.global.util.MemberUtil;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -58,11 +60,24 @@ public class StudentStudyDetailService {
         final List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyIdOrderByWeekAsc(studyId);
         final List<AssignmentHistory> assignmentHistories =
                 assignmentHistoryRepository.findAssignmentHistoriesByStudentAndStudy(member, studyId);
+        final List<Attendance> attendances = attendanceRepository.findByMemberAndStudyId(member, studyId);
 
-        List<StudyTodoResponse> response = studyDetails.stream().filter(s)
-        // 출석체크 정보
+        LocalDate now = LocalDate.of(2024, 9, 4);
+        List<StudyTodoResponse> response = new ArrayList<>();
+        // 출석체크 정보 (개설 상태이고, 오늘이 출석체크날짜인 것)
+        studyDetails.stream()
+                .filter(studyDetail -> studyDetail.getSession().isOpened()
+                        && studyDetail.getAttendanceDay().equals(now))
+                .forEach(studyDetail -> response.add(StudyTodoResponse.createAttendanceType(
+                        studyDetail, now, isAttended(attendances, studyDetail))));
 
-        return;
+        // 과제 정보 (오늘이 과제 제출 기간에 포함된 과제 정보)
+        studyDetails.stream()
+                .filter(studyDetail -> studyDetail.getAssignment().isOpened()
+                        && studyDetail.getAssignment().isDeadlineRemaining())
+                .forEach(studyDetail -> response.add(StudyTodoResponse.createAssignmentType(
+                        studyDetail, getSubmittedAssignment(assignmentHistories, studyDetail))));
+        return response;
     }
 
     public List<StudyStudentSessionResponse> getStudySessions(Long studyId) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
@@ -2,8 +2,10 @@ package com.gdschongik.gdsc.domain.study.application;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.dao.AssignmentHistoryRepository;
+import com.gdschongik.gdsc.domain.study.dao.StudyDetailRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
+import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentDashboardResponse;
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentSubmittableDto;
@@ -23,6 +25,7 @@ public class StudentStudyDetailService {
     private final MemberUtil memberUtil;
     private final StudyHistoryRepository studyHistoryRepository;
     private final AssignmentHistoryRepository assignmentHistoryRepository;
+    private final StudyDetailRepository studyDetailRepository;
 
     @Transactional(readOnly = true)
     public AssignmentDashboardResponse getSubmittableAssignments(Long studyId) {
@@ -43,5 +46,11 @@ public class StudentStudyDetailService {
     }
 
     @Transactional(readOnly = true)
-    public List<StudyTodoResponse> getStudyTodoList(Long studyId) {}
+    public List<StudyTodoResponse> getStudyTodoList(Long studyId) {
+        Member member = memberUtil.getCurrentMember();
+        final List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyIdOrderByWeekAsc(studyId);
+        final List<AssignmentHistory> assignmentHistories =
+                assignmentHistoryRepository.findAssignmentHistoriesByMenteeAndStudy(member, studyId);
+        return ;
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
@@ -8,6 +8,7 @@ import com.gdschongik.gdsc.domain.study.domain.vo.Assignment;
 import com.gdschongik.gdsc.domain.study.domain.vo.Session;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.*;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -96,10 +97,25 @@ public class StudyDetail extends BaseEntity {
 
     // 스터디 시작일자 + 현재 주차 * 7 + (스터디 요일 - 스터디 기간 시작 요일)
     public LocalDate getAttendanceDay() {
-        return study.getStartDate()
-                .plusDays(week * 7
-                        + study.getDayOfWeek().getValue()
-                        - study.getStartDate().getDayOfWeek().getValue());
+        // 스터디 시작일자
+        LocalDate startDate = study.getStartDate();
+
+        // 스터디 요일
+        DayOfWeek studyDayOfWeek = study.getDayOfWeek();
+
+        // 스터디 기간 시작 요일
+        DayOfWeek startDayOfWeek = startDate.getDayOfWeek();
+
+        // 스터디 요일이 스터디 기간 시작 요일보다 앞서면, 다음 주로 넘어가게 처리
+        Long daysDifference = Long.valueOf(studyDayOfWeek.getValue() - startDayOfWeek.getValue());
+        if (daysDifference < 0) {
+            daysDifference += 7;
+        }
+
+        // 현재 주차에 따른 일수 계산
+        Long daysToAdd = (week - 1) * 7 + daysDifference;
+
+        return startDate.plusDays(daysToAdd);
     }
 
     public void updateSession(

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
@@ -89,10 +89,6 @@ public class Assignment {
         return status == NONE;
     }
 
-    public boolean isOpened() {
-        return status == OPEN;
-    }
-
     public boolean isDeadlineRemaining() {
         LocalDateTime now = LocalDateTime.now();
         return now.isBefore(deadline);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
@@ -91,6 +91,10 @@ public class Assignment {
         return status == NONE;
     }
 
+    public boolean isOpened() {
+        return status == OPEN;
+    }
+
     public boolean isDeadlineRemaining() {
         LocalDateTime now = LocalDateTime.now();
         return now.isBefore(deadline);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Session.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Session.java
@@ -55,4 +55,9 @@ public class Session {
                 .status(status)
                 .build();
     }
+
+    // 데이터 전달 로직
+    public boolean isOpened() {
+        return status == StudyStatus.OPEN;
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Session.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Session.java
@@ -57,7 +57,7 @@ public class Session {
     }
 
     // 데이터 전달 로직
-    public boolean isOpened() {
+    public boolean isOpen() {
         return status == StudyStatus.OPEN;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyTodoResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyTodoResponse.java
@@ -1,6 +1,12 @@
 package com.gdschongik.gdsc.domain.study.dto.response;
 
+import static com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse.StudyTodoType.ASSIGNMENT;
+import static com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse.StudyTodoType.ATTENDANCE;
+
+import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
+import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,7 +16,7 @@ public record StudyTodoResponse(
         @Schema(description = "현 주차수") Long week,
         @Schema(description = "할일 타입") StudyTodoType todoType,
         @Schema(description = "마감 시각") LocalDateTime deadLine,
-                @Schema(description = "출석 상태 (출석타입일 때만 사용)") AttendanceStatusResponse attendanceStatus,
+        @Schema(description = "출석 상태 (출석타입일 때만 사용)") AttendanceStatusResponse attendanceStatus,
         @Schema(description = "과제 제목 (과제타입일 때만 사용)") String assignmentTitle,
         @Schema(description = "과제 제출 상태 (과제타입일 때만 사용)") AssignmentSubmissionStatusResponse assignmentSubmissionStatus) {
 
@@ -21,5 +27,27 @@ public record StudyTodoResponse(
         ASSIGNMENT("과제");
 
         private final String value;
+    }
+
+    public static StudyTodoResponse createAttendanceType(StudyDetail studyDetail, LocalDate now, boolean isAttended) {
+        return new StudyTodoResponse(
+                studyDetail.getId(),
+                studyDetail.getWeek(),
+                ATTENDANCE,
+                studyDetail.getAttendanceDay().atTime(23, 59, 59),
+                AttendanceStatusResponse.of(studyDetail, now, isAttended),
+                null,
+                null);
+    }
+
+    public static StudyTodoResponse createAssignmentType(StudyDetail studyDetail, AssignmentHistory assignmentHistory) {
+        return new StudyTodoResponse(
+                studyDetail.getId(),
+                studyDetail.getWeek(),
+                ASSIGNMENT,
+                studyDetail.getAssignment().getDeadline(),
+                null,
+                studyDetail.getAssignment().getTitle(),
+                AssignmentSubmissionStatusResponse.from(assignmentHistory));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyTodoResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyTodoResponse.java
@@ -1,0 +1,27 @@
+package com.gdschongik.gdsc.domain.study.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public record StudyTodoResponse(
+        Long studyDetailId,
+        @Schema(description = "현 주차수") Long week,
+        @Schema(description = "할일 타입") StudyTodoType todoType,
+        @Schema(description = "마감 시각") LocalDateTime deadLine,
+        //        @Schema(description = "출석 상태 (출석타입일 때만 사용)") AttendanceStatusResponse attendanceStatus,
+        @Schema(description = "과제 제목 (과제타입일 때만 사용)") String assignmentTitle
+        //        @Schema(description = "과제 제출 상태 (과제타입일 때만 사용)") AssignmentSubmissionStatusResponse
+        // assignmentSubmissionStatus
+        ) {
+
+    @Getter
+    @AllArgsConstructor
+    public enum StudyTodoType {
+        ATTENDANCE("출석"),
+        ASSIGNMENT("과제");
+
+        private final String value;
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyTodoResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyTodoResponse.java
@@ -8,8 +8,8 @@ import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 public record StudyTodoResponse(
         Long studyDetailId,
@@ -19,15 +19,6 @@ public record StudyTodoResponse(
         @Schema(description = "출석 상태 (출석타입일 때만 사용)") AttendanceStatusResponse attendanceStatus,
         @Schema(description = "과제 제목 (과제타입일 때만 사용)") String assignmentTitle,
         @Schema(description = "과제 제출 상태 (과제타입일 때만 사용)") AssignmentSubmissionStatusResponse assignmentSubmissionStatus) {
-
-    @Getter
-    @AllArgsConstructor
-    public enum StudyTodoType {
-        ATTENDANCE("출석"),
-        ASSIGNMENT("과제");
-
-        private final String value;
-    }
 
     public static StudyTodoResponse createAttendanceType(StudyDetail studyDetail, LocalDate now, boolean isAttended) {
         return new StudyTodoResponse(
@@ -49,5 +40,14 @@ public record StudyTodoResponse(
                 null,
                 studyDetail.getAssignment().getTitle(),
                 AssignmentSubmissionStatusResponse.from(assignmentHistory));
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum StudyTodoType {
+        ATTENDANCE("출석"),
+        ASSIGNMENT("과제");
+
+        private final String value;
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #670

## 📌 작업 내용 및 특이사항
- 내할일목록 API입니다
- StudentStudyDetailService에 해당 response를 만들어 list에  add해지는 로직이 길어져서 따로 private 메소드로 빼려고 했으나, 그렇다면 해당 메소드안에서 또 isAttended, getSubmittedAssignment 메소드들을 호출하면서 함수의 depth가 너무 길어질까봐 따로 빼진 않았습니다.
- 그리고 StudyDetail 안에서 출석일자를 가져오는 함수인 getAttendanceDay메소드가 스터디기간 시작요일이 스터디요일 보다 늦은 경우를 고려하지 않고 있어서 보강했습니다!

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- 특정 스터디에 관련된 과제 목록을 조회할 수 있는 새로운 API 엔드포인트 추가.
	- 스터디 관련 작업을 효과적으로 관리하기 위한 `StudyTodoResponse` 클래스 도입.
	- 과제와 세션의 상태를 확인할 수 있는 `isOpened()` 메서드 추가.

- **Bug Fixes**
	- `getAttendanceDay` 메서드의 가독성과 유지 관리성을 개선하여 더 명확한 계산 로직 제공.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->