### PR TITLE
fix: 스터디 공지 조회 API 역할 검증 로직 제거

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/CommonStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/CommonStudyService.java
@@ -2,7 +2,6 @@ package com.gdschongik.gdsc.domain.study.application;
 
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
-import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.dao.AssignmentHistoryRepository;
 import com.gdschongik.gdsc.domain.study.dao.AttendanceRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyAnnouncementRepository;
@@ -10,14 +9,12 @@ import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyRepository;
 import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyAnnouncement;
-import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import com.gdschongik.gdsc.domain.study.domain.StudyValidator;
 import com.gdschongik.gdsc.domain.study.dto.response.CommonStudyResponse;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyAnnouncementResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -44,12 +41,6 @@ public class CommonStudyService {
 
     @Transactional(readOnly = true)
     public List<StudyAnnouncementResponse> getStudyAnnouncements(Long studyId) {
-        Member currentMember = memberUtil.getCurrentMember();
-        final Study study = studyRepository.findById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
-        Optional<StudyHistory> studyHistory = studyHistoryRepository.findByStudentAndStudyId(currentMember, studyId);
-
-        studyValidator.validateStudyMentorOrStudent(currentMember, study, studyHistory);
-
         final List<StudyAnnouncement> studyAnnouncements =
                 studyAnnouncementRepository.findAllByStudyIdOrderByCreatedAtDesc(studyId);
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyValidator.java
@@ -5,7 +5,6 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
-import java.util.Optional;
 
 @DomainService
 public class StudyValidator {
@@ -17,23 +16,6 @@ public class StudyValidator {
 
         // 멘토인지 검증
         if (!currentMember.isMentor()) {
-            throw new CustomException(STUDY_ACCESS_NOT_ALLOWED);
-        }
-
-        // 해당 스터디의 담당 멘토인지 검증
-        if (!currentMember.getId().equals(study.getMentor().getId())) {
-            throw new CustomException(STUDY_MENTOR_INVALID);
-        }
-    }
-
-    public void validateStudyMentorOrStudent(Member currentMember, Study study, Optional<StudyHistory> studyHistory) {
-        // 어드민인 경우 검증 통과
-        if (currentMember.isAdmin()) {
-            return;
-        }
-
-        // 해당 스터디의 수강생인지 검증
-        if (currentMember.isStudent() && studyHistory.isEmpty()) {
             throw new CustomException(STUDY_ACCESS_NOT_ALLOWED);
         }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyValidatorTest.java
@@ -8,7 +8,6 @@ import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.FixtureHelper;
 import java.time.LocalDateTime;
-import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -87,47 +86,6 @@ public class StudyValidatorTest {
             // when & then
             assertThatCode(() -> studyValidator.validateStudyMentor(admin, study))
                     .doesNotThrowAnyException();
-        }
-    }
-
-    @Nested
-    class 스터디_멘토_또는_학생역할_검증시 {
-
-        @Test
-        void 수강하지않는_스터디가_아니라면_실패한다() {
-            // given
-            Member student = createMember(1L);
-            Member mentor = createMentor(2L);
-            LocalDateTime assignmentCreatedDate = LocalDateTime.now().minusDays(1);
-            Study study = fixtureHelper.createStudy(
-                    mentor,
-                    Period.createPeriod(assignmentCreatedDate.plusDays(5), assignmentCreatedDate.plusDays(10)),
-                    Period.createPeriod(assignmentCreatedDate.minusDays(5), assignmentCreatedDate));
-            StudyHistory studyHistory = null;
-
-            // when & then
-            assertThatThrownBy(() -> studyValidator.validateStudyMentorOrStudent(
-                            student, study, Optional.ofNullable(studyHistory)))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(STUDY_ACCESS_NOT_ALLOWED.getMessage());
-        }
-
-        @Test
-        void 멘토이지만_자신이_맡은_스터디가_아니라면_실패한다() {
-            // given
-            Member currentMember = createMentor(1L);
-            Member mentor = createMentor(2L);
-            LocalDateTime assignmentCreatedDate = LocalDateTime.now().minusDays(1);
-            Study study = fixtureHelper.createStudy(
-                    mentor,
-                    Period.createPeriod(assignmentCreatedDate.plusDays(5), assignmentCreatedDate.plusDays(10)),
-                    Period.createPeriod(assignmentCreatedDate.minusDays(5), assignmentCreatedDate));
-
-            // when & then
-            assertThatThrownBy(
-                            () -> studyValidator.validateStudyMentorOrStudent(currentMember, study, Optional.empty()))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(STUDY_MENTOR_INVALID.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #767

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- `getStudyAnnouncements` 메서드에서 멤버 검증 및 스터디 이력 조회 로직이 제거되어, 특정 검증 없이 공지사항을 가져오는 방식으로 변경되었습니다.
  
- **기능 변경**
	- `StudyValidator` 클래스에서 `validateStudyMentorOrStudent` 메서드가 제거되어, 스터디 접근에 대한 검증 로직이 간소화되었습니다.

- **테스트 수정**
	- `StudyValidatorTest`에서 특정 검증 관련 테스트 케이스가 제거되어, 검증 로직의 테스트 커버리지가 감소하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->