### PR TITLE
test: 1차 모집시 멤버십 생성 후 실제 가입하지 않은 경우 2차 모집 멤버십 접수 테스트 추가

### DIFF
--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -2,15 +2,19 @@ package com.gdschongik.gdsc.domain.membership.application;
 
 import static com.gdschongik.gdsc.domain.common.model.RequirementStatus.SATISFIED;
 import static com.gdschongik.gdsc.domain.member.domain.MemberRole.ASSOCIATE;
+import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.dao.MembershipRepository;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
+import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.IntegrationTest;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,7 +42,36 @@ public class MembershipServiceTest extends IntegrationTest {
                     .hasMessage(RECRUITMENT_ROUND_NOT_FOUND.getMessage());
         }
 
-        // todo: 1차 모집시 멤버십 생성 후 실제 가입은 하지 않고 2차 모집 시 가입하려고 하는 케이스 추가
+        @Test
+        void 멤버십을_1차모집시_생성했지만_정회원_가입조건을_만족하지_않았다면_2차모집에서_멤버십_가입신청에_성공한다() {
+            // given
+            createMember();
+            logoutAndReloginAs(1L, ASSOCIATE);
+
+            RecruitmentRound firstRound = createRecruitmentRound(
+                    RECRUITMENT_ROUND_NAME,
+                    LocalDateTime.now().minusDays(5),
+                    LocalDateTime.now().plusDays(1),
+                    ACADEMIC_YEAR,
+                    SEMESTER_TYPE,
+                    ROUND_TYPE,
+                    Money.from(20000L));
+
+            RecruitmentRound secondRound = createRecruitmentRound(
+                    RECRUITMENT_ROUND_NAME,
+                    LocalDateTime.now().minusDays(1),
+                    LocalDateTime.now().plusDays(1),
+                    ACADEMIC_YEAR,
+                    SEMESTER_TYPE,
+                    RoundType.SECOND,
+                    Money.from(20000L));
+
+            // when & then
+            membershipService.submitMembership(firstRound.getId());
+
+            assertThatCode(() -> membershipService.submitMembership(secondRound.getId()))
+                    .doesNotThrowAnyException();
+        }
     }
 
     @Test


### PR DESCRIPTION
## 🌱 관련 이슈
- close #729
- #728

## 📌 작업 내용 및 특이사항
- 지난번에 todo로 남겨뒀던 부분 테스트 작성했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
	- 멤버십 신청 프로세스의 두 번째 모집 라운드에서의 성공적인 신청을 검증하는 새로운 테스트 케이스 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->