### PR TITLE
feat: 과제 히스토리 API 응답 바디에 과제 휴강 상태 추가 

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentHistoryResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentHistoryResponse.java
@@ -2,12 +2,14 @@ package com.gdschongik.gdsc.domain.study.dto.response;
 
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionStatus;
+import com.gdschongik.gdsc.domain.study.domain.StudyStatus;
 import com.gdschongik.gdsc.domain.study.domain.SubmissionFailureType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record AssignmentHistoryResponse(
         Long assignmentHistoryId,
+        @Schema(description = "과제 휴강 여부") StudyStatus status,
         @Schema(description = "과제 제목") String title,
         @Schema(description = "마감 기한") LocalDateTime deadline,
         @Schema(description = "과제 명세 링크") String descriptionLink,
@@ -18,6 +20,7 @@ public record AssignmentHistoryResponse(
     public static AssignmentHistoryResponse from(AssignmentHistory assignmentHistory) {
         return new AssignmentHistoryResponse(
                 assignmentHistory.getId(),
+                assignmentHistory.getStudyDetail().getAssignment().getStatus(),
                 assignmentHistory.getStudyDetail().getAssignment().getTitle(),
                 assignmentHistory.getStudyDetail().getAssignment().getDeadline(),
                 assignmentHistory.getStudyDetail().getAssignment().getDescriptionLink(),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #682 

## 📌 작업 내용 및 특이사항
- https://app.slack.com/client/T06MT9HP4JF/C06Q93M2U81
- 프론트 요청사항입니다

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 과제 상태를 나타내는 `status` 필드를 추가하여, 과제의 상태에 대한 보다 상세한 정보를 제공합니다.
- **개선사항**
  - API 응답 구조를 개선하여 클라이언트가 과제 데이터를 처리하는 방식에 영향을 줄 수 있는 추가 컨텍스트를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->