### PR TITLE
feat: 수강생 명단 페이지 대시보드 조회 API 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyController.java
@@ -10,6 +10,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -35,10 +37,10 @@ public class MentorStudyController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "스터디 수강생 명단 조회", description = "해당 스터디의 수강생 명단을 조회합니다")
+    @Operation(summary = "스터디 수강생 관리", description = "해당 스터디의 수강생을 관리합니다")
     @GetMapping("/{studyId}/students")
-    public ResponseEntity<List<StudyStudentResponse>> getStudyStudents(@PathVariable Long studyId) {
-        List<StudyStudentResponse> response = mentorStudyService.getStudyStudents(studyId);
+    public ResponseEntity<Page<StudyStudentResponse>> getStudyStudents(@PathVariable Long studyId, Pageable pageable) {
+        Page<StudyStudentResponse> response = mentorStudyService.getStudyStudents(studyId, pageable);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
@@ -3,6 +3,9 @@ package com.gdschongik.gdsc.domain.study.application;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.STUDY_NOT_FOUND;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.study.dao.AssignmentHistoryRepository;
+import com.gdschongik.gdsc.domain.study.dao.AttendanceRepository;
+import com.gdschongik.gdsc.domain.study.dao.StudyAchievementRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyAnnouncementRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyDetailRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;
@@ -17,14 +20,20 @@ import com.gdschongik.gdsc.domain.study.dto.request.StudyCurriculumCreateRequest
 import com.gdschongik.gdsc.domain.study.dto.request.StudyUpdateRequest;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyResponse;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyStudentResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.global.util.MemberUtil;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,12 +43,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class MentorStudyService {
 
     private final MemberUtil memberUtil;
+    private final StudyValidator studyValidator;
+    private final StudyDetailValidator studyDetailValidator;
     private final StudyRepository studyRepository;
     private final StudyAnnouncementRepository studyAnnouncementRepository;
     private final StudyHistoryRepository studyHistoryRepository;
-    private final StudyValidator studyValidator;
     private final StudyDetailRepository studyDetailRepository;
-    private final StudyDetailValidator studyDetailValidator;
+    private final StudyAchievementRepository studyAchievementRepository;
+    private final AttendanceRepository attendanceRepository;
+    private final AssignmentHistoryRepository assignmentHistoryRepository;
 
     @Transactional(readOnly = true)
     public List<StudyResponse> getStudiesInCharge() {
@@ -49,15 +61,71 @@ public class MentorStudyService {
     }
 
     @Transactional(readOnly = true)
-    public List<StudyStudentResponse> getStudyStudents(Long studyId) {
+    public Page<StudyStudentResponse> getStudyStudents(Long studyId, Pageable pageable) {
         Member currentMember = memberUtil.getCurrentMember();
         Study study =
                 studyRepository.findById(studyId).orElseThrow(() -> new CustomException(ErrorCode.STUDY_NOT_FOUND));
-
         studyValidator.validateStudyMentor(currentMember, study);
-        List<StudyHistory> studyHistories = studyHistoryRepository.findByStudyId(studyId);
 
-        return studyHistories.stream().map(StudyStudentResponse::from).toList();
+        List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyId(studyId);
+        Page<StudyHistory> studyHistories = studyHistoryRepository.findByStudyId(studyId, pageable);
+        List<Long> studentIds = studyHistories.getContent().stream()
+                .map(studyHistory -> studyHistory.getStudent().getId())
+                .toList();
+
+        List<Attendance> attendances = attendanceRepository.findByStudyIdAndMemberIds(studyId, studentIds);
+        List<AssignmentHistory> assignmentHistories =
+                assignmentHistoryRepository.findByStudyIdAndMemberIds(studyId, studentIds);
+        List<StudyAchievement> studyAchievements =
+                studyAchievementRepository.findByStudyIdAndMemberIds(studyId, studentIds);
+
+        List<StudyStudentResponse> response = new ArrayList<>();
+        studyHistories.forEach(studyHistory -> {
+            List<StudyAchievement> currentStudyAchievements = studyAchievements.stream()
+                    .filter(studyAchievement -> studyAchievement
+                            .getStudent()
+                            .getId()
+                            .equals(studyHistory.getStudent().getId()))
+                    .toList();
+            List<Attendance> currentAttendances = attendances.stream()
+                    .filter(attendance -> attendance
+                            .getStudent()
+                            .getId()
+                            .equals(studyHistory.getStudent().getId()))
+                    .toList();
+            List<AssignmentHistory> currentAssignmentHistories = assignmentHistories.stream()
+                    .filter(assignmentHistory -> assignmentHistory
+                            .getMember()
+                            .getId()
+                            .equals(studyHistory.getStudent().getId()))
+                    .toList();
+
+            List<StudyTodoResponse> studyTodos = new ArrayList<>();
+            studyDetails.forEach(studyDetail -> {
+                studyTodos.add(StudyTodoResponse.createAttendanceType(
+                        studyDetail, LocalDate.now(), isAttended(currentAttendances, studyDetail)));
+                studyTodos.add(StudyTodoResponse.createAssignmentType(
+                        studyDetail, getSubmittedAssignment(currentAssignmentHistories, studyDetail)));
+            });
+
+            response.add(StudyStudentResponse.of(studyHistory, currentStudyAchievements, studyTodos));
+        });
+
+        return new PageImpl<>(response, pageable, studyHistories.getTotalElements());
+    }
+
+    private boolean isAttended(List<Attendance> attendances, StudyDetail studyDetail) {
+        return attendances.stream()
+                .anyMatch(attendance -> attendance.getStudyDetail().getId().equals(studyDetail.getId()));
+    }
+
+    private AssignmentHistory getSubmittedAssignment(
+            List<AssignmentHistory> assignmentHistories, StudyDetail studyDetail) {
+        return assignmentHistories.stream()
+                .filter(assignmentHistory ->
+                        assignmentHistory.getStudyDetail().getId().equals(studyDetail.getId()))
+                .findFirst()
+                .orElse(null);
     }
 
     @Transactional

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
@@ -22,7 +22,6 @@ import com.gdschongik.gdsc.domain.study.dto.response.StudyResponse;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyStudentResponse;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -63,8 +62,7 @@ public class MentorStudyService {
     @Transactional(readOnly = true)
     public Page<StudyStudentResponse> getStudyStudents(Long studyId, Pageable pageable) {
         Member currentMember = memberUtil.getCurrentMember();
-        Study study =
-                studyRepository.findById(studyId).orElseThrow(() -> new CustomException(ErrorCode.STUDY_NOT_FOUND));
+        Study study = studyRepository.findById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
         studyValidator.validateStudyMentor(currentMember, study);
 
         List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyId(studyId);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
@@ -73,14 +73,14 @@ public class MentorStudyService {
                 .map(studyHistory -> studyHistory.getStudent().getId())
                 .toList();
 
+        List<StudyAchievement> studyAchievements =
+                studyAchievementRepository.findByStudyIdAndMemberIds(studyId, studentIds);
         List<Attendance> attendances = attendanceRepository.findByStudyIdAndMemberIds(studyId, studentIds);
         List<AssignmentHistory> assignmentHistories =
                 assignmentHistoryRepository.findByStudyIdAndMemberIds(studyId, studentIds);
-        List<StudyAchievement> studyAchievements =
-                studyAchievementRepository.findByStudyIdAndMemberIds(studyId, studentIds);
 
         List<StudyStudentResponse> response = new ArrayList<>();
-        studyHistories.forEach(studyHistory -> {
+        studyHistories.getContent().forEach(studyHistory -> {
             List<StudyAchievement> currentStudyAchievements = studyAchievements.stream()
                     .filter(studyAchievement -> studyAchievement
                             .getStudent()

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepository.java
@@ -11,5 +11,7 @@ public interface AssignmentHistoryCustomRepository {
 
     List<AssignmentHistory> findAssignmentHistoriesByStudentAndStudyId(Member member, Long studyId);
 
+    List<AssignmentHistory> findByStudyIdAndMemberIds(Long studyId, List<Long> memberIds);
+
     void deleteByStudyIdAndMemberId(Long studyId, Long memberId);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepositoryImpl.java
@@ -1,19 +1,18 @@
 package com.gdschongik.gdsc.domain.study.dao;
 
-import static com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionStatus.*;
 import static com.gdschongik.gdsc.domain.study.domain.QAssignmentHistory.*;
 import static com.gdschongik.gdsc.domain.study.domain.QStudyDetail.studyDetail;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
 import com.gdschongik.gdsc.domain.study.domain.Study;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class AssignmentHistoryCustomRepositoryImpl implements AssignmentHistoryCustomRepository {
+public class AssignmentHistoryCustomRepositoryImpl
+        implements AssignmentHistoryCustomRepository, AssignmentHistoryQueryMethod {
 
     private final JPAQueryFactory queryFactory;
 
@@ -28,18 +27,6 @@ public class AssignmentHistoryCustomRepositoryImpl implements AssignmentHistoryC
         return fetchOne != null;
     }
 
-    private BooleanExpression eqMember(Member member) {
-        return member == null ? null : assignmentHistory.member.eq(member);
-    }
-
-    private BooleanExpression eqStudy(Study study) {
-        return study == null ? null : assignmentHistory.studyDetail.study.eq(study);
-    }
-
-    private BooleanExpression isSubmitted() {
-        return assignmentHistory.submissionStatus.in(FAILURE, SUCCESS);
-    }
-
     @Override
     public List<AssignmentHistory> findAssignmentHistoriesByStudentAndStudyId(Member currentMember, Long studyId) {
         return queryFactory
@@ -50,10 +37,6 @@ public class AssignmentHistoryCustomRepositoryImpl implements AssignmentHistoryC
                 .fetch();
     }
 
-    private BooleanExpression eqStudyId(Long studyId) {
-        return studyId != null ? studyDetail.study.id.eq(studyId) : null;
-    }
-
     @Override
     public void deleteByStudyIdAndMemberId(Long studyId, Long memberId) {
         queryFactory
@@ -62,7 +45,13 @@ public class AssignmentHistoryCustomRepositoryImpl implements AssignmentHistoryC
                 .execute();
     }
 
-    private BooleanExpression eqMemberId(Long memberId) {
-        return memberId != null ? assignmentHistory.member.id.eq(memberId) : null;
+    @Override
+    public List<AssignmentHistory> findByStudyIdAndMemberIds(Long studyId, List<Long> memberIds) {
+        return queryFactory
+                .selectFrom(assignmentHistory)
+                .innerJoin(assignmentHistory.studyDetail, studyDetail)
+                .fetchJoin()
+                .where(assignmentHistory.member.id.in(memberIds), eqStudyId(studyId))
+                .fetch();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryQueryMethod.java
@@ -1,0 +1,31 @@
+package com.gdschongik.gdsc.domain.study.dao;
+
+import static com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionStatus.*;
+import static com.gdschongik.gdsc.domain.study.domain.QAssignmentHistory.*;
+import static com.gdschongik.gdsc.domain.study.domain.QStudyDetail.*;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+public interface AssignmentHistoryQueryMethod {
+    default BooleanExpression eqMember(Member member) {
+        return member == null ? null : assignmentHistory.member.eq(member);
+    }
+
+    default BooleanExpression eqStudy(Study study) {
+        return study == null ? null : assignmentHistory.studyDetail.study.eq(study);
+    }
+
+    default BooleanExpression isSubmitted() {
+        return assignmentHistory.submissionStatus.in(FAILURE, SUCCESS);
+    }
+
+    default BooleanExpression eqStudyId(Long studyId) {
+        return studyId != null ? studyDetail.study.id.eq(studyId) : null;
+    }
+
+    default BooleanExpression eqMemberId(Long memberId) {
+        return memberId != null ? assignmentHistory.member.id.eq(memberId) : null;
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryRepository.java
@@ -8,5 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AssignmentHistoryRepository
         extends JpaRepository<AssignmentHistory, Long>, AssignmentHistoryCustomRepository {
+    // todo: public 제거
     public Optional<AssignmentHistory> findByMemberAndStudyDetail(Member member, StudyDetail studyDetail);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepository.java
@@ -7,5 +7,7 @@ import java.util.List;
 public interface AttendanceCustomRepository {
     List<Attendance> findByMemberAndStudyId(Member member, Long studyId);
 
+    List<Attendance> findByStudyIdAndMemberIds(Long studyId, List<Long> memberIds);
+
     void deleteByStudyIdAndMemberId(Long studyId, Long memberId);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepositoryImpl.java
@@ -1,6 +1,5 @@
 package com.gdschongik.gdsc.domain.study.dao;
 
-import static com.gdschongik.gdsc.domain.member.domain.QMember.member;
 import static com.gdschongik.gdsc.domain.study.domain.QAttendance.attendance;
 import static com.gdschongik.gdsc.domain.study.domain.QStudyDetail.studyDetail;
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceCustomRepositoryImpl.java
@@ -26,6 +26,16 @@ public class AttendanceCustomRepositoryImpl implements AttendanceCustomRepositor
                 .fetch();
     }
 
+    @Override
+    public List<Attendance> findByStudyIdAndMemberIds(Long studyId, List<Long> memberIds) {
+        return queryFactory
+                .selectFrom(attendance)
+                .innerJoin(attendance.studyDetail, studyDetail)
+                .fetchJoin()
+                .where(attendance.student.id.in(memberIds), eqStudyId(studyId))
+                .fetch();
+    }
+
     private BooleanExpression eqMemberId(Long memberId) {
         return memberId != null ? attendance.student.id.eq(memberId) : null;
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAchievementCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAchievementCustomRepository.java
@@ -1,0 +1,8 @@
+package com.gdschongik.gdsc.domain.study.dao;
+
+import com.gdschongik.gdsc.domain.study.domain.StudyAchievement;
+import java.util.List;
+
+public interface StudyAchievementCustomRepository {
+    List<StudyAchievement> findByStudyIdAndMemberIds(Long studyId, List<Long> memberIds);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAchievementCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAchievementCustomRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.gdschongik.gdsc.domain.study.dao;
+
+import static com.gdschongik.gdsc.domain.study.domain.QStudyAchievement.*;
+
+import com.gdschongik.gdsc.domain.study.domain.StudyAchievement;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class StudyAchievementCustomRepositoryImpl implements StudyAchievementCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<StudyAchievement> findByStudyIdAndMemberIds(Long studyId, List<Long> memberIds) {
+        return queryFactory
+                .selectFrom(studyAchievement)
+                .where(studyAchievement.student.id.in(memberIds), eqStudyId(studyId))
+                .fetch();
+    }
+
+    private BooleanExpression eqStudyId(Long studyId) {
+        return studyId != null ? studyAchievement.study.id.eq(studyId) : null;
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAchievementCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAchievementCustomRepositoryImpl.java
@@ -17,7 +17,7 @@ public class StudyAchievementCustomRepositoryImpl implements StudyAchievementCus
     public List<StudyAchievement> findByStudyIdAndMemberIds(Long studyId, List<Long> memberIds) {
         return queryFactory
                 .selectFrom(studyAchievement)
-                .where(studyAchievement.student.id.in(memberIds), eqStudyId(studyId))
+                .where(eqStudyId(studyId), studyAchievement.student.id.in(memberIds))
                 .fetch();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAchievementRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAchievementRepository.java
@@ -1,12 +1,7 @@
 package com.gdschongik.gdsc.domain.study.dao;
 
-import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyAchievement;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StudyAchievementRepository extends JpaRepository<StudyAchievement, Long> {
-
-    List<StudyAchievement> findByStudentAndStudy(Member student, Study study);
-}
+public interface StudyAchievementRepository
+        extends JpaRepository<StudyAchievement, Long>, StudyAchievementCustomRepository {}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAchievementRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAchievementRepository.java
@@ -1,0 +1,12 @@
+package com.gdschongik.gdsc.domain.study.dao;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.domain.study.domain.StudyAchievement;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyAchievementRepository extends JpaRepository<StudyAchievement, Long> {
+
+    List<StudyAchievement> findByStudentAndStudy(Member student, Study study);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryRepository.java
@@ -5,11 +5,11 @@ import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudyHistoryRepository extends JpaRepository<StudyHistory, Long> {
-
-    List<StudyHistory> findByStudyId(Long studyId);
 
     List<StudyHistory> findAllByStudent(Member member);
 
@@ -18,4 +18,6 @@ public interface StudyHistoryRepository extends JpaRepository<StudyHistory, Long
     boolean existsByStudentAndStudy(Member member, Study study);
 
     Optional<StudyHistory> findByStudentAndStudyId(Member member, Long studyId);
+
+    Page<StudyHistory> findByStudyId(Long studyId, Pageable pageable);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Curriculum.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Curriculum.java
@@ -60,4 +60,8 @@ public class Curriculum {
     public boolean isOpen() {
         return status == StudyStatus.OPEN;
     }
+
+    public boolean isCancelled() {
+        return status == StudyStatus.CANCELLED;
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmissionStatusResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmissionStatusResponse.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.study.dto.response;
 
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
+import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -14,7 +15,10 @@ public enum AssignmentSubmissionStatusResponse {
 
     private final String value;
 
-    public static AssignmentSubmissionStatusResponse from(AssignmentHistory assignmentHistory) {
+    public static AssignmentSubmissionStatusResponse of(AssignmentHistory assignmentHistory, StudyDetail studyDetail) {
+        if (studyDetail.getAssignment().isCancelled()) {
+            return CANCELLED;
+        }
         if (assignmentHistory == null) {
             return NOT_SUBMITTED;
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmissionStatusResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmissionStatusResponse.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 public enum AssignmentSubmissionStatusResponse {
     NOT_SUBMITTED("미제출"),
     FAILURE("제출 실패"),
-    SUCCESS("제출 성공");
+    SUCCESS("제출 성공"),
+    CANCELLED("휴강");
 
     private final String value;
 
@@ -22,5 +23,9 @@ public enum AssignmentSubmissionStatusResponse {
         } else {
             return FAILURE;
         }
+    }
+
+    public static AssignmentSubmissionStatusResponse getCancelled() {
+        return CANCELLED;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmissionStatusResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmissionStatusResponse.java
@@ -24,8 +24,4 @@ public enum AssignmentSubmissionStatusResponse {
             return FAILURE;
         }
     }
-
-    public static AssignmentSubmissionStatusResponse getCancelled() {
-        return CANCELLED;
-    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AttendanceStatusResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AttendanceStatusResponse.java
@@ -11,11 +11,16 @@ import lombok.RequiredArgsConstructor;
 public enum AttendanceStatusResponse {
     ATTENDED("출석"),
     NOT_ATTENDED("미출석"),
-    BEFORE_ATTENDANCE("출석전");
+    BEFORE_ATTENDANCE("출석전"),
+    CANCELLED("휴강");
 
     private final String value;
 
     public static AttendanceStatusResponse of(StudyDetail studyDetail, LocalDate now, boolean isAttended) {
+        if (studyDetail.getCurriculum().isCancelled()) {
+            return CANCELLED;
+        }
+
         if (studyDetail.getAttendanceDay().isAfter(now)) {
             return BEFORE_ATTENDANCE;
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentCurriculumResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentCurriculumResponse.java
@@ -37,7 +37,7 @@ public record StudyStudentCurriculumResponse(
                 studyDetail.getCurriculum().getDifficulty(),
                 AttendanceStatusResponse.of(studyDetail, now.toLocalDate(), isAttended),
                 studyDetail.getAssignment().getStatus(),
-                AssignmentSubmissionStatusResponse.from(assignmentHistory),
+                AssignmentSubmissionStatusResponse.of(assignmentHistory, studyDetail),
                 assignmentHistory != null ? assignmentHistory.getSubmissionFailureType() : NOT_SUBMITTED,
                 assignmentHistory != null ? assignmentHistory.getSubmissionLink() : null);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentResponse.java
@@ -48,12 +48,8 @@ public record StudyStudentResponse(
                 isOutstandingStudent(FIRST_ROUND_OUTSTANDING_STUDENT, studyAchievements),
                 isOutstandingStudent(SECOND_ROUND_OUTSTANDING_STUDENT, studyAchievements),
                 studyTodos,
-                assignments.size() != cancelledAssignmentsCount
-                        ? (double) successAssignmentsCount * 100 / (assignments.size() - cancelledAssignmentsCount)
-                        : 0,
-                attendances.size() != cancelledAttendanceCount
-                        ? (double) (attendedCount * 100) / (attendances.size() - cancelledAttendanceCount)
-                        : 0);
+                calculateRateOrZero(successAssignmentsCount, assignments.size() - cancelledAssignmentsCount),
+                calculateRateOrZero(attendedCount, attendances.size() - cancelledAttendanceCount));
     }
 
     private static boolean isOutstandingStudent(
@@ -73,5 +69,9 @@ public record StudyStudentResponse(
         return attendances.stream()
                 .filter(studyTodoResponse -> studyTodoResponse.attendanceStatus() == status)
                 .count();
+    }
+
+    private static double calculateRateOrZero(long dividend, long divisor) {
+        return divisor == 0 ? 0 : (double) dividend * 100 / divisor;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentResponse.java
@@ -1,7 +1,13 @@
 package com.gdschongik.gdsc.domain.study.dto.response;
 
+import static com.gdschongik.gdsc.domain.study.domain.AchievementType.*;
+
+import com.gdschongik.gdsc.domain.study.domain.AchievementType;
+import com.gdschongik.gdsc.domain.study.domain.StudyAchievement;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse.StudyTodoType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 
 public record StudyStudentResponse(
         @Schema(description = "멤버 아이디") Long memberId,
@@ -9,14 +15,57 @@ public record StudyStudentResponse(
         @Schema(description = "학번") String studentId,
         @Schema(description = "디스코드 사용자명") String discordUsername,
         @Schema(description = "디스코드 닉네임") String nickname,
-        @Schema(description = "깃허브 링크") String githubLink) {
-    public static StudyStudentResponse from(StudyHistory studyHistory) {
+        @Schema(description = "깃허브 링크") String githubLink,
+        @Schema(description = "1차 우수 스터디원") boolean isFirstRoundOutstandingStudent,
+        @Schema(description = "2차 우수 스터디원") boolean isSecondRoundOutstandingStudent,
+        @Schema(description = "과제 및 출석 이력") List<StudyTodoResponse> studyTodos,
+        @Schema(description = "과제 수행률") double assignmentRate,
+        @Schema(description = "출석률") double attendanceRate) {
+    public static StudyStudentResponse of(
+            StudyHistory studyHistory, List<StudyAchievement> studyAchievements, List<StudyTodoResponse> studyTodos) {
+        List<StudyTodoResponse> assignments = studyTodos.stream()
+                .filter(studyTodoResponse -> studyTodoResponse.todoType() == StudyTodoType.ASSIGNMENT)
+                .toList();
+
+        List<StudyTodoResponse> attendances = studyTodos.stream()
+                .filter(studyTodoResponse -> studyTodoResponse.todoType() == StudyTodoType.ATTENDANCE)
+                .toList();
+
+        long successAssignmentsCount = assignments.stream()
+                .filter(studyTodoResponse ->
+                        studyTodoResponse.assignmentSubmissionStatus() == AssignmentSubmissionStatusResponse.SUCCESS)
+                .count();
+
+        long cancelledAssignmentsCount = assignments.stream()
+                .filter(studyTodoResponse ->
+                        studyTodoResponse.assignmentSubmissionStatus() == AssignmentSubmissionStatusResponse.CANCELLED)
+                .count();
+
+        long attendedCount = attendances.stream()
+                .filter(studyTodoResponse -> studyTodoResponse.attendanceStatus() == AttendanceStatusResponse.ATTENDED)
+                .count();
+
+        long cancelledAttendanceCount = attendances.stream()
+                .filter(studyTodoResponse -> studyTodoResponse.attendanceStatus() == AttendanceStatusResponse.CANCELLED)
+                .count();
+
         return new StudyStudentResponse(
                 studyHistory.getStudent().getId(),
                 studyHistory.getStudent().getName(),
                 studyHistory.getStudent().getStudentId(),
                 studyHistory.getStudent().getDiscordUsername(),
                 studyHistory.getStudent().getNickname(),
-                studyHistory.getRepositoryLink());
+                studyHistory.getRepositoryLink(),
+                isOutstandingStudent(FIRST_ROUND_OUTSTANDING_STUDENT, studyAchievements),
+                isOutstandingStudent(SECOND_ROUND_OUTSTANDING_STUDENT, studyAchievements),
+                studyTodos,
+                (double) successAssignmentsCount * 100 / (assignments.size() - cancelledAssignmentsCount),
+                (double) (attendedCount * 100) / (attendances.size() - cancelledAttendanceCount));
+    }
+
+    private static boolean isOutstandingStudent(
+            AchievementType achievementType, List<StudyAchievement> studyAchievements) {
+        return studyAchievements.stream()
+                .anyMatch(studyAchievement -> studyAchievement.getAchievementType() == achievementType);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentResponse.java
@@ -32,21 +32,11 @@ public record StudyStudentResponse(
                 .filter(studyTodoResponse -> studyTodoResponse.todoType() == ATTENDANCE)
                 .toList();
 
-        long successAssignmentsCount = assignments.stream()
-                .filter(studyTodoResponse -> studyTodoResponse.assignmentSubmissionStatus() == SUCCESS)
-                .count();
+        long successAssignmentsCount = countAssignmentByStatus(assignments, SUCCESS);
+        long cancelledAssignmentsCount = countAssignmentByStatus(assignments, CANCELLED);
 
-        long cancelledAssignmentsCount = assignments.stream()
-                .filter(studyTodoResponse -> studyTodoResponse.assignmentSubmissionStatus() == CANCELLED)
-                .count();
-
-        long attendedCount = attendances.stream()
-                .filter(studyTodoResponse -> studyTodoResponse.attendanceStatus() == AttendanceStatusResponse.ATTENDED)
-                .count();
-
-        long cancelledAttendanceCount = attendances.stream()
-                .filter(studyTodoResponse -> studyTodoResponse.attendanceStatus() == AttendanceStatusResponse.CANCELLED)
-                .count();
+        long attendedCount = countAttendanceByStatus(attendances, AttendanceStatusResponse.ATTENDED);
+        long cancelledAttendanceCount = countAttendanceByStatus(attendances, AttendanceStatusResponse.CANCELLED);
 
         return new StudyStudentResponse(
                 studyHistory.getStudent().getId(),
@@ -66,5 +56,18 @@ public record StudyStudentResponse(
             AchievementType achievementType, List<StudyAchievement> studyAchievements) {
         return studyAchievements.stream()
                 .anyMatch(studyAchievement -> studyAchievement.getAchievementType() == achievementType);
+    }
+
+    private static long countAssignmentByStatus(
+            List<StudyTodoResponse> assignments, AssignmentSubmissionStatusResponse status) {
+        return assignments.stream()
+                .filter(studyTodoResponse -> studyTodoResponse.assignmentSubmissionStatus() == status)
+                .count();
+    }
+
+    private static long countAttendanceByStatus(List<StudyTodoResponse> attendances, AttendanceStatusResponse status) {
+        return attendances.stream()
+                .filter(studyTodoResponse -> studyTodoResponse.attendanceStatus() == status)
+                .count();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentResponse.java
@@ -1,11 +1,12 @@
 package com.gdschongik.gdsc.domain.study.dto.response;
 
 import static com.gdschongik.gdsc.domain.study.domain.AchievementType.*;
+import static com.gdschongik.gdsc.domain.study.dto.response.AssignmentSubmissionStatusResponse.*;
+import static com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse.StudyTodoType.*;
 
 import com.gdschongik.gdsc.domain.study.domain.AchievementType;
 import com.gdschongik.gdsc.domain.study.domain.StudyAchievement;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
-import com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse.StudyTodoType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
@@ -24,21 +25,19 @@ public record StudyStudentResponse(
     public static StudyStudentResponse of(
             StudyHistory studyHistory, List<StudyAchievement> studyAchievements, List<StudyTodoResponse> studyTodos) {
         List<StudyTodoResponse> assignments = studyTodos.stream()
-                .filter(studyTodoResponse -> studyTodoResponse.todoType() == StudyTodoType.ASSIGNMENT)
+                .filter(studyTodoResponse -> studyTodoResponse.todoType() == ASSIGNMENT)
                 .toList();
 
         List<StudyTodoResponse> attendances = studyTodos.stream()
-                .filter(studyTodoResponse -> studyTodoResponse.todoType() == StudyTodoType.ATTENDANCE)
+                .filter(studyTodoResponse -> studyTodoResponse.todoType() == ATTENDANCE)
                 .toList();
 
         long successAssignmentsCount = assignments.stream()
-                .filter(studyTodoResponse ->
-                        studyTodoResponse.assignmentSubmissionStatus() == AssignmentSubmissionStatusResponse.SUCCESS)
+                .filter(studyTodoResponse -> studyTodoResponse.assignmentSubmissionStatus() == SUCCESS)
                 .count();
 
         long cancelledAssignmentsCount = assignments.stream()
-                .filter(studyTodoResponse ->
-                        studyTodoResponse.assignmentSubmissionStatus() == AssignmentSubmissionStatusResponse.CANCELLED)
+                .filter(studyTodoResponse -> studyTodoResponse.assignmentSubmissionStatus() == CANCELLED)
                 .count();
 
         long attendedCount = attendances.stream()

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentResponse.java
@@ -48,8 +48,12 @@ public record StudyStudentResponse(
                 isOutstandingStudent(FIRST_ROUND_OUTSTANDING_STUDENT, studyAchievements),
                 isOutstandingStudent(SECOND_ROUND_OUTSTANDING_STUDENT, studyAchievements),
                 studyTodos,
-                (double) successAssignmentsCount * 100 / (assignments.size() - cancelledAssignmentsCount),
-                (double) (attendedCount * 100) / (attendances.size() - cancelledAttendanceCount));
+                assignments.size() != cancelledAssignmentsCount
+                        ? (double) successAssignmentsCount * 100 / (assignments.size() - cancelledAssignmentsCount)
+                        : 0,
+                attendances.size() != cancelledAttendanceCount
+                        ? (double) (attendedCount * 100) / (attendances.size() - cancelledAttendanceCount)
+                        : 0);
     }
 
     private static boolean isOutstandingStudent(

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyTodoResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyTodoResponse.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+// todo: 활용이 다양해졌으므로 rename 필요
 public record StudyTodoResponse(
         Long studyDetailId,
         @Schema(description = "현 주차수") Long week,
@@ -32,6 +33,17 @@ public record StudyTodoResponse(
     }
 
     public static StudyTodoResponse createAssignmentType(StudyDetail studyDetail, AssignmentHistory assignmentHistory) {
+        if (studyDetail.getAssignment().isCancelled()) {
+            return new StudyTodoResponse(
+                    studyDetail.getId(),
+                    studyDetail.getWeek(),
+                    ASSIGNMENT,
+                    null,
+                    null,
+                    null,
+                    AssignmentSubmissionStatusResponse.getCancelled());
+        }
+
         return new StudyTodoResponse(
                 studyDetail.getId(),
                 studyDetail.getWeek(),

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyTodoResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyTodoResponse.java
@@ -22,6 +22,16 @@ public record StudyTodoResponse(
         @Schema(description = "과제 제출 상태 (과제타입일 때만 사용)") AssignmentSubmissionStatusResponse assignmentSubmissionStatus) {
 
     public static StudyTodoResponse createAttendanceType(StudyDetail studyDetail, LocalDate now, boolean isAttended) {
+        if (studyDetail.getCurriculum().isCancelled()) {
+            return new StudyTodoResponse(
+                    studyDetail.getId(),
+                    studyDetail.getWeek(),
+                    ATTENDANCE,
+                    null,
+                    AttendanceStatusResponse.CANCELLED,
+                    null,
+                    null);
+        }
         return new StudyTodoResponse(
                 studyDetail.getId(),
                 studyDetail.getWeek(),
@@ -41,7 +51,7 @@ public record StudyTodoResponse(
                     null,
                     null,
                     null,
-                    AssignmentSubmissionStatusResponse.getCancelled());
+                    AssignmentSubmissionStatusResponse.CANCELLED);
         }
 
         return new StudyTodoResponse(

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyTodoResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyTodoResponse.java
@@ -51,7 +51,7 @@ public record StudyTodoResponse(
                     null,
                     null,
                     null,
-                    AssignmentSubmissionStatusResponse.CANCELLED);
+                    AssignmentSubmissionStatusResponse.of(null, studyDetail));
         }
 
         return new StudyTodoResponse(
@@ -61,7 +61,7 @@ public record StudyTodoResponse(
                 studyDetail.getAssignment().getDeadline(),
                 null,
                 studyDetail.getAssignment().getTitle(),
-                AssignmentSubmissionStatusResponse.from(assignmentHistory));
+                AssignmentSubmissionStatusResponse.of(assignmentHistory, studyDetail));
     }
 
     @Getter


### PR DESCRIPTION
## 🌱 관련 이슈
- close #789

## 📌 작업 내용 및 특이사항
![image](https://github.com/user-attachments/assets/2a5be9da-cf0e-453c-817d-32df71d52773)
- 다양한 테이블을 조회해야 해서 서비스 로직이 좀 복잡합니다.
- 각 레포지토리에 멤버마다 쿼리를 날리면 쿼리 수가 너무 많아져서 쿼리 나가는 수를 줄이기 위해, 조회하려는 멤버의 pk를 담은 List를 repository에 넘기는 방식을 사용했습니다.
- 이렇게 가져온 것들을 stream.filter로 찾아서 활용합니다.
- 기존 StudyTodoResponse가 가진 필드들이 이번 api에서 필요한 것과 겹쳐서 재활용했습니다. rename은 필요할 것 같아서 todo 남겨뒀고 이슈도(#795) 생성해뒀습니다.

## 📝 참고사항
- AssignmentHistoryRepository에 불필요하게 public이 붙어있어서 컨벤션상 제거하는 것이 좋을 것 같습니다. 이것 역시 todo와 이슈 #790 생성했습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

- **새로운 기능**
	- 수강생의 과제 제출 비율 및 출석률을 계산하는 기능이 추가되었습니다.
	- 출석 및 과제 상태에 '취소됨' 상태가 추가되었습니다.

- **변경 사항**
	- `StudyStudentResponse` 구조가 개선되어, 학생의 성취도 및 과제 제출 상태를 보다 효과적으로 관리할 수 있게 되었습니다.
	- `StudyTodoResponse`에서 출석 및 과제 유형의 취소 상태를 처리하는 로직이 개선되었습니다.
	- 수강생 응답 구조에 새로운 필드가 추가되어, 우수 학생 여부 및 과제와 출석률을 포함한 정보를 제공할 수 있게 되었습니다.
	- `StudyStudentResponse`의 메서드가 페이지네이션을 지원하도록 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->