### PR TITLE
fix: 레포지토리 조회 메서드가 레포지토리 링크를 받도록 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryService.java
@@ -1,6 +1,5 @@
 package com.gdschongik.gdsc.domain.study.application;
 
-import static com.gdschongik.gdsc.global.common.constant.GithubConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
@@ -56,8 +55,7 @@ public class StudentStudyHistoryService {
 
         boolean isAnyAssignmentSubmitted =
                 assignmentHistoryRepository.existsSubmittedAssignmentByMemberAndStudy(currentMember, study);
-        String ownerRepo = getOwnerRepo(request.repositoryLink());
-        GHRepository repository = githubClient.getRepository(ownerRepo);
+        GHRepository repository = githubClient.getRepository(request.repositoryLink());
         // TODO: GHRepository 등을 wrapper로 감싸서 테스트 가능하도록 변경
         studyHistoryValidator.validateUpdateRepository(
                 isAnyAssignmentSubmitted, String.valueOf(repository.getOwner().getId()), currentMember.getOauthId());
@@ -69,11 +67,6 @@ public class StudentStudyHistoryService {
                 "[StudyHistoryService] 레포지토리 입력: studyHistoryId={}, repositoryLink={}",
                 studyHistory.getId(),
                 request.repositoryLink());
-    }
-
-    private String getOwnerRepo(String repositoryLink) {
-        int startIndex = repositoryLink.indexOf(GITHUB_DOMAIN) + GITHUB_DOMAIN.length();
-        return repositoryLink.substring(startIndex);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
@@ -60,8 +60,7 @@ public class GithubClient {
     }
 
     private AssignmentSubmission getLatestAssignmentSubmission(String repo, int week) {
-        String ownerRepo = getOwnerRepo(repo);
-        GHRepository ghRepository = getRepository(ownerRepo);
+        GHRepository ghRepository = getRepository(repo);
         String assignmentPath = GITHUB_ASSIGNMENT_PATH.formatted(week);
 
         // GHContent#getSize() 의 경우 한글 문자열을 byte 단위로 계산하기 때문에, 직접 content를 읽어서 길이를 계산

--- a/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
@@ -30,8 +30,9 @@ public class GithubClient {
     private final GitHub github;
     private final GitHubConnector gitHubConnector = GitHubConnector.DEFAULT;
 
-    public GHRepository getRepository(String ownerRepo) {
+    public GHRepository getRepository(String repo) {
         try {
+            String ownerRepo = getOwnerRepo(repo);
             return github.getRepository(ownerRepo);
         } catch (IOException e) {
             throw new CustomException(GITHUB_REPOSITORY_NOT_FOUND);
@@ -59,7 +60,8 @@ public class GithubClient {
     }
 
     private AssignmentSubmission getLatestAssignmentSubmission(String repo, int week) {
-        GHRepository ghRepository = getRepository(repo);
+        String ownerRepo = getOwnerRepo(repo);
+        GHRepository ghRepository = getRepository(ownerRepo);
         String assignmentPath = GITHUB_ASSIGNMENT_PATH.formatted(week);
 
         // GHContent#getSize() 의 경우 한글 문자열을 byte 단위로 계산하기 때문에, 직접 content를 읽어서 길이를 계산
@@ -106,5 +108,10 @@ public class GithubClient {
         } catch (IOException e) {
             throw new CustomException(GITHUB_COMMIT_DATE_FETCH_FAILED);
         }
+    }
+
+    private String getOwnerRepo(String repositoryLink) {
+        int startIndex = repositoryLink.indexOf(GITHUB_DOMAIN) + GITHUB_DOMAIN.length();
+        return repositoryLink.substring(startIndex);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #749

## 📌 작업 내용 및 특이사항
- `GithubClient`의 `getRepository` 메서드는 'owner/repo'의 형식으로 값을 받아야 하는데, repo링크가 통째로 들어가서 발생한 이슈입니다.
- repo 링크를 받아서 `getRepository` 메서드 내부에서 변환하도록 수정했습니다.
- `getOwnerRepo` 메서드를 GithubUtil로 분리할까도 생각해봤지만, api 호출을 위해 적절한 형식으로 변환하는 것도 GithubClient의 역할이라고 볼 수 있고, 결정적으로 사용하는 곳이 여기밖에 없어서 분리하지 않았습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- `getOwnerRepo` 메서드를 추가하여 전체 리포지토리 링크에서 소유자 및 리포지토리 이름을 추출하는 로직을 중앙 집중화했습니다.
	- `getRepository` 메서드의 매개변수를 명확하게 변경하여 리포지토리 정보를 보다 간결하게 처리합니다.
- **버그 수정**
	- API 호출 시 리포지토리 이름의 일관성을 보장하기 위해 `getCommitDate` 메서드를 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->