### PR TITLE
feat: 스터디 시작 시간 및 종료 시간의 NotNull 검증 제거

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/request/StudyCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/request/StudyCreateRequest.java
@@ -27,6 +27,6 @@ public record StudyCreateRequest(
         @Future @NotNull(message = "스터디 시작일은 null이 될 수 없습니다.") @Schema(description = "스터디 시작일", pattern = DATE)
                 LocalDate startDate,
         @NotNull(message = "스터디 요일은 null이 될 수 없습니다.") @Schema(description = "스터디 요일") DayOfWeek dayOfWeek,
-        @NotNull @Schema(description = "스터디 시작 시간") LocalTime studyStartTime,
-        @NotNull @Schema(description = "스터디 종료 시간") LocalTime studyEndTime,
+        @Schema(description = "스터디 시작 시간") LocalTime studyStartTime,
+        @Schema(description = "스터디 종료 시간") LocalTime studyEndTime,
         @NotNull(message = "스터디 타입은 null이 될 수 없습니다.") @Schema(description = "스터디 타입") StudyType studyType) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #699

## 📌 작업 내용 및 특이사항
- 과제 스터디는 시작 시간과 종료 시간을 입력받지 않으므로 NotNull 조건을 제거했습니다.
- NotNull을 제거해도 도메인에서 별도로 검증이 이루어지므로 온라인/오프라인 스터디의 필드가 null이 될 일이 없습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **기능 변경**
	- 스터디 요청 생성 시 `studyStartTime`과 `studyEndTime` 필드에서 null 값을 허용하도록 변경되었습니다. 이로 인해 스터디 요청의 유효성 검사 로직이 변경되었습니다.
- **문서화**
	- 해당 필드에 대한 설명은 유지되어 API 문서의 명확성을 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->