### PR TITLE
refactor: 출석체크시 수강신청 여부 검증 로직을 도메인 서비스로 이동

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
@@ -93,17 +93,15 @@ public class StudentStudyService {
         final Study study = studyDetail.getStudy();
         final boolean isAlreadyAttended =
                 attendanceRepository.existsByStudentIdAndStudyDetailId(currentMember.getId(), studyDetailId);
-        final StudyHistory studyHistory = studyHistoryRepository
-                .findByStudentAndStudy(currentMember, study)
-                .orElseThrow(() -> new CustomException(STUDY_HISTORY_NOT_FOUND));
+        boolean isAppliedToStudy = studyHistoryRepository.existsByStudentAndStudy(currentMember, study);
 
         attendanceValidator.validateAttendance(
-                studyDetail, request.attendanceNumber(), LocalDate.now(), isAlreadyAttended);
+                studyDetail, request.attendanceNumber(), LocalDate.now(), isAlreadyAttended, isAppliedToStudy);
 
         Attendance attendance = Attendance.create(currentMember, studyDetail);
         attendanceRepository.save(attendance);
 
-        log.info("[StudyService] 스터디 출석: attendanceId={}", attendance.getId());
+        log.info("[StudyService] 스터디 출석: attendanceId={}, memberId={}", attendance.getId(), currentMember.getId());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AttendanceValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AttendanceValidator.java
@@ -8,8 +8,13 @@ import java.time.LocalDate;
 
 @DomainService
 public class AttendanceValidator {
+
     public void validateAttendance(
-            StudyDetail studyDetail, String attendanceNumber, LocalDate date, boolean isAlreadyAttended) {
+            StudyDetail studyDetail,
+            String attendanceNumber,
+            LocalDate date,
+            boolean isAlreadyAttended,
+            boolean isAppliedToStudy) {
         // 출석체크 날짜 검증
         LocalDate attendanceDay = studyDetail.getAttendanceDay();
         if (!attendanceDay.equals(date)) {
@@ -24,6 +29,11 @@ public class AttendanceValidator {
         // 출석체크 번호 검증
         if (isAlreadyAttended) {
             throw new CustomException(STUDY_DETAIL_ALREADY_ATTENDED);
+        }
+
+        // 스터디 신청 여부 검증
+        if (!isAppliedToStudy) {
+            throw new CustomException(STUDY_HISTORY_NOT_FOUND);
         }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -116,6 +116,7 @@ public enum ErrorCode {
     STUDY_DETAIL_ASSIGNMENT_INVALID_UPDATE_DEADLINE(HttpStatus.CONFLICT, "수정하려고 하는 과제의 마감기한은 기존의 마감기한보다 빠르면 안됩니다."),
     STUDY_DETAIL_ID_INVALID(HttpStatus.CONFLICT, "수정하려는 스터디 상세정보가 서버에 존재하지 않거나 유효하지 않습니다."),
     STUDY_DETAIL_CURRICULUM_SIZE_MISMATCH(HttpStatus.BAD_REQUEST, "스터디 커리큘럼의 총 개수가 일치하지 않습니다."),
+
     // StudyHistory
     STUDY_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 수강 기록입니다."),
     STUDY_HISTORY_DUPLICATE(HttpStatus.CONFLICT, "이미 해당 스터디를 신청했습니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #709 

## 📌 작업 내용 및 특이사항
- 출석체크시 해당 스터디에 신청했는지 확인하는 로직이 필요한데, 기존에는 findById로 조회하고 있었습니다.
  exists로 조회하도록 수정했고 존재 여부로 예외를 던지는 부분은 Validator에서 처리하도록 했습니다.

## 📝 참고사항
- test에서 수강생의 변수명이 mentor로 되어있어서 student로 모두 수정했습니다!

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 출석 검증 로직 간소화 및 성능 향상.
	- 출석 시 학생의 신청 여부를 확인하는 추가 조건 도입.

- **버그 수정**
	- 출석 검증에서 신청하지 않은 학생에 대한 예외 처리 추가.

- **테스트**
	- 학생 관련 출석 검증 테스트 케이스 추가 및 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->