### PR TITLE
feat: 수강신청 철회 시 연관 엔티티도 같이 삭제하도록 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/CommonStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/CommonStudyService.java
@@ -1,8 +1,10 @@
 package com.gdschongik.gdsc.domain.study.application;
 
-import static com.gdschongik.gdsc.global.exception.ErrorCode.STUDY_NOT_FOUND;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.study.dao.AssignmentHistoryRepository;
+import com.gdschongik.gdsc.domain.study.dao.AttendanceRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyAnnouncementRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyRepository;
@@ -29,6 +31,8 @@ public class CommonStudyService {
     private final StudyRepository studyRepository;
     private final StudyHistoryRepository studyHistoryRepository;
     private final StudyAnnouncementRepository studyAnnouncementRepository;
+    private final AttendanceRepository attendanceRepository;
+    private final AssignmentHistoryRepository assignmentHistoryRepository;
     private final MemberUtil memberUtil;
     private final StudyValidator studyValidator;
 
@@ -50,5 +54,27 @@ public class CommonStudyService {
                 studyAnnouncementRepository.findAllByStudyIdOrderByCreatedAtDesc(studyId);
 
         return studyAnnouncements.stream().map(StudyAnnouncementResponse::from).toList();
+    }
+
+    /**
+     * 이벤트 핸들러에서 사용되므로, `@Transactional` 을 사용하지 않습니다.
+     */
+    public void deleteAttendanceByStudyHistory(Long studyHistoryId) {
+        StudyHistory studyHistory = studyHistoryRepository
+                .findById(studyHistoryId)
+                .orElseThrow(() -> new CustomException(STUDY_HISTORY_NOT_FOUND));
+
+        attendanceRepository.deleteByStudyHistory(studyHistory);
+    }
+
+    /**
+     * 이벤트 핸들러에서 사용되므로, `@Transactional` 을 사용하지 않습니다.
+     */
+    public void deleteAssignmentHistoryByStudyHistory(Long studyHistoryId) {
+        StudyHistory studyHistory = studyHistoryRepository
+                .findById(studyHistoryId)
+                .orElseThrow(() -> new CustomException(STUDY_HISTORY_NOT_FOUND));
+
+        assignmentHistoryRepository.deleteByStudyHistory(studyHistory);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
@@ -70,6 +70,7 @@ public class StudentStudyService {
 
     @Transactional
     public void cancelStudyApply(Long studyId) {
+        // TODO: 통합 테스트 통해 수강철회 관련 이벤트 처리 확인
         Study study = studyRepository.findById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
         Member currentMember = memberUtil.getCurrentMember();
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyEventHandler.java
@@ -1,0 +1,23 @@
+package com.gdschongik.gdsc.domain.study.application;
+
+import com.gdschongik.gdsc.domain.study.domain.StudyApplyCanceledEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StudyEventHandler {
+
+    private final CommonStudyService commonStudyService;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleStudyApplyCanceledEvent(StudyApplyCanceledEvent event) {
+        log.info("[StudyEventHandler] 스터디 수강신청 취소 이벤트 수신: studyHistoryId={}", event.studyHistoryId());
+        commonStudyService.deleteAttendanceByStudyHistory(event.studyHistoryId());
+        commonStudyService.deleteAssignmentHistoryByStudyHistory(event.studyHistoryId());
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepository.java
@@ -3,6 +3,7 @@ package com.gdschongik.gdsc.domain.study.dao;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
 import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import java.util.List;
 
 public interface AssignmentHistoryCustomRepository {
@@ -10,4 +11,6 @@ public interface AssignmentHistoryCustomRepository {
     boolean existsSubmittedAssignmentByMemberAndStudy(Member member, Study study);
 
     List<AssignmentHistory> findAssignmentHistoriesByStudentAndStudyId(Member member, Long studyId);
+
+    void deleteByStudyHistory(StudyHistory studyHistory);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepositoryImpl.java
@@ -7,6 +7,7 @@ import static com.gdschongik.gdsc.domain.study.domain.QStudyDetail.studyDetail;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
 import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -52,5 +53,13 @@ public class AssignmentHistoryCustomRepositoryImpl implements AssignmentHistoryC
 
     private BooleanExpression eqStudyId(Long studyId) {
         return studyId != null ? studyDetail.study.id.eq(studyId) : null;
+    }
+
+    @Override
+    public void deleteByStudyHistory(StudyHistory studyHistory) {
+        queryFactory
+                .delete(assignmentHistory)
+                .where(eqMember(studyHistory.getStudent()).and(eqStudy(studyHistory.getStudy())))
+                .execute();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepository.java
@@ -2,8 +2,11 @@ package com.gdschongik.gdsc.domain.study.dao;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.Attendance;
+import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import java.util.List;
 
 public interface AttendanceCustomRepository {
     List<Attendance> findByMemberAndStudyId(Member member, Long studyId);
+
+    void deleteByStudyHistory(StudyHistory studyHistory);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepositoryImpl.java
@@ -6,6 +6,7 @@ import static com.gdschongik.gdsc.domain.study.domain.QStudyDetail.studyDetail;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.Attendance;
+import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -32,5 +33,16 @@ public class AttendanceCustomRepositoryImpl implements AttendanceCustomRepositor
 
     private BooleanExpression eqStudyId(Long studyId) {
         return studyId != null ? attendance.studyDetail.study.id.eq(studyId) : null;
+    }
+
+    @Override
+    public void deleteByStudyHistory(StudyHistory studyHistory) {
+        queryFactory
+                .delete(attendance)
+                .where(attendance
+                        .student
+                        .eq(studyHistory.getStudent())
+                        .and(attendance.studyDetail.study.eq(studyHistory.getStudy())))
+                .execute();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyApplyCanceledEvent.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyApplyCanceledEvent.java
@@ -1,0 +1,3 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+public record StudyApplyCanceledEvent(Long studyHistoryId) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PreRemove;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -46,6 +47,11 @@ public class StudyHistory extends BaseEntity {
 
     public static StudyHistory create(Member student, Study study) {
         return StudyHistory.builder().student(student).study(study).build();
+    }
+
+    @PreRemove
+    private void preRemove() {
+        registerEvent(new StudyApplyCanceledEvent(this.id));
     }
 
     /**


### PR DESCRIPTION
## 🌱 관련 이슈
- close #755

## 📌 작업 내용 및 특이사항
- 출석, 과제제출정보 제거

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 특정 연구 이력과 관련된 출석 및 과제 기록을 삭제할 수 있는 기능 추가.
	- 연구 신청 취소 이벤트를 처리하는 새로운 이벤트 핸들러 클래스 추가.
	- 연구 이력 삭제 시 이벤트를 등록하는 기능 추가.

- **버그 수정**
	- 연구 신청 취소 처리에 대한 통합 테스트 필요성에 대한 주석 추가.

- **문서화**
	- 새로운 이벤트 레코드 `StudyApplyCanceledEvent` 정의.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->