### PR TITLE
fix: 무료 주문 생성 시 쿠폰 사용 로직이 누락된 문제 해결

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
@@ -164,6 +164,7 @@ public class OrderService {
         orderValidator.validateFreeOrderCreate(membership, issuedCoupon, currentMember);
 
         Order order = Order.createFree(request.orderNanoId(), membership, issuedCoupon.orElse(null), moneyInfo);
+        issuedCoupon.ifPresent(IssuedCoupon::use);
 
         orderRepository.save(order);
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #697

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 주문 생성 시 쿠폰 사용 처리 기능이 추가되었습니다.
- **버그 수정**
	- 주문 완료 시 쿠폰 상태 업데이트를 확인하는 테스트 케이스가 추가되었습니다.
	- 무료 주문 생성 시 쿠폰 사용 상태 업데이트를 검증하는 테스트가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->