### PR TITLE
fix: 가입 미완료인 이전 회차 멤버십 있어도 새로운 멤버십 생성 가능하도록 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -69,10 +69,10 @@ public class MembershipService {
                 .findById(recruitmentRoundId)
                 .orElseThrow(() -> new CustomException(RECRUITMENT_ROUND_NOT_FOUND));
 
-        boolean isMembershipAlreadySubmitted =
-                membershipRepository.existsByMemberAndRecruitment(currentMember, recruitmentRound.getRecruitment());
+        boolean isMembershipDuplicate = membershipRepository.existsByMemberAndRecruitmentWithSatisfiedRequirements(
+                currentMember, recruitmentRound.getRecruitment());
 
-        membershipValidator.validateMembershipSubmit(currentMember, recruitmentRound, isMembershipAlreadySubmitted);
+        membershipValidator.validateMembershipSubmit(currentMember, recruitmentRound, isMembershipDuplicate);
 
         Membership membership = Membership.createMembership(currentMember, recruitmentRound);
         membershipRepository.save(membership);

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipCustomRepository.java
@@ -5,5 +5,5 @@ import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 
 public interface MembershipCustomRepository {
 
-    boolean existsByMemberAndRecruitment(Member member, Recruitment recruitment);
+    boolean existsByMemberAndRecruitmentWithSatisfiedRequirements(Member member, Recruitment recruitment);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipCustomRepositoryImpl.java
@@ -2,9 +2,11 @@ package com.gdschongik.gdsc.domain.membership.dao;
 
 import static com.gdschongik.gdsc.domain.membership.domain.QMembership.*;
 
+import com.gdschongik.gdsc.domain.common.model.RequirementStatus;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.EnumPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
@@ -14,11 +16,14 @@ public class MembershipCustomRepositoryImpl implements MembershipCustomRepositor
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public boolean existsByMemberAndRecruitment(Member member, Recruitment recruitment) {
+    public boolean existsByMemberAndRecruitmentWithSatisfiedRequirements(Member member, Recruitment recruitment) {
         Integer fetchOne = queryFactory
                 .selectOne()
                 .from(membership)
-                .where(eqMember(member), eqRecruitment(recruitment))
+                .where(
+                        eqMember(member),
+                        eqRecruitment(recruitment),
+                        eqRequirementStatus(membership.regularRequirement.paymentStatus, RequirementStatus.SATISFIED))
                 .fetchFirst();
 
         return fetchOne != null;
@@ -30,5 +35,10 @@ public class MembershipCustomRepositoryImpl implements MembershipCustomRepositor
 
     private BooleanExpression eqRecruitment(Recruitment recruitment) {
         return recruitment != null ? membership.recruitmentRound.recruitment.eq(recruitment) : null;
+    }
+
+    private BooleanExpression eqRequirementStatus(
+            EnumPath<RequirementStatus> requirement, RequirementStatus requirementStatus) {
+        return requirementStatus != null ? requirement.eq(requirementStatus) : null;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidator.java
@@ -13,15 +13,15 @@ import lombok.RequiredArgsConstructor;
 public class MembershipValidator {
 
     public void validateMembershipSubmit(
-            Member currentMember, RecruitmentRound recruitmentRound, boolean isMembershipAlreadySubmitted) {
+            Member currentMember, RecruitmentRound recruitmentRound, boolean isMembershipDuplicate) {
         // 준회원인지 검증
         // TODO: 어드민인 경우 리쿠르팅 지원 및 결제에 대한 정책 검토 필요. 현재는 불가능하도록 설정
         if (!currentMember.isAssociate()) {
             throw new CustomException(MEMBERSHIP_NOT_APPLICABLE);
         }
 
-        // 이미 접수한 멤버십이 있는지 검증
-        if (isMembershipAlreadySubmitted) {
+        // 이미 멤버십이 있는지 검증
+        if (isMembershipDuplicate) {
             throw new CustomException(MEMBERSHIP_ALREADY_SUBMITTED);
         }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -37,6 +37,8 @@ public class MembershipServiceTest extends IntegrationTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessage(RECRUITMENT_ROUND_NOT_FOUND.getMessage());
         }
+
+        // todo: 1차 모집시 멤버십 생성 후 실제 가입은 하지 않고 2차 모집 시 가입하려고 하는 케이스 추가
     }
 
     @Test


### PR DESCRIPTION
## 🌱 관련 이슈
- close #727

## 📌 작업 내용 및 특이사항
- 1차 모집 기간에 멤버십을 생성만 하고 과정을 완료하지 않은 경우, 2차 모집시 멤버십을 생성할 수 없는 문제가 있습니다.

## 📝 참고사항
-

## 📚 기타
-
