### PR TITLE
refactor: enum equals 로직 개선

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/domain/DiscordValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/domain/DiscordValidator.java
@@ -32,7 +32,7 @@ public class DiscordValidator {
     }
 
     public void validateAdminPermission(Member currentMember) {
-        if (!currentMember.getManageRole().equals(MemberManageRole.ADMIN)) {
+        if (currentMember.getManageRole() != MemberManageRole.ADMIN) {
             throw new CustomException(INVALID_ROLE);
         }
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -137,7 +137,7 @@ public class Member extends BaseEntity {
      * 준회원 승급 가능 여부를 검증합니다.
      */
     private void validateAssociateAvailable() {
-        if (role.equals(ASSOCIATE)) {
+        if (isAssociate()) {
             throw new CustomException(MEMBER_ALREADY_ASSOCIATE);
         }
 
@@ -152,7 +152,7 @@ public class Member extends BaseEntity {
             throw new CustomException(MEMBER_ALREADY_REGULAR);
         }
 
-        if (!role.equals(ASSOCIATE)) {
+        if (!isAssociate()) {
             throw new CustomException(MEMBER_NOT_ASSOCIATE);
         }
     }
@@ -335,26 +335,26 @@ public class Member extends BaseEntity {
 
     // 데이터 전달 로직
     public boolean isGuest() {
-        return role.equals(GUEST);
+        return role == GUEST;
     }
 
     public boolean isAssociate() {
-        return role.equals(ASSOCIATE);
+        return role == ASSOCIATE;
     }
 
     public boolean isRegular() {
-        return role.equals(REGULAR);
+        return role == REGULAR;
     }
 
     public boolean isAdmin() {
-        return manageRole.equals(ADMIN);
+        return manageRole == ADMIN;
     }
 
     public boolean isMentor() {
-        return studyRole.equals(MENTOR);
+        return studyRole == MENTOR;
     }
 
     public boolean isStudent() {
-        return studyRole.equals(STUDENT);
+        return studyRole == STUDENT;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberStatus.java
@@ -13,10 +13,10 @@ public enum MemberStatus {
     private final String value;
 
     public boolean isDeleted() {
-        return this.equals(DELETED);
+        return this == DELETED;
     }
 
     public boolean isForbidden() {
-        return this.equals(FORBIDDEN);
+        return this == FORBIDDEN;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
@@ -94,6 +94,6 @@ public class RecruitmentRound extends BaseSemesterEntity {
     }
 
     public boolean isFirstRound() {
-        return roundType.equals(RoundType.FIRST);
+        return roundType == RoundType.FIRST;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidator.java
@@ -1,6 +1,5 @@
 package com.gdschongik.gdsc.domain.recruitment.domain;
 
-import static com.gdschongik.gdsc.domain.recruitment.domain.RoundType.*;
 import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
@@ -67,7 +66,7 @@ public class RecruitmentRoundValidator {
     // 학년도, 학기, 모집회차가 모두 같은 경우
     private void validateRoundOverlap(List<RecruitmentRound> recruitmentRounds, RoundType roundType) {
         recruitmentRounds.stream()
-                .filter(recruitmentRound -> recruitmentRound.getRoundType().equals(roundType))
+                .filter(recruitmentRound -> recruitmentRound.getRoundType() == roundType)
                 .findAny()
                 .ifPresent(ignored -> {
                     throw new CustomException(RECRUITMENT_ROUND_TYPE_OVERLAP);
@@ -76,14 +75,14 @@ public class RecruitmentRoundValidator {
 
     // 1차 모집이 없는데 2차 모집을 생성하려고 하는 경우
     private void validateRoundOneExist(List<RecruitmentRound> recruitmentRounds, RoundType roundType) {
-        if (roundType.equals(SECOND) && recruitmentRounds.stream().noneMatch(RecruitmentRound::isFirstRound)) {
+        if (roundType.isSecond() && recruitmentRounds.stream().noneMatch(RecruitmentRound::isFirstRound)) {
             throw new CustomException(ROUND_ONE_DOES_NOT_EXIST);
         }
     }
 
     // 1차 모집을 비워둬서는 안되므로, 1차 모집을 2차 모집으로 수정하려고 하는 경우 예외 발생
     private void validateRoundOneToTwo(RoundType previousRoundType, RoundType newRoundType) {
-        if (previousRoundType.equals(FIRST) && newRoundType.equals(SECOND)) {
+        if (previousRoundType.isFirst() && newRoundType.isSecond()) {
             throw new CustomException(ROUND_ONE_DOES_NOT_EXIST);
         }
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RoundType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RoundType.java
@@ -10,4 +10,12 @@ public enum RoundType {
     SECOND("2차");
 
     private final String value;
+
+    public boolean isFirst() {
+        return this == FIRST;
+    }
+
+    public boolean isSecond() {
+        return this == SECOND;
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #633

## 📌 작업 내용 및 특이사항
- enum의 비교시 `equals` 대신 `==`를 사용합니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- `RoundType` 열거형에 `isFirst()` 및 `isSecond()` 메서드 추가.
- **버그 수정**
	- 다양한 역할 및 상태 검증 메서드에서 문자열 비교를 참조 비교로 변경하여 성능 향상.
- **문서화**
	- 코드 가독성과 유지보수성을 높이기 위한 메서드 변경 및 역할 검증 로직 간소화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->