### PR TITLE
fix: 제출 이력이 없는 과제도 포함하도록 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
@@ -40,7 +40,8 @@ public class StudentStudyDetailService {
         List<AssignmentHistory> assignmentHistories =
                 assignmentHistoryRepository.findAssignmentHistoriesByStudentAndStudy(currentMember, studyId);
         List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyIdOrderByWeekAsc(studyId).stream()
-                .filter(StudyDetail::isAssignmentDeadlineRemaining)
+                .filter(studyDetail ->
+                        studyDetail.getAssignment().isOpen() && studyDetail.isAssignmentDeadlineRemaining())
                 .toList();
 
         boolean isAnySubmitted = assignmentHistories.stream().anyMatch(AssignmentHistory::isSubmitted);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
@@ -5,7 +5,6 @@ import com.gdschongik.gdsc.domain.study.dao.AssignmentHistoryRepository;
 import com.gdschongik.gdsc.domain.study.dao.AttendanceRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyDetailRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;
-import com.gdschongik.gdsc.domain.study.dao.StudyRepository;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
 import com.gdschongik.gdsc.domain.study.domain.Attendance;
 import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
@@ -27,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class StudentStudyDetailService {
 
     private final MemberUtil memberUtil;
-    private final StudyRepository studyRepository;
     private final StudyHistoryRepository studyHistoryRepository;
     private final AssignmentHistoryRepository assignmentHistoryRepository;
     private final StudyDetailRepository studyDetailRepository;

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
@@ -46,12 +46,7 @@ public class StudentStudyDetailService {
         boolean isAnySubmitted = assignmentHistories.stream().anyMatch(AssignmentHistory::isSubmitted);
         List<AssignmentSubmittableDto> submittableAssignments = studyDetails.stream()
                 .map(studyDetail -> AssignmentSubmittableDto.of(
-                        studyDetail,
-                        assignmentHistories.stream()
-                                .filter(assignmentHistory ->
-                                        assignmentHistory.getStudyDetail().equals(studyDetail))
-                                .findAny()
-                                .orElse(null)))
+                        studyDetail, getSubmittedAssignment(assignmentHistories, studyDetail)))
                 .toList();
 
         return AssignmentDashboardResponse.of(studyHistory.getRepositoryLink(), isAnySubmitted, submittableAssignments);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
@@ -77,6 +77,10 @@ public class Assignment {
 
     // 데이터 전달 로직
 
+    public boolean isOpen() {
+        return status == OPEN;
+    }
+
     public boolean isCancelled() {
         return status == CANCELLED;
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmittableDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmittableDto.java
@@ -20,12 +20,15 @@ public record AssignmentSubmittableDto(
         @Nullable @Schema(description = "마감 기한") LocalDateTime deadline,
         @Nullable @Schema(description = "과제 제출 링크") String submissionLink,
         @Nullable @Schema(description = "과제 제출 실패 사유") SubmissionFailureType submissionFailureType) {
-    public static AssignmentSubmittableDto from(AssignmentHistory assignmentHistory) {
-        StudyDetail studyDetail = assignmentHistory.getStudyDetail();
+    public static AssignmentSubmittableDto of(StudyDetail studyDetail, AssignmentHistory assignmentHistory) {
         Assignment assignment = studyDetail.getAssignment();
 
         if (assignment.isCancelled()) {
             return cancelledAssignment(studyDetail, assignment);
+        }
+
+        if (assignmentHistory == null) {
+            return notSubmittedAssignment(studyDetail, assignment);
         }
 
         return new AssignmentSubmittableDto(
@@ -37,13 +40,24 @@ public record AssignmentSubmittableDto(
                 assignment.getDescriptionLink(),
                 assignment.getDeadline(),
                 assignmentHistory.getSubmissionLink(),
-                assignmentHistory.getSubmissionFailureType() == null
-                        ? null
-                        : assignmentHistory.getSubmissionFailureType());
+                assignmentHistory.getSubmissionFailureType());
     }
 
     private static AssignmentSubmittableDto cancelledAssignment(StudyDetail studyDetail, Assignment assignment) {
         return new AssignmentSubmittableDto(
                 studyDetail.getId(), assignment.getStatus(), studyDetail.getWeek(), null, null, null, null, null, null);
+    }
+
+    private static AssignmentSubmittableDto notSubmittedAssignment(StudyDetail studyDetail, Assignment assignment) {
+        return new AssignmentSubmittableDto(
+                studyDetail.getId(),
+                assignment.getStatus(),
+                studyDetail.getWeek(),
+                assignment.getTitle(),
+                AssignmentSubmissionStatus.FAILURE,
+                assignment.getDescriptionLink(),
+                assignment.getDeadline(),
+                null,
+                SubmissionFailureType.NOT_SUBMITTED);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #673

## 📌 작업 내용 및 특이사항
- 기존 로직은 AssignmentHistory를 기반으로 response를 만들기 때문에 제출 이력이 없는 과제들은 누락되는 일이 발생했습니다.
AssignmentHistory가 수강신청을 하는 시점에 생성될 것이라는 생각에 선택한 방식이었으나, 최초 제출 시 생성되도록 구현되었기 때문에 로직 변경이 필요합니다.

## 📝 참고사항
- service에서 StudyRepository가 사용되지 않고 있길래 제거했습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
  - 과제 제출 가능 목록을 개선하여 현재 상태에 따라 제출할 수 있는 과제를 더 효과적으로 필터링합니다.
  - 과제 상태를 보다 명확하게 표현하기 위해 `AssignmentSubmittableDto`의 기능을 확장했습니다.
  - 과제의 현재 상태가 `OPEN`인지 확인할 수 있는 `isOpen()` 메서드를 추가했습니다.

- **버그 수정**
  - 제출되지 않은 과제에 대한 새로운 조건 검사를 추가하여 예외적인 경우를 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->