### PR TITLE
feat: 스터디 멘토 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
@@ -1,6 +1,8 @@
 package com.gdschongik.gdsc.domain.member.dao;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberStudyRole;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -14,4 +16,6 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberCus
     Optional<Member> findByDiscordUsername(String discordUsername);
 
     Optional<Member> findByOauthId(String oauthId);
+
+    List<Member> findAllByStudyRole(MemberStudyRole studyRole);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/AdminStudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/AdminStudyController.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.domain.study.api;
 
 import com.gdschongik.gdsc.domain.study.application.AdminStudyService;
 import com.gdschongik.gdsc.domain.study.dto.request.StudyCreateRequest;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyMentorResponse;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -34,6 +35,13 @@ public class AdminStudyController {
     @GetMapping
     public ResponseEntity<List<StudyResponse>> getStudies() {
         List<StudyResponse> response = adminStudyService.getAllStudies();
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "멘토 목록 조회", description = "모든 멘토 목록을 조회합니다. 코어멤버만 접근 가능합니다.")
+    @GetMapping("/mentors")
+    public ResponseEntity<List<StudyMentorResponse>> getMentors() {
+        List<StudyMentorResponse> response = adminStudyService.getAllMentors();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/AdminStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/AdminStudyService.java
@@ -2,11 +2,13 @@ package com.gdschongik.gdsc.domain.study.application;
 
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberStudyRole;
 import com.gdschongik.gdsc.domain.study.dao.StudyDetailRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyRepository;
 import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import com.gdschongik.gdsc.domain.study.dto.request.StudyCreateRequest;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyMentorResponse;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyResponse;
 import com.gdschongik.gdsc.domain.study.factory.StudyDomainFactory;
 import com.gdschongik.gdsc.global.exception.CustomException;
@@ -59,5 +61,12 @@ public class AdminStudyService {
     @Transactional(readOnly = true)
     public List<StudyResponse> getAllStudies() {
         return studyRepository.findAll().stream().map(StudyResponse::from).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<StudyMentorResponse> getAllMentors() {
+        return memberRepository.findAllByStudyRole(MemberStudyRole.MENTOR).stream()
+                .map(StudyMentorResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyMentorResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyMentorResponse.java
@@ -1,0 +1,9 @@
+package com.gdschongik.gdsc.domain.study.dto.response;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+
+public record StudyMentorResponse(Long mentorId, String mentorName) {
+    public static StudyMentorResponse from(Member mentor) {
+        return new StudyMentorResponse(mentor.getId(), mentor.getName());
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #701

## 📌 작업 내용 및 특이사항
- 멘토 목록 조회하는 api를 새로 만들었습니다.
- 스터디 개설 시 멘토를 설정하는 드롭다운이 필요하고, 여기서 활용됩니다.
이미지 상으로는 검색이지만, 피그마에 기획이 반영되지 않은 것 같습니다.
![image](https://github.com/user-attachments/assets/b380d9aa-3383-4fda-94b4-970d1a103de2)


## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 스터디 역할에 따라 멤버를 검색할 수 있는 기능 추가.
	- 멘토 정보를 조회할 수 있는 새로운 API 엔드포인트 추가.
- **버그 수정**
	- 멘토 정보를 반환하는 서비스 로직 개선.
- **문서화**
	- 새로운 API 메서드에 대한 메타데이터 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->