### PR TITLE
refactor: 테스트에서만 사용하는 메서드 제거

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -44,11 +44,6 @@ public class MembershipService {
         findMembershipAndVerifyPayment(membershipId);
     }
 
-    @Transactional
-    public void verifyPaymentStatus(Long membershipId) {
-        findMembershipAndVerifyPayment(membershipId);
-    }
-
     private void findMembershipAndVerifyPayment(Long membershipId) {
         Membership currentMembership = membershipRepository
                 .findById(membershipId)

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
@@ -62,7 +62,7 @@ public class Membership extends BaseEntity {
 
     // 검증 로직
 
-    public void validateRegularRequirement() {
+    private void validateRegularRequirement() {
         if (isRegularRequirementAllSatisfied()) {
             throw new CustomException(MEMBERSHIP_ALREADY_SATISFIED);
         }

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -1,15 +1,11 @@
 package com.gdschongik.gdsc.domain.membership.application;
 
-import static com.gdschongik.gdsc.domain.common.model.RequirementStatus.SATISFIED;
 import static com.gdschongik.gdsc.domain.member.domain.MemberRole.ASSOCIATE;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.common.vo.Money;
-import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.membership.dao.MembershipRepository;
-import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import com.gdschongik.gdsc.global.exception.CustomException;
@@ -23,9 +19,6 @@ public class MembershipServiceTest extends IntegrationTest {
 
     @Autowired
     private MembershipService membershipService;
-
-    @Autowired
-    private MembershipRepository membershipRepository;
 
     @Nested
     class 멤버십_가입신청시 {
@@ -71,40 +64,6 @@ public class MembershipServiceTest extends IntegrationTest {
 
             assertThatCode(() -> membershipService.submitMembership(secondRound.getId()))
                     .doesNotThrowAnyException();
-        }
-    }
-
-    @Test
-    void 멤버십_회비납부시_이미_회비납부_했다면_회비납부_실패한다() {
-        // given
-        Member member = createMember();
-        logoutAndReloginAs(1L, ASSOCIATE);
-        RecruitmentRound recruitmentRound = createRecruitmentRound();
-        Membership membership = createMembership(member, recruitmentRound);
-        membershipService.verifyPaymentStatus(membership.getId());
-
-        // when & then
-        assertThatThrownBy(() -> membershipService.verifyPaymentStatus(membership.getId()))
-                .isInstanceOf(CustomException.class)
-                .hasMessage(MEMBERSHIP_ALREADY_SATISFIED.getMessage());
-    }
-
-    @Nested
-    class 정회원_가입조건_인증시도시 {
-        @Test
-        void 멤버십_회비납부시_정회원_가입조건중_회비납부_인증상태가_인증_성공한다() {
-            // given
-            Member member = createMember();
-            logoutAndReloginAs(1L, ASSOCIATE);
-            RecruitmentRound recruitmentRound = createRecruitmentRound();
-            Membership membership = createMembership(member, recruitmentRound);
-
-            // when
-            membershipService.verifyPaymentStatus(membership.getId());
-            membership = membershipRepository.findById(membership.getId()).get();
-
-            // then
-            assertThat(membership.getRegularRequirement().getPaymentStatus()).isEqualTo(SATISFIED);
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #737

## 📌 작업 내용 및 특이사항
- 테스트에서만 사용하는 메서드가 있어서 제거했습니다.

## 📝 참고사항
- `Membership`의 내부에서만 호출하는 검증 메서드가 public으로 되어 있어서 private으로 수정했습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 결제 상태 확인을 위한 중복 메서드를 제거하여 서비스 인터페이스를 간소화했습니다.
  
- **변경 사항**
	- 특정 메서드의 접근 제어자를 변경하여 클래스 내부에서만 접근 가능하도록 수정했습니다.

- **테스트**
	- `MembershipServiceTest`에서 여러 테스트 메서드와 관련 변수를 제거하여 테스트 범위를 축소했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->