### PR TITLE
fix: 스터디 중복신청 불가능하도록 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
@@ -42,7 +42,7 @@ public class StudentStudyService {
         Member currentMember = memberUtil.getCurrentMember();
         List<StudyHistory> studyHistories = studyHistoryRepository.findAllByStudent(currentMember);
         Optional<Study> appliedStudy = studyHistories.stream()
-                .filter(StudyHistory::isStudyOngoing)
+                .filter(StudyHistory::isWithinApplicationAndCourse)
                 .map(StudyHistory::getStudy)
                 .findFirst();
         List<StudyResponse> studyResponses = studyRepository.findAll().stream()
@@ -106,7 +106,7 @@ public class StudentStudyService {
     public StudentMyCurrentStudyResponse getMyCurrentStudy() {
         Member currentMember = memberUtil.getCurrentMember();
         StudyHistory studyHistory = studyHistoryRepository.findAllByStudent(currentMember).stream()
-                .filter(StudyHistory::isStudyOngoing)
+                .filter(StudyHistory::isWithinApplicationAndCourse)
                 .findFirst()
                 .orElse(null);
         return StudentMyCurrentStudyResponse.from(studyHistory);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
@@ -17,7 +17,6 @@ import com.gdschongik.gdsc.domain.study.dto.response.StudyResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -43,8 +42,8 @@ public class StudentStudyService {
         Member currentMember = memberUtil.getCurrentMember();
         List<StudyHistory> studyHistories = studyHistoryRepository.findAllByStudent(currentMember);
         Optional<Study> appliedStudy = studyHistories.stream()
+                .filter(StudyHistory::isStudyOngoing)
                 .map(StudyHistory::getStudy)
-                .filter(Study::isStudyOngoing)
                 .findFirst();
         List<StudyResponse> studyResponses = studyRepository.findAll().stream()
                 .filter(Study::isApplicable)
@@ -107,8 +106,7 @@ public class StudentStudyService {
     public StudentMyCurrentStudyResponse getMyCurrentStudy() {
         Member currentMember = memberUtil.getCurrentMember();
         StudyHistory studyHistory = studyHistoryRepository.findAllByStudent(currentMember).stream()
-                .filter(s -> s.getStudy().getApplicationPeriod().getStartDate().isBefore(LocalDateTime.now())
-                        && s.getStudy().getPeriod().getEndDate().isAfter(LocalDateTime.now()))
+                .filter(StudyHistory::isStudyOngoing)
                 .findFirst()
                 .orElse(null);
         return StudentMyCurrentStudyResponse.from(studyHistory);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
@@ -176,7 +176,9 @@ public class Study extends BaseSemesterEntity {
     }
 
     public boolean isStudyOngoing() {
-        return period.isOpen();
+        LocalDateTime now = LocalDateTime.now();
+        return applicationPeriod.getStartDate().isBefore(now)
+                && period.getEndDate().isAfter(now);
     }
 
     public LocalDate getStartDate() {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
@@ -175,7 +175,7 @@ public class Study extends BaseSemesterEntity {
         return applicationPeriod.isOpen();
     }
 
-    public boolean isStudyOngoing() {
+    public boolean isWithinApplicationAndCourse() {
         LocalDateTime now = LocalDateTime.now();
         return applicationPeriod.getStartDate().isBefore(now)
                 && period.getEndDate().isAfter(now);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -56,7 +56,7 @@ public class StudyHistory extends BaseEntity {
     }
 
     // 데이터 전달 로직
-    public boolean isStudyOngoing() {
-        return study.isStudyOngoing();
+    public boolean isWithinApplicationAndCourse() {
+        return study.isWithinApplicationAndCourse();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
@@ -24,9 +24,10 @@ public class StudyHistoryValidator {
         }
 
         // 이미 듣고 있는 스터디가 있는 경우
-        boolean isInOngoingStudy = currentMemberStudyHistories.stream().anyMatch(StudyHistory::isStudyOngoing);
+        boolean hasAppliedStudy =
+                currentMemberStudyHistories.stream().anyMatch(StudyHistory::isWithinApplicationAndCourse);
 
-        if (isInOngoingStudy) {
+        if (hasAppliedStudy) {
             throw new CustomException(STUDY_HISTORY_ONGOING_ALREADY_EXISTS);
         }
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
@@ -24,7 +24,6 @@ public class StudyHistoryValidator {
         }
 
         // 이미 듣고 있는 스터디가 있는 경우
-        // todo: StudyHistory가 아닌 Study의 isOngoning 호출하도록 수정
         boolean isInOngoingStudy = currentMemberStudyHistories.stream().anyMatch(StudyHistory::isStudyOngoing);
 
         if (isInOngoingStudy) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #708

## 📌 작업 내용 및 특이사항
- 수강신청 종료일이 개강일보다 앞서는 경우 이미 신청한 스터디가 있어도 다른 스터디를 신청할 수 있는 케이스가 발생했습니다.
- 기존 `isOngoing` 메서드는 스터디 `개강일 ~ 종강일`에 포함되는지를 판단했지만, `수강신청 시작일 ~ 종강일`을 기준으로 해야 수강신청 종료일과 개강일 사이의 기간에 대한 처리가 가능합니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **기능 개선**
	- 진행 중인 연구를 확인하는 로직을 개선하여 보다 정확한 판단을 가능하게 하였습니다.
	- `StudyHistory` 클래스를 통해 진행 중인 연구를 필터링하도록 변경하여 코드의 가독성과 유지보수성을 향상시켰습니다.

- **주석 수정**
	- `StudyHistoryValidator` 클래스의 주석을 수정하여 연구 상태 확인 로직에 대한 방향성을 명확히 하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->