### PR TITLE
feat: 어드민에게 멘토 API 접근 권한 부여

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
@@ -123,7 +123,7 @@ public class WebSecurityConfig {
                 .requestMatchers("/admin/**")
                 .hasRole("ADMIN")
                 .requestMatchers("/mentor/**")
-                .hasRole("MENTOR")
+                .hasAnyRole("MENTOR", "ADMIN")
                 .anyRequest()
                 .authenticated());
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #691

## 📌 작업 내용 및 특이사항
- 어드민 권한을 가진 사용자가 멘토 권한이 없어도 `/mentor`에 접근할 수 있도록 수정

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **기능 개선**
	- `/mentor/**` 엔드포인트에 대한 접근 권한이 "MENTOR" 역할을 가진 사용자뿐만 아니라 "ADMIN" 역할을 가진 사용자도 허용하도록 변경되었습니다. 
	- 이 조정은 사용자 관리의 유연성을 높이고 관리 권한을 가진 사용자에게 더 나은 사용성을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->