### PR TITLE
fix: 과제 미제출과 제출전을 구별하도록 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentHistoryStatusResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentHistoryStatusResponse.java
@@ -1,7 +1,5 @@
 package com.gdschongik.gdsc.domain.study.dto.response;
 
-import static com.gdschongik.gdsc.domain.study.domain.SubmissionFailureType.NOT_SUBMITTED;
-
 import com.gdschongik.gdsc.domain.study.domain.*;
 import com.gdschongik.gdsc.domain.study.domain.vo.Assignment;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -34,7 +32,7 @@ public record AssignmentHistoryStatusResponse(
                     studyDetail.getAssignment().getDescriptionLink(),
                     studyDetail.getAssignment().getDeadline(),
                     null,
-                    NOT_SUBMITTED,
+                    null,
                     null);
         }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmittableDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmittableDto.java
@@ -28,7 +28,7 @@ public record AssignmentSubmittableDto(
         }
 
         if (assignmentHistory == null) {
-            return notSubmittedAssignment(studyDetail, assignment);
+            return beforeAssignmentSubmit(studyDetail, assignment);
         }
 
         return new AssignmentSubmittableDto(
@@ -48,16 +48,16 @@ public record AssignmentSubmittableDto(
                 studyDetail.getId(), assignment.getStatus(), studyDetail.getWeek(), null, null, null, null, null, null);
     }
 
-    private static AssignmentSubmittableDto notSubmittedAssignment(StudyDetail studyDetail, Assignment assignment) {
+    private static AssignmentSubmittableDto beforeAssignmentSubmit(StudyDetail studyDetail, Assignment assignment) {
         return new AssignmentSubmittableDto(
                 studyDetail.getId(),
                 assignment.getStatus(),
                 studyDetail.getWeek(),
                 assignment.getTitle(),
-                AssignmentSubmissionStatus.FAILURE,
+                null,
                 assignment.getDescriptionLink(),
                 assignment.getDeadline(),
                 null,
-                SubmissionFailureType.NOT_SUBMITTED);
+                null);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #720

## 📌 작업 내용 및 특이사항
- assignmentHistory가 null인 경우(제출 전), 과제 제출 상태와 실패여부에 대한 필드를 null로 반환하도록 수정했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 과제 제출 상태를 보다 유연하게 처리할 수 있도록 응답 구조를 개선했습니다.
	- 과제 제출 전 상태를 보다 명확하게 표현하기 위해 메서드 이름을 변경했습니다.

- **버그 수정**
	- 제출되지 않은 과제를 실패로 간주하지 않고, 정의되지 않은 상태로 처리하도록 로직을 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->