### PR TITLE
refactor: 스터디 개강일 전에도 내 수강중인 스터디 조회 API에서 선별할 수 있도록 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
@@ -17,6 +17,7 @@ import com.gdschongik.gdsc.domain.study.dto.response.StudyResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -106,7 +107,8 @@ public class StudentStudyService {
     public StudentMyCurrentStudyResponse getMyCurrentStudy() {
         Member currentMember = memberUtil.getCurrentMember();
         StudyHistory studyHistory = studyHistoryRepository.findAllByStudent(currentMember).stream()
-                .filter(s -> s.getStudy().isStudyOngoing())
+                .filter(s -> s.getStudy().getApplicationPeriod().getStartDate().isBefore(LocalDateTime.now())
+                        && s.getStudy().getPeriod().getEndDate().isAfter(LocalDateTime.now()))
                 .findFirst()
                 .orElse(null);
         return StudentMyCurrentStudyResponse.from(studyHistory);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #693

## 📌 작업 내용 및 특이사항
- 개강일이 스터디 신청기간과 별개이므로 개강전에는 ` 수강중인 스터디 조회 API`가 수강중인 스터디를 null로 반환하고 있습니다.
이를 방지하기 위해 필터링 조건을 `신청 시작일~종강일`로 변경했습니다.
- 핵심 로직은 아닌 것 같아서 별도 메서드 분리는 하지 않았습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 현재 진행 중인 스터디를 보다 정확하게 필터링하는 기능 개선.
	- 스터디의 신청 기간에 따라 진행 중인 스터디를 확인할 수 있도록 로직 업데이트.
  
- **버그 수정**
	- 스터디의 시작 및 종료 날짜를 기준으로 진행 중인 스터디를 올바르게 판별하도록 수정.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->