### PR TITLE
fix: 삭제 이벤트 연관 객체 ID를 받아서 처리하도록 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/CommonStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/CommonStudyService.java
@@ -59,22 +59,14 @@ public class CommonStudyService {
     /**
      * 이벤트 핸들러에서 사용되므로, `@Transactional` 을 사용하지 않습니다.
      */
-    public void deleteAttendanceByStudyHistory(Long studyHistoryId) {
-        StudyHistory studyHistory = studyHistoryRepository
-                .findById(studyHistoryId)
-                .orElseThrow(() -> new CustomException(STUDY_HISTORY_NOT_FOUND));
-
-        attendanceRepository.deleteByStudyHistory(studyHistory);
+    public void deleteAttendance(Long studyId, Long memberId) {
+        attendanceRepository.deleteByStudyIdAndMemberId(studyId, memberId);
     }
 
     /**
      * 이벤트 핸들러에서 사용되므로, `@Transactional` 을 사용하지 않습니다.
      */
-    public void deleteAssignmentHistoryByStudyHistory(Long studyHistoryId) {
-        StudyHistory studyHistory = studyHistoryRepository
-                .findById(studyHistoryId)
-                .orElseThrow(() -> new CustomException(STUDY_HISTORY_NOT_FOUND));
-
-        assignmentHistoryRepository.deleteByStudyHistory(studyHistory);
+    public void deleteAssignmentHistory(Long studyId, Long memberId) {
+        assignmentHistoryRepository.deleteByStudyIdAndMemberId(studyId, memberId);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudyEventHandler.java
@@ -16,8 +16,8 @@ public class StudyEventHandler {
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handleStudyApplyCanceledEvent(StudyApplyCanceledEvent event) {
-        log.info("[StudyEventHandler] 스터디 수강신청 취소 이벤트 수신: studyHistoryId={}", event.studyHistoryId());
-        commonStudyService.deleteAttendanceByStudyHistory(event.studyHistoryId());
-        commonStudyService.deleteAssignmentHistoryByStudyHistory(event.studyHistoryId());
+        log.info("[StudyEventHandler] 스터디 수강신청 취소 이벤트 수신: studyId={}, memberId={}", event.studyId(), event.memberId());
+        commonStudyService.deleteAttendance(event.studyId(), event.memberId());
+        commonStudyService.deleteAssignmentHistory(event.studyId(), event.memberId());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepository.java
@@ -3,7 +3,6 @@ package com.gdschongik.gdsc.domain.study.dao;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
 import com.gdschongik.gdsc.domain.study.domain.Study;
-import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import java.util.List;
 
 public interface AssignmentHistoryCustomRepository {
@@ -12,5 +11,5 @@ public interface AssignmentHistoryCustomRepository {
 
     List<AssignmentHistory> findAssignmentHistoriesByStudentAndStudyId(Member member, Long studyId);
 
-    void deleteByStudyHistory(StudyHistory studyHistory);
+    void deleteByStudyIdAndMemberId(Long studyId, Long memberId);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepositoryImpl.java
@@ -7,7 +7,6 @@ import static com.gdschongik.gdsc.domain.study.domain.QStudyDetail.studyDetail;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
 import com.gdschongik.gdsc.domain.study.domain.Study;
-import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -56,10 +55,14 @@ public class AssignmentHistoryCustomRepositoryImpl implements AssignmentHistoryC
     }
 
     @Override
-    public void deleteByStudyHistory(StudyHistory studyHistory) {
+    public void deleteByStudyIdAndMemberId(Long studyId, Long memberId) {
         queryFactory
                 .delete(assignmentHistory)
-                .where(eqMember(studyHistory.getStudent()).and(eqStudy(studyHistory.getStudy())))
+                .where(eqMemberId(memberId), eqStudyId(studyId))
                 .execute();
+    }
+
+    private BooleanExpression eqMemberId(Long memberId) {
+        return memberId != null ? assignmentHistory.member.id.eq(memberId) : null;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepository.java
@@ -2,11 +2,10 @@ package com.gdschongik.gdsc.domain.study.dao;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.Attendance;
-import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import java.util.List;
 
 public interface AttendanceCustomRepository {
     List<Attendance> findByMemberAndStudyId(Member member, Long studyId);
 
-    void deleteByStudyHistory(StudyHistory studyHistory);
+    void deleteByStudyIdAndMemberId(Long studyId, Long memberId);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepositoryImpl.java
@@ -6,7 +6,6 @@ import static com.gdschongik.gdsc.domain.study.domain.QStudyDetail.studyDetail;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.Attendance;
-import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -36,13 +35,10 @@ public class AttendanceCustomRepositoryImpl implements AttendanceCustomRepositor
     }
 
     @Override
-    public void deleteByStudyHistory(StudyHistory studyHistory) {
+    public void deleteByStudyIdAndMemberId(Long studyId, Long memberId) {
         queryFactory
                 .delete(attendance)
-                .where(attendance
-                        .student
-                        .eq(studyHistory.getStudent())
-                        .and(attendance.studyDetail.study.eq(studyHistory.getStudy())))
+                .where(eqMemberId(memberId), eqStudyId(studyId))
                 .execute();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyApplyCanceledEvent.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyApplyCanceledEvent.java
@@ -1,3 +1,3 @@
 package com.gdschongik.gdsc.domain.study.domain;
 
-public record StudyApplyCanceledEvent(Long studyHistoryId) {}
+public record StudyApplyCanceledEvent(Long studyId, Long memberId) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -51,7 +51,7 @@ public class StudyHistory extends BaseEntity {
 
     @PreRemove
     private void preRemove() {
-        registerEvent(new StudyApplyCanceledEvent(this.id));
+        registerEvent(new StudyApplyCanceledEvent(this.study.getId(), this.student.getId()));
     }
 
     /**


### PR DESCRIPTION
## 🌱 관련 이슈
- close #758

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 출석 및 과제 기록 삭제 기능이 개선되어, 더 구체적인 매개변수(`studyId` 및 `memberId`)를 사용하여 삭제할 수 있습니다.
	- `StudyApplyCanceledEvent` 이벤트에 `studyId`와 `memberId` 필드가 추가되어 취소 처리의 맥락이 향상되었습니다.

- **Bug Fixes**
	- 이벤트 처리 로직이 수정되어, 취소 시 삭제되는 기록의 정확성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->