### PR TITLE
feat: 과제 제출 컨벤션 소문자로 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/GithubConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/GithubConstant.java
@@ -3,7 +3,7 @@ package com.gdschongik.gdsc.global.common.constant;
 public class GithubConstant {
 
     public static final String GITHUB_DOMAIN = "github.com/";
-    public static final String GITHUB_ASSIGNMENT_PATH = "week%d/WIL.md";
+    public static final String GITHUB_ASSIGNMENT_PATH = "week%d/wil.md";
     public static final String GITHUB_USER_API_URL = "https://api.github.com/user/%s";
 
     private GithubConstant() {}

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/StudyConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/StudyConstant.java
@@ -39,7 +39,7 @@ public class StudyConstant {
     public static final String CURRICULUM_DESCRIPTION = "curriculumDescription";
 
     // AssignmentHistory
-    public static final String SUBMISSION_LINK = "https://github.com/ownername/reponame/blob/main/week1/WIL.md";
+    public static final String SUBMISSION_LINK = "https://github.com/ownername/reponame/blob/main/week1/wil.md";
     public static final String COMMIT_HASH = "aa11bb22cc33";
     public static final Integer CONTENT_LENGTH = 2000;
     public static final LocalDateTime COMMITTED_AT = LocalDateTime.of(2024, 9, 8, 0, 0);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #731

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- GitHub 과제 경로의 파일 확장자를 대문자에서 소문자로 변경하여 파일 접근 시의 일관성을 개선했습니다.
	- 제출 링크의 파일 이름을 대문자에서 소문자로 변경하여 명명 규칙을 일관되게 유지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->