### PR TITLE
feat: 스터디 수료 필드와 우수 스터디원 테이블 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AchievementType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AchievementType.java
@@ -1,0 +1,13 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AchievementType {
+    FIRST_ROUND_OUTSTANDING_STUDENT("1차 우수 스터디원"),
+    SECOND_ROUND_OUTSTANDING_STUDENT("2차 우수 스터디원");
+
+    private final String value;
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAchievement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAchievement.java
@@ -1,0 +1,51 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyAchievement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_achievement_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member student;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_id")
+    private Study study;
+
+    private AchievementType achievementType;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private StudyAchievement(Member student, Study study, AchievementType achievementType) {
+        this.student = student;
+        this.study = study;
+        this.achievementType = achievementType;
+    }
+
+    public static StudyAchievement create(Member student, Study study, AchievementType achievementType) {
+        return StudyAchievement.builder()
+                .student(student)
+                .study(study)
+                .achievementType(achievementType)
+                .build();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAchievement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAchievement.java
@@ -11,6 +11,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +21,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"member_id", "study_id", "achievement_type"})})
 public class StudyAchievement {
 
     @Id

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAchievement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAchievement.java
@@ -3,6 +3,8 @@ package com.gdschongik.gdsc.domain.study.domain;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -32,6 +34,7 @@ public class StudyAchievement {
     @JoinColumn(name = "study_id")
     private Study study;
 
+    @Enumerated(EnumType.STRING)
     private AchievementType achievementType;
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -17,6 +17,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
 
 @Getter
 @Entity
@@ -39,10 +40,14 @@ public class StudyHistory extends BaseEntity {
 
     private String repositoryLink;
 
+    @Comment("수료 여부")
+    private boolean hasCompleted;
+
     @Builder(access = AccessLevel.PRIVATE)
     private StudyHistory(Member student, Study study) {
         this.student = student;
         this.study = study;
+        this.hasCompleted = false;
     }
 
     public static StudyHistory create(Member student, Study study) {
@@ -59,6 +64,13 @@ public class StudyHistory extends BaseEntity {
      */
     public void updateRepositoryLink(String repositoryLink) {
         this.repositoryLink = repositoryLink;
+    }
+
+    /**
+     * 스터디 수료
+     */
+    public void complete() {
+        hasCompleted = true;
     }
 
     // 데이터 전달 로직

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -1,9 +1,13 @@
 package com.gdschongik.gdsc.domain.study.domain;
 
+import static com.gdschongik.gdsc.domain.study.domain.StudyHistoryStatus.*;
+
 import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -40,14 +44,15 @@ public class StudyHistory extends BaseEntity {
 
     private String repositoryLink;
 
-    @Comment("수료 여부")
-    private Boolean hasCompleted;
+    @Comment("수료 상태")
+    @Enumerated(EnumType.STRING)
+    private StudyHistoryStatus studyHistoryStatus;
 
     @Builder(access = AccessLevel.PRIVATE)
     private StudyHistory(Member student, Study study) {
         this.student = student;
         this.study = study;
-        this.hasCompleted = false;
+        this.studyHistoryStatus = NONE;
     }
 
     public static StudyHistory create(Member student, Study study) {
@@ -70,7 +75,7 @@ public class StudyHistory extends BaseEntity {
      * 스터디 수료
      */
     public void complete() {
-        hasCompleted = true;
+        studyHistoryStatus = COMPLETED;
     }
 
     // 데이터 전달 로직

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -41,7 +41,7 @@ public class StudyHistory extends BaseEntity {
     private String repositoryLink;
 
     @Comment("수료 여부")
-    private boolean hasCompleted;
+    private Boolean hasCompleted;
 
     @Builder(access = AccessLevel.PRIVATE)
     private StudyHistory(Member student, Study study) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryStatus.java
@@ -1,0 +1,13 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StudyHistoryStatus {
+    NONE("미수료"),
+    COMPLETED("수료");
+
+    private final String value;
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryTest.java
@@ -1,0 +1,61 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.helper.FixtureHelper;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class StudyHistoryTest {
+
+    FixtureHelper fixtureHelper = new FixtureHelper();
+
+    @Nested
+    class 스터디_히스토리_생성시 {
+
+        @Test
+        void 수료여부는_false이다() {
+            // given
+            Member student = fixtureHelper.createRegularMember(1L);
+            Member mentor = fixtureHelper.createRegularMember(2L);
+            LocalDateTime now = LocalDateTime.now();
+            Study study = fixtureHelper.createStudy(
+                    mentor,
+                    Period.createPeriod(now.plusDays(5), now.plusDays(10)),
+                    Period.createPeriod(now.minusDays(5), now));
+
+            // when
+            StudyHistory studyHistory = StudyHistory.create(student, study);
+
+            // then
+            assertThat(studyHistory.getHasCompleted()).isFalse();
+        }
+    }
+
+    @Nested
+    class 스터디_수료시 {
+
+        @Test
+        void 수료여부는_true이다() {
+            // given
+            Member student = fixtureHelper.createRegularMember(1L);
+            Member mentor = fixtureHelper.createRegularMember(2L);
+            LocalDateTime now = LocalDateTime.now();
+            Study study = fixtureHelper.createStudy(
+                    mentor,
+                    Period.createPeriod(now.plusDays(5), now.plusDays(10)),
+                    Period.createPeriod(now.minusDays(5), now));
+
+            StudyHistory studyHistory = StudyHistory.create(student, study);
+
+            // when
+            studyHistory.complete();
+
+            // then
+            assertThat(studyHistory.getHasCompleted()).isTrue();
+        }
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryTest.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.domain.study.domain;
 
+import static com.gdschongik.gdsc.domain.study.domain.StudyHistoryStatus.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
@@ -17,7 +18,7 @@ public class StudyHistoryTest {
     class 스터디_히스토리_생성시 {
 
         @Test
-        void 수료여부는_false이다() {
+        void 수료상태는_NONE이다() {
             // given
             Member student = fixtureHelper.createRegularMember(1L);
             Member mentor = fixtureHelper.createRegularMember(2L);
@@ -31,7 +32,7 @@ public class StudyHistoryTest {
             StudyHistory studyHistory = StudyHistory.create(student, study);
 
             // then
-            assertThat(studyHistory.getHasCompleted()).isFalse();
+            assertThat(studyHistory.getStudyHistoryStatus()).isEqualTo(NONE);
         }
     }
 
@@ -39,7 +40,7 @@ public class StudyHistoryTest {
     class 스터디_수료시 {
 
         @Test
-        void 수료여부는_true이다() {
+        void 수료상태는_COMPLETED이다() {
             // given
             Member student = fixtureHelper.createRegularMember(1L);
             Member mentor = fixtureHelper.createRegularMember(2L);
@@ -55,7 +56,7 @@ public class StudyHistoryTest {
             studyHistory.complete();
 
             // then
-            assertThat(studyHistory.getHasCompleted()).isTrue();
+            assertThat(studyHistory.getStudyHistoryStatus()).isEqualTo(COMPLETED);
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #781

## 📌 작업 내용 및 특이사항
- 스터디 수료 여부에 대한 boolean 필드를 StudyHistory에 추가했습니다.
- 우수 스터디원으로 지정시 StudyHistory 테이블에 같이 저장하기보다, 별도 테이블에 저장하는 편이 우수 스터디원과 관련된 조회나 지정의 케이스에서 유리할 것 같아서 `StudyAchievement` 테이블을 추가했습니다.
- `StudyAchievement` 이 `StudyHistory`를 가질지, Study와 Member를 각각 가질지에 대한 포인트에서 고민이 있었습니다.
우수 스터디원인지를 조회하는 일은 과제와 출석 테이블을 조회할 때 같이 발생하는데, 이 두가지가 모두 Study와 Member를 이용하므로 `StudyAchievement`도 Study와 Member를 각각 가지는것이 적합해보입니다.

## 📝 참고사항
- 다른 테이블들에서 따닥 이슈가 생기고 있어서 unique constraint로 추가했습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - `AchievementType` 열거형 추가: 두 가지 상수 `FIRST_ROUND_OUTSTANDING_STUDENT` 및 `SECOND_ROUND_OUTSTANDING_STUDENT`가 추가되어 성취 유형을 정의합니다.
  - `StudyAchievement` 클래스 추가: 학생, 연구 및 성취 유형을 포함하는 새로운 엔티티 클래스입니다.
  - `StudyHistory` 클래스 수정: `studyHistoryStatus` 필드 추가로 연구 완료 여부를 추적할 수 있게 되었습니다.
  - `StudyHistoryStatus` 열거형 추가: 연구 상태를 나타내는 두 가지 상수 `NONE` 및 `COMPLETED`가 정의되었습니다.

- **버그 수정**
  - `complete()` 메서드 추가: 연구 완료 상태를 업데이트할 수 있는 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->