### PR TITLE
fix: OAuth 콜백 파라미터로 리다이렉트 위치를 지정하도록 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/SecurityConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/SecurityConstant.java
@@ -8,6 +8,7 @@ public class SecurityConstant {
     public static final String GITHUB_NAME_ATTR_KEY = "id";
     public static final String ACCESS_TOKEN_HEADER_PREFIX = "Bearer ";
     public static final String OAUTH_REDIRECT_PATH_SEGMENT = "/social-login/redirect";
+    public static final String OAUTH_TARGET_URL_PARAM_NAME = "target";
 
     private SecurityConstant() {}
 }

--- a/src/main/java/com/gdschongik/gdsc/global/security/CustomOAuth2AuthorizationRequestResolver.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/CustomOAuth2AuthorizationRequestResolver.java
@@ -1,0 +1,49 @@
+package com.gdschongik.gdsc.global.security;
+
+import static com.gdschongik.gdsc.global.common.constant.SecurityConstant.*;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+public class CustomOAuth2AuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+    private final DefaultOAuth2AuthorizationRequestResolver delegate;
+
+    public CustomOAuth2AuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
+        this.delegate =
+                new DefaultOAuth2AuthorizationRequestResolver(clientRegistrationRepository, "/oauth2/authorization");
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        OAuth2AuthorizationRequest authorizationRequest = delegate.resolve(request);
+        return authorizationRequest != null ? customizeAuthorizationRequest(request, authorizationRequest) : null;
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        OAuth2AuthorizationRequest authorizationRequest = delegate.resolve(request, clientRegistrationId);
+        return authorizationRequest != null ? customizeAuthorizationRequest(request, authorizationRequest) : null;
+    }
+
+    private OAuth2AuthorizationRequest customizeAuthorizationRequest(
+            HttpServletRequest request, OAuth2AuthorizationRequest authorizationRequest) {
+
+        String referer = request.getHeader("Referer");
+        if (referer == null || referer.isEmpty()) {
+            return authorizationRequest;
+        }
+
+        Map<String, Object> additionalParameters = new HashMap<>();
+        additionalParameters.put(OAUTH_TARGET_URL_PARAM_NAME, referer);
+
+        return OAuth2AuthorizationRequest.from(authorizationRequest)
+                .additionalParameters(additionalParameters)
+                .build();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/security/CustomSuccessHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/CustomSuccessHandler.java
@@ -24,7 +24,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     public CustomSuccessHandler(JwtService jwtService, CookieUtil cookieUtil) {
         this.jwtService = jwtService;
         this.cookieUtil = cookieUtil;
-        setUseReferer(true);
+        setTargetUrlParameter(OAUTH_TARGET_URL_PARAM_NAME);
     }
 
     @Override


### PR DESCRIPTION
## 🌱 관련 이슈
- close #684

## 📌 작업 내용 및 특이사항
### 문제 상황
- 저번에 referer가 초기 클라이언트 요청 위치인걸 분명히 확인했었는데... 어째서인지 referer가 github.com으로 변경되어, 클라이언트가 로그인 이후 리다이렉트를 받지 못하는 이슈가 또 발생했습니다.
- 원인은 파악하기 어려웠고, 리다이렉트 로직을 referer 기반이 아닌, 다른 로직으로 수정했습니다.

### 콜백 URI 파라미터로 위치를 저장하기
- 저번에 `SavedRequestAwareAuthenticationSucessHandler` 로 해결하는 방법 찾아봤었는데요, 저희는 세션을 사용하고 있지 않기 때문에 불가능했습니다.
- 그러다가 든 생각이, github에서 callback url (= redirect uri) 적을 때 (`/login/oauth2/code`) 쿼리 파라미터로 이를 지정해주면 깃허브에서 리다이렉트를 내려주면서 referer가 소실되는 문제를 해결할 수 있지 않을까? 싶었습니다.
- `application-security.yml` 에서, 다음과 같이 수정하고 테스트해봤습니다.
    - `redirect-uri: "https://{baseHost}{basePort}{basePath}/login/oauth2/code/{registrationId}"`
    - `redirect-uri: "https://{baseHost}{basePort}{basePath}/login/oauth2/code/{registrationId}?target=https://local-onboarding.gdschongik.com"`
- 그리고`CustomSuccessHandler` 에서 `setUserReferer` (레퍼러 기반 리다이렉트 정책) 을 다음과 같이 변경했습니다.
```java
public CustomSuccessHandler(JwtService jwtService, CookieUtil cookieUtil) {
    this.jwtService = jwtService;
    this.cookieUtil = cookieUtil;
    setTargetUrlParameter(OAUTH_TARGET_URL_PARAM_NAME);
}
```
- 이러면 요청 URL에서 특정 파라미터의 값을 가져와서 그것을 리다이렉트 URL로 삼습니다.
- 결과는 잘 작동했습니다.

### OAuth 인가 요청에 추가 파라미터 넣기
- redirect uri에 추가 파라미터를 담는 요구사항이 많아서 그런지 스프링 시큐리티에는 이미 해당 기능 커스터마이징이 가능했습니다.
- `OAuth2AuthorizationRequestResolver` 라는게 있는데, 말그대로 'OAuth' '인가 요청'을 리졸브하는 클래스입니다. 즉 `resolve()` 메서드를 통해 `OAuth2AuthorizationRequest` 객체를 만들어서 반환합니다.
- 방법은 간단한데요, 이 request 객체의 `additionalParameters` 프로퍼티에 우리가 원하는 (`target`, `클라이언트 URL`) 쌍을 넣으면 됩니다. 클라이언트 URL = referrer이므로 이는 헤더에서 가져옵시다.
```java
private OAuth2AuthorizationRequest customizeAuthorizationRequest(
        HttpServletRequest request, OAuth2AuthorizationRequest authorizationRequest) {

    String referer = request.getHeader("Referer");
    if (referer == null || referer.isEmpty()) {
        return authorizationRequest;
    }

    Map<String, Object> additionalParameters = new HashMap<>();
    additionalParameters.put(OAUTH_TARGET_URL_PARAM_NAME, referer);

    return OAuth2AuthorizationRequest.from(authorizationRequest)
            .additionalParameters(additionalParameters)
            .build();
}
```
- 요런 느낌입니다. 이러면 잘 작동합니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OAuth2 인증 요청 처리를 개선하기 위해 새로운 상수와 사용자 정의 요청 해결자를 추가했습니다.
  - 인증 성공 시 사용되는 URL 타겟팅 방식을 개선했습니다.

- **Bug Fixes**
  - 인증 흐름의 리디렉션을 더 잘 처리하도록 설정을 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->