### PR TITLE
feat: 제출 가능한 과제 API 응답에 최종 수정 일시 필드 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyDetailController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyDetailController.java
@@ -46,7 +46,7 @@ public class StudentStudyDetailController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "이번주 제출해야 할 과제 조회", description = "마감 기한이 이번주까지인 과제를 조회합니다.")
+    @Operation(summary = "이번주 제출해야 할 과제 조회", description = "마감 기한이 이번주까지인 과제를 조회합니다.", deprecated = true)
     @GetMapping("/assignments/upcoming")
     public ResponseEntity<List<AssignmentHistoryStatusResponse>> getUpcomingAssignments(
             @RequestParam(name = "studyId") Long studyId) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyDetailController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyDetailController.java
@@ -46,7 +46,8 @@ public class StudentStudyDetailController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "이번주 제출해야 할 과제 조회", description = "마감 기한이 이번주까지인 과제를 조회합니다.", deprecated = true)
+    @Deprecated
+    @Operation(summary = "이번주 제출해야 할 과제 조회", description = "마감 기한이 이번주까지인 과제를 조회합니다.")
     @GetMapping("/assignments/upcoming")
     public ResponseEntity<List<AssignmentHistoryStatusResponse>> getUpcomingAssignments(
             @RequestParam(name = "studyId") Long studyId) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmittableDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmittableDto.java
@@ -19,7 +19,8 @@ public record AssignmentSubmittableDto(
         @Nullable @Schema(description = "과제 명세 링크") String descriptionLink,
         @Nullable @Schema(description = "마감 기한") LocalDateTime deadline,
         @Nullable @Schema(description = "과제 제출 링크") String submissionLink,
-        @Nullable @Schema(description = "과제 제출 실패 사유") SubmissionFailureType submissionFailureType) {
+        @Nullable @Schema(description = "과제 제출 실패 사유") SubmissionFailureType submissionFailureType,
+        @Nullable @Schema(description = "최종 수정 일시") LocalDateTime committedAt) {
     public static AssignmentSubmittableDto of(StudyDetail studyDetail, AssignmentHistory assignmentHistory) {
         Assignment assignment = studyDetail.getAssignment();
 
@@ -40,12 +41,22 @@ public record AssignmentSubmittableDto(
                 assignment.getDescriptionLink(),
                 assignment.getDeadline(),
                 assignmentHistory.getSubmissionLink(),
-                assignmentHistory.getSubmissionFailureType());
+                assignmentHistory.getSubmissionFailureType(),
+                assignmentHistory.getCommittedAt());
     }
 
     private static AssignmentSubmittableDto cancelledAssignment(StudyDetail studyDetail, Assignment assignment) {
         return new AssignmentSubmittableDto(
-                studyDetail.getId(), assignment.getStatus(), studyDetail.getWeek(), null, null, null, null, null, null);
+                studyDetail.getId(),
+                assignment.getStatus(),
+                studyDetail.getWeek(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
     }
 
     private static AssignmentSubmittableDto beforeAssignmentSubmit(StudyDetail studyDetail, Assignment assignment) {
@@ -57,6 +68,7 @@ public record AssignmentSubmittableDto(
                 null,
                 assignment.getDescriptionLink(),
                 assignment.getDeadline(),
+                null,
                 null,
                 null);
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #761

## 📌 작업 내용 및 특이사항
- 과제 최종 수정 일시 필드 추가했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **버그 수정**
	- `getUpcomingAssignments` 메서드가 더 이상 사용되지 않음을 표시하기 위해 `deprecated = true` 속성이 추가되었습니다.

- **새로운 기능**
	- `AssignmentSubmittableDto`에 `committedAt` 필드가 추가되어 과제 제출에 대한 최종 수정 타임스탬프 정보를 포함할 수 있게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->