### PR TITLE
feat: 과제 응답 DTO에 커리큘럼 시작일 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentResponse.java
@@ -5,6 +5,7 @@ import com.gdschongik.gdsc.domain.study.domain.StudyStatus;
 import com.gdschongik.gdsc.domain.study.domain.vo.Assignment;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 public record AssignmentResponse(
         Long studyDetailId,
@@ -13,7 +14,8 @@ public record AssignmentResponse(
         @Schema(description = "마감 기한") LocalDateTime deadline,
         @Schema(description = "주차") Long week,
         @Schema(description = "과제 명세 링크") String descriptionLink,
-        @Schema(description = "과제 상태") StudyStatus assignmentStatus) {
+        @Schema(description = "과제 상태") StudyStatus assignmentStatus,
+        @Schema(description = "커리큘럼 시작일") LocalTime curriculumStartAt) {
     public static AssignmentResponse from(StudyDetail studyDetail) {
         Assignment assignment = studyDetail.getAssignment();
         return new AssignmentResponse(
@@ -23,6 +25,7 @@ public record AssignmentResponse(
                 assignment.getDeadline(),
                 studyDetail.getWeek(),
                 assignment.getDescriptionLink(),
-                assignment.getStatus());
+                assignment.getStatus(),
+                studyDetail.getCurriculum().getStartAt());
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #752

## 📌 작업 내용 및 특이사항
- 프론트측 요청으로 과제 응답에 커리큘럼 시작일 필드를 추가했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 과제 응답에 "커리큘럼 시작일" 필드 추가로 과제에 대한 추가 정보 제공.
  
- **버그 수정**
	- 과제 데이터 구조 개선으로 더 정확한 정보 표현.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->