### PR TITLE
refactor: VO의 정적 팩토리 메서드 네이밍 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/common/vo/Money.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/vo/Money.java
@@ -17,6 +17,8 @@ import lombok.NonNull;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public final class Money {
 
+    public static final Money ZERO = Money.from(BigDecimal.ZERO);
+
     private BigDecimal amount;
 
     @Override
@@ -33,8 +35,6 @@ public final class Money {
     private Money(BigDecimal amount) {
         this.amount = amount;
     }
-
-    public static final Money ZERO = Money.from(BigDecimal.ZERO);
 
     public static Money from(BigDecimal amount) {
         validateAmountNotNull(amount);

--- a/src/main/java/com/gdschongik/gdsc/domain/common/vo/Period.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/vo/Period.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Period {
+public final class Period {
     private LocalDateTime startDate;
 
     private LocalDateTime endDate;

--- a/src/main/java/com/gdschongik/gdsc/domain/common/vo/Period.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/vo/Period.java
@@ -39,6 +39,7 @@ public final class Period {
     }
 
     public boolean isOpen() {
+        // TODO: now를 내부에서 선언하지 않고 파라미터로 받아서 테스트 가능하도록 변경
         LocalDateTime now = LocalDateTime.now();
         return (now.isAfter(startDate) || now.isEqual(startDate)) && (now.isBefore(endDate) || now.isEqual(startDate));
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/common/vo/Period.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/vo/Period.java
@@ -1,4 +1,4 @@
-package com.gdschongik.gdsc.domain.recruitment.domain.vo;
+package com.gdschongik.gdsc.domain.common.vo;
 
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 

--- a/src/main/java/com/gdschongik/gdsc/domain/common/vo/Period.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/vo/Period.java
@@ -5,16 +5,18 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.Embeddable;
 import java.time.LocalDateTime;
-import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
+@EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public final class Period {
+
     private LocalDateTime startDate;
 
     private LocalDateTime endDate;
@@ -45,18 +47,5 @@ public final class Period {
         if (!this.endDate.isBefore(startDate) && !this.startDate.isAfter(endDate)) {
             throw new CustomException(PERIOD_OVERLAP);
         }
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Period that = (Period) o;
-        return startDate == that.startDate && endDate == that.endDate;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(startDate, endDate);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponService.java
@@ -37,7 +37,7 @@ public class CouponService {
 
     @Transactional
     public void createCoupon(CouponCreateRequest request) {
-        Coupon coupon = Coupon.createCoupon(request.name(), Money.from(request.discountAmount()));
+        Coupon coupon = Coupon.create(request.name(), Money.from(request.discountAmount()));
         couponRepository.save(coupon);
         log.info("[CouponService] 쿠폰 생성: name={}, discountAmount={}", request.name(), request.discountAmount());
     }
@@ -59,7 +59,7 @@ public class CouponService {
         List<Member> members = memberRepository.findAllById(request.memberIds());
 
         List<IssuedCoupon> issuedCoupons = members.stream()
-                .map(member -> IssuedCoupon.issue(coupon, member))
+                .map(member -> IssuedCoupon.create(coupon, member))
                 .toList();
 
         issuedCouponRepository.saveAll(issuedCoupons);

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
@@ -37,7 +37,7 @@ public class Coupon extends BaseEntity {
         this.discountAmount = discountAmount;
     }
 
-    public static Coupon createCoupon(String name, Money discountAmount) {
+    public static Coupon create(String name, Money discountAmount) {
         validateDiscountAmountPositive(discountAmount);
         return Coupon.builder().name(name).discountAmount(discountAmount).build();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
@@ -51,7 +51,7 @@ public class IssuedCoupon extends BaseEntity {
         this.hasRevoked = hasRevoked;
     }
 
-    public static IssuedCoupon issue(Coupon coupon, Member member) {
+    public static IssuedCoupon create(Coupon coupon, Member member) {
         return IssuedCoupon.builder()
                 .coupon(coupon)
                 .member(member)

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/PingpongListener.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/PingpongListener.java
@@ -20,9 +20,9 @@ public class PingpongListener extends ListenerAdapter {
         User author = event.getAuthor();
         TextChannel channel = event.getChannel().asTextChannel();
         Message message = event.getMessage();
-        String content = message.getContentRaw(); // get only textual content of message
+        String content = message.getContentRaw(); // get only textual content create message
 
-        log.info("Message of {} in {}: {}", author.getName(), channel.getName(), message.getContentDisplay());
+        log.info("Message create {} in {}: {}", author.getName(), channel.getName(), message.getContentDisplay());
 
         if (author.isBot()) return;
 

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/PingpongListener.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/PingpongListener.java
@@ -20,9 +20,9 @@ public class PingpongListener extends ListenerAdapter {
         User author = event.getAuthor();
         TextChannel channel = event.getChannel().asTextChannel();
         Message message = event.getMessage();
-        String content = message.getContentRaw(); // get only textual content create message
+        String content = message.getContentRaw();
 
-        log.info("Message create {} in {}: {}", author.getName(), channel.getName(), message.getContentDisplay());
+        log.info("Message of {} in {}: {}", author.getName(), channel.getName(), message.getContentDisplay());
 
         if (author.isBot()) return;
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/TestMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/TestMemberService.java
@@ -31,7 +31,7 @@ public class TestMemberService {
             throw new CustomException(INTERNAL_SERVER_ERROR);
         }
 
-        Member guestMember = Member.createGuestMember(githubOauthId);
+        Member guestMember = Member.createGuest(githubOauthId);
         memberRepository.save(guestMember);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/AssociateRequirement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/AssociateRequirement.java
@@ -44,7 +44,7 @@ public class AssociateRequirement {
         this.infoStatus = infoStatus;
     }
 
-    public static AssociateRequirement create() {
+    public static AssociateRequirement unsatisfied() {
         return AssociateRequirement.builder()
                 .univStatus(UNSATISFIED)
                 .discordStatus(UNSATISFIED)

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/AssociateRequirement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/AssociateRequirement.java
@@ -44,7 +44,7 @@ public class AssociateRequirement {
         this.infoStatus = infoStatus;
     }
 
-    public static AssociateRequirement createRequirement() {
+    public static AssociateRequirement create() {
         return AssociateRequirement.builder()
                 .univStatus(UNSATISFIED)
                 .discordStatus(UNSATISFIED)

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -107,7 +107,7 @@ public class Member extends BaseEntity {
     }
 
     public static Member createGuestMember(String oauthId) {
-        AssociateRequirement associateRequirement = AssociateRequirement.createRequirement();
+        AssociateRequirement associateRequirement = AssociateRequirement.create();
         return Member.builder()
                 .oauthId(oauthId)
                 .role(GUEST)

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -107,7 +107,7 @@ public class Member extends BaseEntity {
     }
 
     public static Member createGuestMember(String oauthId) {
-        AssociateRequirement associateRequirement = AssociateRequirement.create();
+        AssociateRequirement associateRequirement = AssociateRequirement.unsatisfied();
         return Member.builder()
                 .oauthId(oauthId)
                 .role(GUEST)

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -106,7 +106,7 @@ public class Member extends BaseEntity {
         this.associateRequirement = associateRequirement;
     }
 
-    public static Member createGuestMember(String oauthId) {
+    public static Member createGuest(String oauthId) {
         AssociateRequirement associateRequirement = AssociateRequirement.unsatisfied();
         return Member.builder()
                 .oauthId(oauthId)

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -69,7 +69,7 @@ public class MembershipService {
 
         membershipValidator.validateMembershipSubmit(currentMember, recruitmentRound, isMembershipDuplicate);
 
-        Membership membership = Membership.createMembership(currentMember, recruitmentRound);
+        Membership membership = Membership.create(currentMember, recruitmentRound);
         membershipRepository.save(membership);
 
         log.info("[MembershipService] 멤버십 가입 신청 접수: membershipId = {}", membership.getId());

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
@@ -56,7 +56,7 @@ public class Membership extends BaseEntity {
         return Membership.builder()
                 .member(member)
                 .recruitmentRound(recruitmentRound)
-                .regularRequirement(RegularRequirement.create())
+                .regularRequirement(RegularRequirement.unsatisfied())
                 .build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
@@ -52,7 +52,7 @@ public class Membership extends BaseEntity {
         this.regularRequirement = regularRequirement;
     }
 
-    public static Membership createMembership(Member member, RecruitmentRound recruitmentRound) {
+    public static Membership create(Member member, RecruitmentRound recruitmentRound) {
         return Membership.builder()
                 .member(member)
                 .recruitmentRound(recruitmentRound)

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
@@ -56,7 +56,7 @@ public class Membership extends BaseEntity {
         return Membership.builder()
                 .member(member)
                 .recruitmentRound(recruitmentRound)
-                .regularRequirement(RegularRequirement.createUnsatisfiedRequirement())
+                .regularRequirement(RegularRequirement.create())
                 .build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/RegularRequirement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/RegularRequirement.java
@@ -27,7 +27,7 @@ public class RegularRequirement {
         this.paymentStatus = paymentStatus;
     }
 
-    public static RegularRequirement createUnsatisfiedRequirement() {
+    public static RegularRequirement create() {
         return RegularRequirement.builder()
                 .paymentStatus(RequirementStatus.UNSATISFIED)
                 .build();

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/RegularRequirement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/RegularRequirement.java
@@ -27,7 +27,7 @@ public class RegularRequirement {
         this.paymentStatus = paymentStatus;
     }
 
-    public static RegularRequirement create() {
+    public static RegularRequirement unsatisfied() {
         return RegularRequirement.builder()
                 .paymentStatus(RequirementStatus.UNSATISFIED)
                 .build();

--- a/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
@@ -53,7 +53,7 @@ public class OrderService {
 
         IssuedCoupon issuedCoupon = request.issuedCouponId() == null ? null : getIssuedCoupon(request.issuedCouponId());
 
-        MoneyInfo moneyInfo = MoneyInfo.of(
+        MoneyInfo moneyInfo = MoneyInfo.create(
                 Money.from(request.totalAmount()),
                 Money.from(request.discountAmount()),
                 Money.from(request.finalPaymentAmount()));
@@ -154,7 +154,7 @@ public class OrderService {
         Optional<IssuedCoupon> issuedCoupon =
                 Optional.ofNullable(request.issuedCouponId()).map(this::getIssuedCoupon);
 
-        MoneyInfo moneyInfo = MoneyInfo.of(
+        MoneyInfo moneyInfo = MoneyInfo.create(
                 Money.from(request.totalAmount()),
                 Money.from(request.discountAmount()),
                 Money.from(request.finalPaymentAmount()));

--- a/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
@@ -53,7 +53,7 @@ public class OrderService {
 
         IssuedCoupon issuedCoupon = request.issuedCouponId() == null ? null : getIssuedCoupon(request.issuedCouponId());
 
-        MoneyInfo moneyInfo = MoneyInfo.create(
+        MoneyInfo moneyInfo = MoneyInfo.of(
                 Money.from(request.totalAmount()),
                 Money.from(request.discountAmount()),
                 Money.from(request.finalPaymentAmount()));
@@ -154,7 +154,7 @@ public class OrderService {
         Optional<IssuedCoupon> issuedCoupon =
                 Optional.ofNullable(request.issuedCouponId()).map(this::getIssuedCoupon);
 
-        MoneyInfo moneyInfo = MoneyInfo.create(
+        MoneyInfo moneyInfo = MoneyInfo.of(
                 Money.from(request.totalAmount()),
                 Money.from(request.discountAmount()),
                 Money.from(request.finalPaymentAmount()));

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/MoneyInfo.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/MoneyInfo.java
@@ -42,7 +42,7 @@ public class MoneyInfo {
         this.finalPaymentAmount = finalPaymentAmount;
     }
 
-    public static MoneyInfo of(Money totalAmount, Money discountAmount, Money finalPaymentAmount) {
+    public static MoneyInfo create(Money totalAmount, Money discountAmount, Money finalPaymentAmount) {
         validateFinalPaymentAmount(totalAmount, discountAmount, finalPaymentAmount);
 
         return MoneyInfo.builder()

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/MoneyInfo.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/MoneyInfo.java
@@ -42,7 +42,7 @@ public class MoneyInfo {
         this.finalPaymentAmount = finalPaymentAmount;
     }
 
-    public static MoneyInfo create(Money totalAmount, Money discountAmount, Money finalPaymentAmount) {
+    public static MoneyInfo of(Money totalAmount, Money discountAmount, Money finalPaymentAmount) {
         validateFinalPaymentAmount(totalAmount, discountAmount, finalPaymentAmount);
 
         return MoneyInfo.builder()

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -45,7 +45,7 @@ public class AdminRecruitmentService {
                 request.semesterType(),
                 Money.from(request.fee()),
                 request.feeName(),
-                Period.createPeriod(request.semesterStartDate(), request.semesterEndDate()));
+                Period.of(request.semesterStartDate(), request.semesterEndDate()));
         recruitmentRepository.save(recruitment);
 
         log.info("[AdminRecruitmentService] 리쿠르팅 생성: recruitmentId={}", recruitment.getId());
@@ -81,10 +81,7 @@ public class AdminRecruitmentService {
                 recruitmentRoundsInThisSemester);
 
         RecruitmentRound recruitmentRound = RecruitmentRound.create(
-                request.name(),
-                Period.createPeriod(request.startDate(), request.endDate()),
-                recruitment,
-                request.roundType());
+                request.name(), Period.of(request.startDate(), request.endDate()), recruitment, request.roundType());
         recruitmentRoundRepository.save(recruitmentRound);
 
         log.info("[AdminRecruitmentService] 모집회차 생성: recruitmentRoundId={}", recruitmentRound.getId());
@@ -106,7 +103,7 @@ public class AdminRecruitmentService {
                 request.startDate(), request.endDate(), request.roundType(), recruitmentRound, recruitmentRounds);
 
         recruitmentRound.updateRecruitmentRound(
-                request.name(), Period.createPeriod(request.startDate(), request.endDate()), request.roundType());
+                request.name(), Period.of(request.startDate(), request.endDate()), request.roundType());
 
         log.info("[AdminRecruitmentService] 모집회차 수정: recruitmentRoundId={}", recruitmentRoundId);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -3,13 +3,13 @@ package com.gdschongik.gdsc.domain.recruitment.application;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRoundValidator;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentValidator;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentRoundCreateRequest;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentRoundUpdateRequest;

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -40,7 +40,7 @@ public class AdminRecruitmentService {
 
         recruitmentValidator.validateRecruitmentCreate(isRecruitmentOverlap);
 
-        Recruitment recruitment = Recruitment.createRecruitment(
+        Recruitment recruitment = Recruitment.create(
                 request.academicYear(),
                 request.semesterType(),
                 Money.from(request.fee()),

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
@@ -37,7 +37,7 @@ public class Recruitment extends BaseSemesterEntity {
         this.semesterPeriod = semesterPeriod;
     }
 
-    public static Recruitment createRecruitment(
+    public static Recruitment create(
             Integer academicYear, SemesterType semesterType, Money fee, String feeName, Period semesterPeriod) {
         return Recruitment.builder()
                 .academicYear(academicYear)

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
@@ -3,7 +3,7 @@ package com.gdschongik.gdsc.domain.recruitment.domain;
 import com.gdschongik.gdsc.domain.common.model.BaseSemesterEntity;
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
@@ -4,7 +4,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.model.BaseSemesterEntity;
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/vo/Period.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/vo/Period.java
@@ -25,7 +25,7 @@ public class Period {
         this.endDate = endDate;
     }
 
-    public static Period createPeriod(LocalDateTime startDate, LocalDateTime endDate) {
+    public static Period of(LocalDateTime startDate, LocalDateTime endDate) {
         validatePeriod(startDate, endDate);
         return Period.builder().startDate(startDate).endDate(endDate).build();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/RecruitmentRoundFullDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/RecruitmentRoundFullDto.java
@@ -1,8 +1,8 @@
 package com.gdschongik.gdsc.domain.recruitment.dto;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import java.math.BigDecimal;
 
 public record RecruitmentRoundFullDto(

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
@@ -131,8 +131,7 @@ public class MentorStudyService {
 
         studyValidator.validateStudyMentor(currentMember, study);
 
-        StudyAnnouncement studyAnnouncement =
-                StudyAnnouncement.createStudyAnnouncement(study, request.title(), request.link());
+        StudyAnnouncement studyAnnouncement = StudyAnnouncement.create(study, request.title(), request.link());
         studyAnnouncementRepository.save(studyAnnouncement);
 
         log.info("[MentorStudyService] 스터디 공지 생성: studyAnnouncementId={}", studyAnnouncement.getId());

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
@@ -98,7 +98,7 @@ public class StudentStudyService {
         attendanceValidator.validateAttendance(
                 studyDetail, request.attendanceNumber(), LocalDate.now(), isAlreadyAttended, isAppliedToStudy);
 
-        Attendance attendance = Attendance.create(currentMember, studyDetail);
+        Attendance attendance = Attendance.of(currentMember, studyDetail);
         attendanceRepository.save(attendance);
 
         log.info("[StudyService] 스터디 출석: attendanceId={}, memberId={}", attendance.getId(), currentMember.getId());

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/Attendance.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/Attendance.java
@@ -42,7 +42,7 @@ public class Attendance extends BaseEntity {
         this.studyDetail = studyDetail;
     }
 
-    public static Attendance create(Member student, StudyDetail studyDetail) {
+    public static Attendance of(Member student, StudyDetail studyDetail) {
         return Attendance.builder().student(student).studyDetail(studyDetail).build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
@@ -5,8 +5,8 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.model.BaseSemesterEntity;
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
@@ -102,7 +102,7 @@ public class Study extends BaseSemesterEntity {
         this.endTime = endTime;
     }
 
-    public static Study createStudy(
+    public static Study create(
             Integer academicYear,
             SemesterType semesterType,
             String title,

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAnnouncement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAnnouncement.java
@@ -40,7 +40,7 @@ public class StudyAnnouncement extends BaseEntity {
         this.link = link;
     }
 
-    public static StudyAnnouncement createStudyAnnouncement(Study study, String title, String link) {
+    public static StudyAnnouncement create(Study study, String title, String link) {
         return StudyAnnouncement.builder().study(study).title(title).link(link).build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
@@ -78,7 +78,7 @@ public class StudyDetail extends BaseEntity {
                 .period(period)
                 .attendanceNumber(attendanceNumber)
                 .period(period)
-                .curriculum(Curriculum.createEmpty())
+                .curriculum(Curriculum.empty())
                 .assignment(Assignment.empty())
                 .build();
     }
@@ -135,7 +135,7 @@ public class StudyDetail extends BaseEntity {
 
     public void updateCurriculum(
             LocalTime startAt, String title, String description, Difficulty difficulty, StudyStatus status) {
-        curriculum = Curriculum.create(startAt, title, description, difficulty, status);
+        curriculum = Curriculum.of(startAt, title, description, difficulty, status);
     }
 
     public void validateAssignmentSubmittable(LocalDateTime now) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
@@ -78,7 +78,7 @@ public class StudyDetail extends BaseEntity {
                 .period(period)
                 .attendanceNumber(attendanceNumber)
                 .period(period)
-                .curriculum(Curriculum.createEmptyCurriculum())
+                .curriculum(Curriculum.createEmpty())
                 .assignment(Assignment.createEmpty())
                 .build();
     }
@@ -135,7 +135,7 @@ public class StudyDetail extends BaseEntity {
 
     public void updateCurriculum(
             LocalTime startAt, String title, String description, Difficulty difficulty, StudyStatus status) {
-        curriculum = Curriculum.generateCurriculum(startAt, title, description, difficulty, status);
+        curriculum = Curriculum.create(startAt, title, description, difficulty, status);
     }
 
     public void validateAssignmentSubmittable(LocalDateTime now) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
@@ -79,20 +79,20 @@ public class StudyDetail extends BaseEntity {
                 .attendanceNumber(attendanceNumber)
                 .period(period)
                 .curriculum(Curriculum.createEmptyCurriculum())
-                .assignment(Assignment.createEmptyAssignment())
+                .assignment(Assignment.createEmpty())
                 .build();
     }
 
     public void cancelAssignment() {
-        assignment = Assignment.cancelAssignment();
+        assignment = Assignment.createCanceled();
     }
 
     public void publishAssignment(String title, LocalDateTime deadLine, String descriptionNotionLink) {
-        assignment = Assignment.generateAssignment(title, deadLine, descriptionNotionLink);
+        assignment = Assignment.create(title, deadLine, descriptionNotionLink);
     }
 
     public void updateAssignment(String title, LocalDateTime deadLine, String descriptionNotionLink) {
-        assignment = Assignment.generateAssignment(title, deadLine, descriptionNotionLink);
+        assignment = Assignment.create(title, deadLine, descriptionNotionLink);
     }
 
     // 데이터 전달 로직

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
@@ -79,20 +79,20 @@ public class StudyDetail extends BaseEntity {
                 .attendanceNumber(attendanceNumber)
                 .period(period)
                 .curriculum(Curriculum.createEmpty())
-                .assignment(Assignment.createEmpty())
+                .assignment(Assignment.empty())
                 .build();
     }
 
     public void cancelAssignment() {
-        assignment = Assignment.createCanceled();
+        assignment = Assignment.canceled();
     }
 
     public void publishAssignment(String title, LocalDateTime deadLine, String descriptionNotionLink) {
-        assignment = Assignment.create(title, deadLine, descriptionNotionLink);
+        assignment = Assignment.of(title, deadLine, descriptionNotionLink);
     }
 
     public void updateAssignment(String title, LocalDateTime deadLine, String descriptionNotionLink) {
-        assignment = Assignment.create(title, deadLine, descriptionNotionLink);
+        assignment = Assignment.of(title, deadLine, descriptionNotionLink);
     }
 
     // 데이터 전달 로직

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
@@ -71,7 +71,7 @@ public class StudyDetail extends BaseEntity {
         this.assignment = assignment;
     }
 
-    public static StudyDetail createStudyDetail(Study study, Long week, String attendanceNumber, Period period) {
+    public static StudyDetail create(Study study, Long week, String attendanceNumber, Period period) {
         return StudyDetail.builder()
                 .study(study)
                 .week(week)

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
@@ -3,7 +3,7 @@ package com.gdschongik.gdsc.domain.study.domain;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.model.BaseEntity;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.study.domain.vo.Assignment;
 import com.gdschongik.gdsc.domain.study.domain.vo.Curriculum;
 import com.gdschongik.gdsc.global.exception.CustomException;

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
@@ -46,7 +46,7 @@ public class Assignment {
         this.status = status;
     }
 
-    public static Assignment create(String title, LocalDateTime deadline, String descriptionLink) {
+    public static Assignment of(String title, LocalDateTime deadline, String descriptionLink) {
         return Assignment.builder()
                 .title(title)
                 .deadline(deadline)
@@ -55,11 +55,11 @@ public class Assignment {
                 .build();
     }
 
-    public static Assignment createEmpty() {
+    public static Assignment empty() {
         return Assignment.builder().status(NONE).build();
     }
 
-    public static Assignment createCanceled() {
+    public static Assignment canceled() {
         return Assignment.builder().status(CANCELLED).build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
@@ -98,6 +98,7 @@ public class Assignment {
 
     public boolean isDeadLineThisWeek() {
         // 현재 날짜와 마감일의 날짜 부분을 비교할 것이므로 LocalDate로 변환
+        // TODO: now를 내부에서 선언하지 않고 파라미터로 받아서 테스트 가능하도록 변경
         LocalDate now = LocalDate.now();
         LocalDate startOfWeek = now.with(DayOfWeek.MONDAY); // 이번 주 월요일
         LocalDate endOfWeek = now.with(DayOfWeek.SUNDAY); // 이번 주 일요일

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
@@ -46,21 +46,21 @@ public class Assignment {
         this.status = status;
     }
 
-    public static Assignment createEmptyAssignment() {
-        return Assignment.builder().status(NONE).build();
-    }
-
-    public static Assignment cancelAssignment() {
-        return Assignment.builder().status(CANCELLED).build();
-    }
-
-    public static Assignment generateAssignment(String title, LocalDateTime deadline, String descriptionLink) {
+    public static Assignment create(String title, LocalDateTime deadline, String descriptionLink) {
         return Assignment.builder()
                 .title(title)
                 .deadline(deadline)
                 .descriptionLink(descriptionLink)
                 .status(StudyStatus.OPEN)
                 .build();
+    }
+
+    public static Assignment createEmpty() {
+        return Assignment.builder().status(NONE).build();
+    }
+
+    public static Assignment createCanceled() {
+        return Assignment.builder().status(CANCELLED).build();
     }
 
     public void validateSubmittable(LocalDateTime now) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Curriculum.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Curriculum.java
@@ -41,11 +41,7 @@ public class Curriculum {
         this.status = status;
     }
 
-    public static Curriculum createEmptyCurriculum() {
-        return Curriculum.builder().status(StudyStatus.NONE).build();
-    }
-
-    public static Curriculum generateCurriculum(
+    public static Curriculum create(
             LocalTime startAt, String title, String description, Difficulty difficulty, StudyStatus status) {
         return Curriculum.builder()
                 .startAt(startAt)
@@ -54,6 +50,10 @@ public class Curriculum {
                 .difficulty(difficulty)
                 .status(status)
                 .build();
+    }
+
+    public static Curriculum createEmpty() {
+        return Curriculum.builder().status(StudyStatus.NONE).build();
     }
 
     // 데이터 전달 로직

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Curriculum.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Curriculum.java
@@ -41,7 +41,7 @@ public class Curriculum {
         this.status = status;
     }
 
-    public static Curriculum create(
+    public static Curriculum of(
             LocalTime startAt, String title, String description, Difficulty difficulty, StudyStatus status) {
         return Curriculum.builder()
                 .startAt(startAt)
@@ -52,7 +52,7 @@ public class Curriculum {
                 .build();
     }
 
-    public static Curriculum createEmpty() {
+    public static Curriculum empty() {
         return Curriculum.builder().status(StudyStatus.NONE).build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/CommonStudyResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/CommonStudyResponse.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.study.dto.response;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.study.domain.Study;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.DayOfWeek;

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyCurriculumResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyCurriculumResponse.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.study.dto.response;
 
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.study.domain.Difficulty;
 import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import com.gdschongik.gdsc.domain.study.domain.StudyStatus;

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentCurriculumResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentCurriculumResponse.java
@@ -2,7 +2,7 @@ package com.gdschongik.gdsc.domain.study.dto.response;
 
 import static com.gdschongik.gdsc.domain.study.domain.SubmissionFailureType.NOT_SUBMITTED;
 
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
 import com.gdschongik.gdsc.domain.study.domain.Difficulty;
 import com.gdschongik.gdsc.domain.study.domain.StudyDetail;

--- a/src/main/java/com/gdschongik/gdsc/domain/study/factory/StudyDomainFactory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/factory/StudyDomainFactory.java
@@ -17,7 +17,7 @@ public class StudyDomainFactory {
     // 새로운 스터디를 생성합니다.
     public Study createNewStudy(StudyCreateRequest request, Member mentor) {
         LocalDate endDate = request.startDate().plusWeeks(request.totalWeek()).minusDays(1);
-        return Study.createStudy(
+        return Study.create(
                 request.academicYear(),
                 request.semesterType(),
                 request.title(),

--- a/src/main/java/com/gdschongik/gdsc/domain/study/factory/StudyDomainFactory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/factory/StudyDomainFactory.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.study.factory;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import com.gdschongik.gdsc.domain.study.dto.request.StudyCreateRequest;

--- a/src/main/java/com/gdschongik/gdsc/domain/study/factory/StudyDomainFactory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/factory/StudyDomainFactory.java
@@ -22,8 +22,8 @@ public class StudyDomainFactory {
                 request.semesterType(),
                 request.title(),
                 mentor,
-                Period.createPeriod(request.startDate().atStartOfDay(), endDate.atTime(LocalTime.MAX)),
-                Period.createPeriod(
+                Period.of(request.startDate().atStartOfDay(), endDate.atTime(LocalTime.MAX)),
+                Period.of(
                         request.applicationStartDate().atStartOfDay(),
                         request.applicationEndDate().atTime(LocalTime.MAX)),
                 request.totalWeek(),
@@ -40,6 +40,6 @@ public class StudyDomainFactory {
 
         String attendanceNumber =
                 new Random().ints(4, 0, 10).mapToObj(String::valueOf).reduce("", String::concat);
-        return StudyDetail.createStudyDetail(study, week, attendanceNumber, Period.createPeriod(startDate, endDate));
+        return StudyDetail.createStudyDetail(study, week, attendanceNumber, Period.of(startDate, endDate));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/factory/StudyDomainFactory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/factory/StudyDomainFactory.java
@@ -40,6 +40,6 @@ public class StudyDomainFactory {
 
         String attendanceNumber =
                 new Random().ints(4, 0, 10).mapToObj(String::valueOf).reduce("", String::concat);
-        return StudyDetail.createStudyDetail(study, week, attendanceNumber, Period.of(startDate, endDate));
+        return StudyDetail.create(study, week, attendanceNumber, Period.of(startDate, endDate));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/security/CustomUserService.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/CustomUserService.java
@@ -1,7 +1,5 @@
 package com.gdschongik.gdsc.global.security;
 
-import static com.gdschongik.gdsc.global.common.constant.SecurityConstant.*;
-
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +31,7 @@ public class CustomUserService extends DefaultOAuth2UserService {
     }
 
     private Member registerMember(OAuth2User oAuth2User) {
-        Member guest = Member.createGuestMember(oAuth2User.getName());
+        Member guest = Member.createGuest(oAuth2User.getName());
         return memberRepository.save(guest);
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/CouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/CouponTest.java
@@ -18,7 +18,7 @@ class CouponTest {
         @Test
         void 성공한다() {
             // when
-            Coupon coupon = Coupon.createCoupon(COUPON_NAME, Money.from(ONE));
+            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE));
 
             // then
             assertThat(coupon).isNotNull();
@@ -30,7 +30,7 @@ class CouponTest {
             Money discountAmount = Money.from(ZERO);
 
             // when & then
-            assertThatThrownBy(() -> Coupon.createCoupon(COUPON_NAME, discountAmount))
+            assertThatThrownBy(() -> Coupon.create(COUPON_NAME, discountAmount))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(COUPON_DISCOUNT_AMOUNT_NOT_POSITIVE.getMessage());
         }

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
@@ -20,9 +20,9 @@ class IssuedCouponTest {
         @Test
         void 성공하면_사용여부는_true이다() {
             // given
-            Coupon coupon = Coupon.createCoupon(COUPON_NAME, Money.from(ONE));
-            Member member = Member.createGuestMember(OAUTH_ID);
-            IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
+            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE));
+            Member member = Member.createGuest(OAUTH_ID);
+            IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
 
             // when
             issuedCoupon.use();
@@ -34,9 +34,9 @@ class IssuedCouponTest {
         @Test
         void 이미_사용한_쿠폰이면_실패한다() {
             // given
-            Coupon coupon = Coupon.createCoupon(COUPON_NAME, Money.from(ONE));
-            Member member = Member.createGuestMember(OAUTH_ID);
-            IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
+            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE));
+            Member member = Member.createGuest(OAUTH_ID);
+            IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
             issuedCoupon.use();
 
             // when & then
@@ -48,9 +48,9 @@ class IssuedCouponTest {
         @Test
         void 이미_회수한_쿠폰이면_실패한다() {
             // given
-            Coupon coupon = Coupon.createCoupon(COUPON_NAME, Money.from(ONE));
-            Member member = Member.createGuestMember(OAUTH_ID);
-            IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
+            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE));
+            Member member = Member.createGuest(OAUTH_ID);
+            IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
             issuedCoupon.revoke();
 
             // when & then
@@ -66,9 +66,9 @@ class IssuedCouponTest {
         @Test
         void 성공하면_회수여부는_true이다() {
             // given
-            Coupon coupon = Coupon.createCoupon(COUPON_NAME, Money.from(ONE));
-            Member member = Member.createGuestMember(OAUTH_ID);
-            IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
+            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE));
+            Member member = Member.createGuest(OAUTH_ID);
+            IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
 
             // when
             issuedCoupon.revoke();
@@ -80,9 +80,9 @@ class IssuedCouponTest {
         @Test
         void 이미_회수한_발급쿠폰이면_실패한다() {
             // given
-            Coupon coupon = Coupon.createCoupon(COUPON_NAME, Money.from(ONE));
-            Member member = Member.createGuestMember(OAUTH_ID);
-            IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
+            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE));
+            Member member = Member.createGuest(OAUTH_ID);
+            IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
             issuedCoupon.revoke();
 
             // when & then
@@ -94,9 +94,9 @@ class IssuedCouponTest {
         @Test
         void 이미_사용한_발급쿠폰이면_실패한다() {
             // given
-            Coupon coupon = Coupon.createCoupon(COUPON_NAME, Money.from(ONE));
-            Member member = Member.createGuestMember(OAUTH_ID);
-            IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
+            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE));
+            Member member = Member.createGuest(OAUTH_ID);
+            IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
             issuedCoupon.use();
 
             // when & then

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
@@ -24,7 +24,7 @@ class AdminMemberServiceTest extends IntegrationTest {
     @Test
     void status가_DELETED라면_예외_발생() {
         // given
-        Member member = Member.createGuestMember(OAUTH_ID);
+        Member member = Member.createGuest(OAUTH_ID);
         member.withdraw();
         memberRepository.save(member);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
@@ -52,7 +52,7 @@ class OnboardingMemberServiceTest extends IntegrationTest {
         @Test
         void 기본정보_미작성시_멤버_기본정보는_모두_null이다() {
             // given
-            memberRepository.save(Member.createGuestMember(OAUTH_ID));
+            memberRepository.save(Member.createGuest(OAUTH_ID));
             logoutAndReloginAs(1L, MemberRole.ASSOCIATE);
 
             // when

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
@@ -4,12 +4,12 @@ import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberDashboardResponse;
 import com.gdschongik.gdsc.domain.recruitment.application.OnboardingRecruitmentService;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.helper.IntegrationTest;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -27,7 +27,7 @@ class MemberRepositoryTest extends RepositoryTest {
     private MemberRepository memberRepository;
 
     private Member getMember() {
-        Member member = Member.createGuestMember(OAUTH_ID);
+        Member member = Member.createGuest(OAUTH_ID);
         return memberRepository.save(member);
     }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -20,7 +20,7 @@ class MemberTest {
         @Test
         void MemberRole은_GUEST이다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             // when
             MemberRole role = member.getRole();
@@ -32,7 +32,7 @@ class MemberTest {
         @Test
         void MemberStatus는_NORMAL이다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             // when
             MemberStatus status = member.getStatus();
@@ -44,7 +44,7 @@ class MemberTest {
         @Test
         void 모든_준회원_가입조건은_인증되지_않은_상태이다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             // when
             AssociateRequirement requirement = member.getAssociateRequirement();
@@ -63,7 +63,7 @@ class MemberTest {
         @Test
         void 기본회원정보_작성시_준회원_가입조건중_기본정보_인증상태가_인증된다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             // when
             member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
@@ -76,7 +76,7 @@ class MemberTest {
         @Test
         void 재학생이메일_인증시_준회원_가입조건중_재학생이메일_인증상태가_인증된다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             // when
             member.completeUnivEmailVerification(UNIV_EMAIL);
@@ -89,7 +89,7 @@ class MemberTest {
         @Test
         void 디스코드_인증시_준회원_가입조건중_디스코드_인증상태가_인증된다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             // when
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
@@ -102,7 +102,7 @@ class MemberTest {
         @Test
         void Bevy_인증시_준회원_가입조건중_Bevy_인증상태가_인증된다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             // when
             member.verifyBevy();
@@ -119,7 +119,7 @@ class MemberTest {
         @Test
         void 기본_회원정보_작성하지_않았으면_실패한다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
             member.completeUnivEmailVerification(UNIV_EMAIL);
@@ -134,7 +134,7 @@ class MemberTest {
         @Test
         void 디스코드_인증하지_않았으면_실패한다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
             member.completeUnivEmailVerification(UNIV_EMAIL);
@@ -149,7 +149,7 @@ class MemberTest {
         @Test
         void Bevy_연동하지_않았으면_실패한다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
             member.completeUnivEmailVerification(UNIV_EMAIL);
@@ -164,7 +164,7 @@ class MemberTest {
         @Test
         void 이미_준회원으로_승급_돼있으면_실패한다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
             member.completeUnivEmailVerification(UNIV_EMAIL);
@@ -181,7 +181,7 @@ class MemberTest {
         @Test
         void 모든_준회원_가입조건이_인증되었으면_성공한다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
             member.completeUnivEmailVerification(UNIV_EMAIL);
@@ -202,7 +202,7 @@ class MemberTest {
         @Test
         void 이미_탈퇴한_유저면_실패한다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             member.withdraw();
 
@@ -215,7 +215,7 @@ class MemberTest {
         @Test
         void 회원탈퇴시_이전에_탈퇴하지_않은_유저면_성공한다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             // when
             member.withdraw();
@@ -230,7 +230,7 @@ class MemberTest {
         @Test
         void 탈퇴하지_않은_유저면_성공한다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             member.updateMemberInfo(
                     MODIFIED_STUDENT_ID, NAME, PHONE_NUMBER, D022, UNIV_EMAIL, DISCORD_USERNAME, NICKNAME);
@@ -242,7 +242,7 @@ class MemberTest {
         @Test
         void 탈퇴한_유저면_실패한다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             member.withdraw();
 
@@ -259,7 +259,7 @@ class MemberTest {
     @Test
     void 디스코드인증시_탈퇴한_유저면_실패한다() {
         // given
-        Member member = Member.createGuestMember(OAUTH_ID);
+        Member member = Member.createGuest(OAUTH_ID);
 
         member.withdraw();
 
@@ -274,7 +274,7 @@ class MemberTest {
     @Test
     void Bevy인증시_탈퇴한_유저면_실패한다() {
         // given
-        Member member = Member.createGuestMember(OAUTH_ID);
+        Member member = Member.createGuest(OAUTH_ID);
 
         member.withdraw();
 
@@ -289,7 +289,7 @@ class MemberTest {
         @Test
         void 이미_정회원이라면_실패한다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
             member.completeUnivEmailVerification(UNIV_EMAIL);
@@ -307,7 +307,7 @@ class MemberTest {
         @Test
         void MemberRole이_GUEST_이라면_실패한다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             // when & then
             assertThatThrownBy(member::advanceToRegular)
@@ -318,7 +318,7 @@ class MemberTest {
         @Test
         void 준회원이라면_성공한다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
             member.completeUnivEmailVerification(UNIV_EMAIL);
@@ -340,7 +340,7 @@ class MemberTest {
         @Test
         void 성공한다() {
             // given
-            Member member = Member.createGuestMember(OAUTH_ID);
+            Member member = Member.createGuest(OAUTH_ID);
 
             member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
             member.completeUnivEmailVerification(UNIV_EMAIL);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
@@ -25,7 +25,7 @@ public class MemberValidatorTest {
         void 해당_학기에_이미_시작된_모집기간이_있다면_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
             LocalDateTime now = LocalDateTime.now();
             RecruitmentRound recruitmentRound = RecruitmentRound.create(
                     RECRUITMENT_ROUND_NAME, Period.of(now.minusDays(1), now.plusDays(1)), recruitment, ROUND_TYPE);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
@@ -5,9 +5,9 @@ import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
@@ -28,10 +28,7 @@ public class MemberValidatorTest {
                     Recruitment.createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
             LocalDateTime now = LocalDateTime.now();
             RecruitmentRound recruitmentRound = RecruitmentRound.create(
-                    RECRUITMENT_ROUND_NAME,
-                    Period.createPeriod(now.minusDays(1), now.plusDays(1)),
-                    recruitment,
-                    ROUND_TYPE);
+                    RECRUITMENT_ROUND_NAME, Period.of(now.minusDays(1), now.plusDays(1)), recruitment, ROUND_TYPE);
             List<RecruitmentRound> recruitmentRounds = List.of(recruitmentRound);
 
             // when & then

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
@@ -30,11 +30,7 @@ class MembershipTest {
             member.advanceToAssociate();
 
             Recruitment recruitment = Recruitment.createRecruitment(
-                    ACADEMIC_YEAR,
-                    SEMESTER_TYPE,
-                    FEE,
-                    FEE_NAME,
-                    Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
+                    ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE));
             RecruitmentRound recruitmentRound =
                     RecruitmentRound.create(RECRUITMENT_ROUND_NAME, START_TO_END_PERIOD, recruitment, ROUND_TYPE);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
@@ -7,10 +7,10 @@ import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
@@ -22,20 +22,20 @@ class MembershipTest {
         @Test
         void 성공한다() {
             // given
-            Member member = createGuestMember(OAUTH_ID);
+            Member member = createGuest(OAUTH_ID);
             member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
             member.completeUnivEmailVerification(UNIV_EMAIL);
             member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
             member.verifyBevy();
             member.advanceToAssociate();
 
-            Recruitment recruitment = Recruitment.createRecruitment(
+            Recruitment recruitment = Recruitment.create(
                     ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE));
             RecruitmentRound recruitmentRound =
                     RecruitmentRound.create(RECRUITMENT_ROUND_NAME, START_TO_END_PERIOD, recruitment, ROUND_TYPE);
 
             // when
-            Membership membership = Membership.createMembership(member, recruitmentRound);
+            Membership membership = Membership.create(member, recruitmentRound);
 
             // then
             assertThat(membership).isNotNull();

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
@@ -42,9 +42,8 @@ class MembershipValidatorTest {
             LocalDateTime startDate,
             LocalDateTime endDate) {
         Recruitment recruitment = Recruitment.createRecruitment(
-                academicYear, semesterType, fee, FEE_NAME, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
-        return RecruitmentRound.create(
-                RECRUITMENT_ROUND_NAME, Period.createPeriod(startDate, endDate), recruitment, ROUND_TYPE);
+                academicYear, semesterType, fee, FEE_NAME, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE));
+        return RecruitmentRound.create(RECRUITMENT_ROUND_NAME, Period.of(startDate, endDate), recruitment, ROUND_TYPE);
     }
 
     @Nested

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
@@ -25,7 +25,7 @@ class MembershipValidatorTest {
     MembershipValidator membershipValidator = new MembershipValidator();
 
     private Member createAssociateMember(Long id) {
-        Member member = createGuestMember(OAUTH_ID);
+        Member member = createGuest(OAUTH_ID);
         member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
         member.completeUnivEmailVerification(UNIV_EMAIL);
         member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
@@ -41,7 +41,7 @@ class MembershipValidatorTest {
             Money fee,
             LocalDateTime startDate,
             LocalDateTime endDate) {
-        Recruitment recruitment = Recruitment.createRecruitment(
+        Recruitment recruitment = Recruitment.create(
                 academicYear, semesterType, fee, FEE_NAME, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE));
         return RecruitmentRound.create(RECRUITMENT_ROUND_NAME, Period.of(startDate, endDate), recruitment, ROUND_TYPE);
     }
@@ -52,7 +52,7 @@ class MembershipValidatorTest {
         @Test
         void 역할이_GUEST라면_멤버십_가입신청에_실패한다() {
             // given
-            Member member = createGuestMember(OAUTH_ID);
+            Member member = createGuest(OAUTH_ID);
 
             RecruitmentRound recruitmentRound =
                     createRecruitmentRound(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, START_DATE, END_DATE);
@@ -85,7 +85,7 @@ class MembershipValidatorTest {
             RecruitmentRound recruitmentRound =
                     createRecruitmentRound(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, START_DATE, END_DATE);
 
-            Membership membership = Membership.createMembership(member, recruitmentRound);
+            Membership membership = Membership.create(member, recruitmentRound);
 
             // when & then
             assertThatThrownBy(() -> membershipValidator.validateMembershipSubmit(member, recruitmentRound, true))

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
@@ -10,10 +10,10 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/MoneyInfoTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/MoneyInfoTest.java
@@ -17,7 +17,7 @@ class MoneyInfoTest {
         Money finalPaymentAmount = Money.from(7000L);
 
         // when
-        MoneyInfo moneyInfo = MoneyInfo.create(totalAmount, discountAmount, finalPaymentAmount);
+        MoneyInfo moneyInfo = MoneyInfo.of(totalAmount, discountAmount, finalPaymentAmount);
 
         // then
         Money expectedFinalPaymentAmount = totalAmount.subtract(discountAmount);
@@ -32,7 +32,7 @@ class MoneyInfoTest {
         Money finalPaymentAmount = Money.from(8000L);
 
         // when & then
-        assertThatThrownBy(() -> MoneyInfo.create(totalAmount, discountAmount, finalPaymentAmount))
+        assertThatThrownBy(() -> MoneyInfo.of(totalAmount, discountAmount, finalPaymentAmount))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ORDER_FINAL_PAYMENT_AMOUNT_MISMATCH.getMessage());
     }
@@ -49,8 +49,8 @@ class MoneyInfoTest {
         Money finalPaymentAmount2 = Money.from(7000L);
 
         // when
-        MoneyInfo moneyInfo1 = MoneyInfo.create(totalAmount1, discountAmount1, finalPaymentAmount1);
-        MoneyInfo moneyInfo2 = MoneyInfo.create(totalAmount2, discountAmount2, finalPaymentAmount2);
+        MoneyInfo moneyInfo1 = MoneyInfo.of(totalAmount1, discountAmount1, finalPaymentAmount1);
+        MoneyInfo moneyInfo2 = MoneyInfo.of(totalAmount2, discountAmount2, finalPaymentAmount2);
 
         // then
         assertThat(moneyInfo1).isEqualTo(moneyInfo2);

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/MoneyInfoTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/MoneyInfoTest.java
@@ -17,7 +17,7 @@ class MoneyInfoTest {
         Money finalPaymentAmount = Money.from(7000L);
 
         // when
-        MoneyInfo moneyInfo = MoneyInfo.of(totalAmount, discountAmount, finalPaymentAmount);
+        MoneyInfo moneyInfo = MoneyInfo.create(totalAmount, discountAmount, finalPaymentAmount);
 
         // then
         Money expectedFinalPaymentAmount = totalAmount.subtract(discountAmount);
@@ -32,7 +32,7 @@ class MoneyInfoTest {
         Money finalPaymentAmount = Money.from(8000L);
 
         // when & then
-        assertThatThrownBy(() -> MoneyInfo.of(totalAmount, discountAmount, finalPaymentAmount))
+        assertThatThrownBy(() -> MoneyInfo.create(totalAmount, discountAmount, finalPaymentAmount))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ORDER_FINAL_PAYMENT_AMOUNT_MISMATCH.getMessage());
     }
@@ -49,8 +49,8 @@ class MoneyInfoTest {
         Money finalPaymentAmount2 = Money.from(7000L);
 
         // when
-        MoneyInfo moneyInfo1 = MoneyInfo.of(totalAmount1, discountAmount1, finalPaymentAmount1);
-        MoneyInfo moneyInfo2 = MoneyInfo.of(totalAmount2, discountAmount2, finalPaymentAmount2);
+        MoneyInfo moneyInfo1 = MoneyInfo.create(totalAmount1, discountAmount1, finalPaymentAmount1);
+        MoneyInfo moneyInfo2 = MoneyInfo.create(totalAmount2, discountAmount2, finalPaymentAmount2);
 
         // then
         assertThat(moneyInfo1).isEqualTo(moneyInfo2);

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderTest.java
@@ -55,7 +55,7 @@ class OrderTest {
                     SemesterType.FIRST,
                     MONEY_10000_WON);
             Membership membership = createMembership(currentMember, recruitmentRound);
-            MoneyInfo freeMoneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_20000_WON, Money.ZERO);
+            MoneyInfo freeMoneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_20000_WON, Money.ZERO);
 
             // when
             Order order = Order.createFree("testNanoId", membership, null, freeMoneyInfo);
@@ -75,7 +75,7 @@ class OrderTest {
                     SemesterType.FIRST,
                     MONEY_10000_WON);
             Membership membership = createMembership(currentMember, recruitmentRound);
-            MoneyInfo freeMoneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_15000_WON, MONEY_5000_WON);
+            MoneyInfo freeMoneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_15000_WON, MONEY_5000_WON);
 
             // when & then
             assertThatThrownBy(() -> Order.createFree("testNanoId", membership, null, freeMoneyInfo))
@@ -100,7 +100,7 @@ class OrderTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             Order order = Order.createPending(
-                    "testNanoId", membership, null, MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+                    "testNanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
 
             ZonedDateTime canceledAt = ZonedDateTime.now();
 
@@ -123,7 +123,7 @@ class OrderTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             Order order = Order.createPending(
-                    "testNanoId", membership, null, MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+                    "testNanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
             order.complete("testPaymentKey", ZonedDateTime.now());
             order.cancel(ZonedDateTime.now());
 
@@ -146,7 +146,7 @@ class OrderTest {
                     SemesterType.FIRST,
                     MONEY_10000_WON);
             Membership membership = createMembership(currentMember, recruitmentRound);
-            MoneyInfo freeMoneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_20000_WON, Money.ZERO);
+            MoneyInfo freeMoneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_20000_WON, Money.ZERO);
 
             Order order = Order.createFree("testNanoId", membership, null, freeMoneyInfo);
 
@@ -171,7 +171,7 @@ class OrderTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             Order order = Order.createPending(
-                    "testNanoId", membership, null, MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+                    "testNanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
             order.complete("testPaymentKey", ZonedDateTime.now());
 
             ZonedDateTime canceledAt = ZonedDateTime.now();

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderTest.java
@@ -55,7 +55,7 @@ class OrderTest {
                     SemesterType.FIRST,
                     MONEY_10000_WON);
             Membership membership = createMembership(currentMember, recruitmentRound);
-            MoneyInfo freeMoneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_20000_WON, Money.ZERO);
+            MoneyInfo freeMoneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_20000_WON, Money.ZERO);
 
             // when
             Order order = Order.createFree("testNanoId", membership, null, freeMoneyInfo);
@@ -75,7 +75,7 @@ class OrderTest {
                     SemesterType.FIRST,
                     MONEY_10000_WON);
             Membership membership = createMembership(currentMember, recruitmentRound);
-            MoneyInfo freeMoneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_15000_WON, MONEY_5000_WON);
+            MoneyInfo freeMoneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_15000_WON, MONEY_5000_WON);
 
             // when & then
             assertThatThrownBy(() -> Order.createFree("testNanoId", membership, null, freeMoneyInfo))
@@ -100,7 +100,7 @@ class OrderTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             Order order = Order.createPending(
-                    "testNanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+                    "testNanoId", membership, null, MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
 
             ZonedDateTime canceledAt = ZonedDateTime.now();
 
@@ -123,7 +123,7 @@ class OrderTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             Order order = Order.createPending(
-                    "testNanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+                    "testNanoId", membership, null, MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
             order.complete("testPaymentKey", ZonedDateTime.now());
             order.cancel(ZonedDateTime.now());
 
@@ -146,7 +146,7 @@ class OrderTest {
                     SemesterType.FIRST,
                     MONEY_10000_WON);
             Membership membership = createMembership(currentMember, recruitmentRound);
-            MoneyInfo freeMoneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_20000_WON, Money.ZERO);
+            MoneyInfo freeMoneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_20000_WON, Money.ZERO);
 
             Order order = Order.createFree("testNanoId", membership, null, freeMoneyInfo);
 
@@ -171,7 +171,7 @@ class OrderTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             Order order = Order.createPending(
-                    "testNanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+                    "testNanoId", membership, null, MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
             order.complete("testPaymentKey", ZonedDateTime.now());
 
             ZonedDateTime canceledAt = ZonedDateTime.now();

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
@@ -68,7 +68,7 @@ class OrderValidatorTest {
 
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
 
-            MoneyInfo moneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+            MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
 
             // when & then
             assertThatThrownBy(() -> orderValidator.validatePendingOrderCreate(
@@ -94,7 +94,7 @@ class OrderValidatorTest {
 
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
 
-            MoneyInfo moneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+            MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
 
             // when & then
             assertThatThrownBy(() -> orderValidator.validatePendingOrderCreate(
@@ -117,7 +117,7 @@ class OrderValidatorTest {
 
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
 
-            MoneyInfo moneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+            MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
 
             // when & then
             assertThatThrownBy(() -> orderValidator.validatePendingOrderCreate(
@@ -143,7 +143,7 @@ class OrderValidatorTest {
             Member anotherMember = createAssociateMember(2L);
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, anotherMember);
 
-            MoneyInfo moneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+            MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
 
             // when & then
             assertThatThrownBy(() -> orderValidator.validatePendingOrderCreate(
@@ -169,7 +169,7 @@ class OrderValidatorTest {
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
             issuedCoupon.revoke();
 
-            MoneyInfo moneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+            MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
 
             // when & then
             assertThatThrownBy(() -> orderValidator.validatePendingOrderCreate(
@@ -195,7 +195,7 @@ class OrderValidatorTest {
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
             issuedCoupon.use();
 
-            MoneyInfo moneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+            MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
 
             // when & then
             assertThatThrownBy(() -> orderValidator.validatePendingOrderCreate(
@@ -220,7 +220,7 @@ class OrderValidatorTest {
 
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
 
-            MoneyInfo moneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+            MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
 
             // when & then
             assertThatThrownBy(() -> orderValidator.validatePendingOrderCreate(
@@ -243,7 +243,7 @@ class OrderValidatorTest {
 
             Membership membership = createMembership(currentMember, recruitmentRound);
 
-            MoneyInfo moneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+            MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
 
             // when & then
             assertThatThrownBy(
@@ -268,7 +268,7 @@ class OrderValidatorTest {
 
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
 
-            MoneyInfo moneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_10000_WON, MONEY_10000_WON);
+            MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_10000_WON, MONEY_10000_WON);
 
             // when & then
             assertThatThrownBy(() -> orderValidator.validatePendingOrderCreate(
@@ -294,7 +294,7 @@ class OrderValidatorTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             Order completedOrder = Order.createPending(
-                    "nanoId", membership, null, MoneyInfo.create(MONEY_20000_WON, Money.ZERO, MONEY_20000_WON));
+                    "nanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, Money.ZERO, MONEY_20000_WON));
             completedOrder.complete("paymentKey", ZonedDateTime.now());
 
             Optional<IssuedCoupon> emptyIssuedCoupon = Optional.empty();
@@ -322,10 +322,7 @@ class OrderValidatorTest {
             issuedCoupon.use(); // 쿠폰을 사용 불가능한 상태로 만듦
 
             Order order = Order.createPending(
-                    "nanoId",
-                    membership,
-                    issuedCoupon,
-                    MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+                    "nanoId", membership, issuedCoupon, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
 
             Optional<IssuedCoupon> optionalIssuedCoupon = Optional.of(issuedCoupon);
 
@@ -352,10 +349,7 @@ class OrderValidatorTest {
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, anotherMember);
 
             Order order = Order.createPending(
-                    "nanoId",
-                    membership,
-                    issuedCoupon,
-                    MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+                    "nanoId", membership, issuedCoupon, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
 
             Optional<IssuedCoupon> optionalIssuedCoupon = Optional.of(issuedCoupon);
 
@@ -380,7 +374,7 @@ class OrderValidatorTest {
             Membership membership = createMembership(anotherMember, recruitmentRound);
 
             Order order = Order.createPending(
-                    "nanoId", membership, null, MoneyInfo.create(MONEY_20000_WON, Money.ZERO, MONEY_20000_WON));
+                    "nanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, Money.ZERO, MONEY_20000_WON));
 
             Optional<IssuedCoupon> emptyIssuedCoupon = Optional.empty();
 
@@ -404,7 +398,7 @@ class OrderValidatorTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             Order order = Order.createPending(
-                    "nanoId", membership, null, MoneyInfo.create(MONEY_20000_WON, Money.ZERO, MONEY_20000_WON));
+                    "nanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, Money.ZERO, MONEY_20000_WON));
 
             Optional<IssuedCoupon> emptyIssuedCoupon = Optional.empty();
 
@@ -429,10 +423,7 @@ class OrderValidatorTest {
 
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
             Order order = Order.createPending(
-                    "nanoId",
-                    membership,
-                    issuedCoupon,
-                    MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+                    "nanoId", membership, issuedCoupon, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
 
             Optional<IssuedCoupon> optionalIssuedCoupon = Optional.of(issuedCoupon);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
@@ -68,7 +68,7 @@ class OrderValidatorTest {
 
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
 
-            MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+            MoneyInfo moneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
 
             // when & then
             assertThatThrownBy(() -> orderValidator.validatePendingOrderCreate(
@@ -94,7 +94,7 @@ class OrderValidatorTest {
 
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
 
-            MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+            MoneyInfo moneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
 
             // when & then
             assertThatThrownBy(() -> orderValidator.validatePendingOrderCreate(
@@ -117,7 +117,7 @@ class OrderValidatorTest {
 
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
 
-            MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+            MoneyInfo moneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
 
             // when & then
             assertThatThrownBy(() -> orderValidator.validatePendingOrderCreate(
@@ -143,7 +143,7 @@ class OrderValidatorTest {
             Member anotherMember = createAssociateMember(2L);
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, anotherMember);
 
-            MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+            MoneyInfo moneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
 
             // when & then
             assertThatThrownBy(() -> orderValidator.validatePendingOrderCreate(
@@ -169,7 +169,7 @@ class OrderValidatorTest {
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
             issuedCoupon.revoke();
 
-            MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+            MoneyInfo moneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
 
             // when & then
             assertThatThrownBy(() -> orderValidator.validatePendingOrderCreate(
@@ -195,7 +195,7 @@ class OrderValidatorTest {
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
             issuedCoupon.use();
 
-            MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+            MoneyInfo moneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
 
             // when & then
             assertThatThrownBy(() -> orderValidator.validatePendingOrderCreate(
@@ -220,7 +220,7 @@ class OrderValidatorTest {
 
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
 
-            MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+            MoneyInfo moneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
 
             // when & then
             assertThatThrownBy(() -> orderValidator.validatePendingOrderCreate(
@@ -243,7 +243,7 @@ class OrderValidatorTest {
 
             Membership membership = createMembership(currentMember, recruitmentRound);
 
-            MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
+            MoneyInfo moneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
 
             // when & then
             assertThatThrownBy(
@@ -268,7 +268,7 @@ class OrderValidatorTest {
 
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
 
-            MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_10000_WON, MONEY_10000_WON);
+            MoneyInfo moneyInfo = MoneyInfo.create(MONEY_20000_WON, MONEY_10000_WON, MONEY_10000_WON);
 
             // when & then
             assertThatThrownBy(() -> orderValidator.validatePendingOrderCreate(
@@ -294,7 +294,7 @@ class OrderValidatorTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             Order completedOrder = Order.createPending(
-                    "nanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, Money.ZERO, MONEY_20000_WON));
+                    "nanoId", membership, null, MoneyInfo.create(MONEY_20000_WON, Money.ZERO, MONEY_20000_WON));
             completedOrder.complete("paymentKey", ZonedDateTime.now());
 
             Optional<IssuedCoupon> emptyIssuedCoupon = Optional.empty();
@@ -322,7 +322,10 @@ class OrderValidatorTest {
             issuedCoupon.use(); // 쿠폰을 사용 불가능한 상태로 만듦
 
             Order order = Order.createPending(
-                    "nanoId", membership, issuedCoupon, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+                    "nanoId",
+                    membership,
+                    issuedCoupon,
+                    MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
 
             Optional<IssuedCoupon> optionalIssuedCoupon = Optional.of(issuedCoupon);
 
@@ -349,7 +352,10 @@ class OrderValidatorTest {
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, anotherMember);
 
             Order order = Order.createPending(
-                    "nanoId", membership, issuedCoupon, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+                    "nanoId",
+                    membership,
+                    issuedCoupon,
+                    MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
 
             Optional<IssuedCoupon> optionalIssuedCoupon = Optional.of(issuedCoupon);
 
@@ -374,7 +380,7 @@ class OrderValidatorTest {
             Membership membership = createMembership(anotherMember, recruitmentRound);
 
             Order order = Order.createPending(
-                    "nanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, Money.ZERO, MONEY_20000_WON));
+                    "nanoId", membership, null, MoneyInfo.create(MONEY_20000_WON, Money.ZERO, MONEY_20000_WON));
 
             Optional<IssuedCoupon> emptyIssuedCoupon = Optional.empty();
 
@@ -398,7 +404,7 @@ class OrderValidatorTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             Order order = Order.createPending(
-                    "nanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, Money.ZERO, MONEY_20000_WON));
+                    "nanoId", membership, null, MoneyInfo.create(MONEY_20000_WON, Money.ZERO, MONEY_20000_WON));
 
             Optional<IssuedCoupon> emptyIssuedCoupon = Optional.empty();
 
@@ -423,7 +429,10 @@ class OrderValidatorTest {
 
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
             Order order = Order.createPending(
-                    "nanoId", membership, issuedCoupon, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+                    "nanoId",
+                    membership,
+                    issuedCoupon,
+                    MoneyInfo.create(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
 
             Optional<IssuedCoupon> optionalIssuedCoupon = Optional.of(issuedCoupon);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -71,14 +71,11 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
             // given
             LocalDateTime now = LocalDateTime.now().withNano(0);
             Recruitment recruitment = Recruitment.createRecruitment(
-                    ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, Period.createPeriod(now, now.plusMonths(3)));
+                    ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, Period.of(now, now.plusMonths(3)));
             recruitmentRepository.save(recruitment);
 
             RecruitmentRound recruitmentRound = RecruitmentRound.create(
-                    RECRUITMENT_ROUND_NAME,
-                    Period.createPeriod(now.plusDays(1), now.plusDays(2)),
-                    recruitment,
-                    ROUND_TYPE);
+                    RECRUITMENT_ROUND_NAME, Period.of(now.plusDays(1), now.plusDays(2)), recruitment, ROUND_TYPE);
             recruitmentRoundRepository.save(recruitmentRound);
 
             RecruitmentRoundUpdateRequest request = new RecruitmentRoundUpdateRequest(

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -5,11 +5,11 @@ import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentCreateRequest;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentRoundCreateRequest;
 import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentRoundUpdateRequest;

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -70,8 +70,8 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         void 성공한다() {
             // given
             LocalDateTime now = LocalDateTime.now().withNano(0);
-            Recruitment recruitment = Recruitment.createRecruitment(
-                    ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, Period.of(now, now.plusMonths(3)));
+            Recruitment recruitment =
+                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, Period.of(now, now.plusMonths(3)));
             recruitmentRepository.save(recruitment);
 
             RecruitmentRound recruitmentRound = RecruitmentRound.create(

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/PeriodTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/PeriodTest.java
@@ -5,7 +5,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.DATE_PRECEDENCE_INV
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/PeriodTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/PeriodTest.java
@@ -17,7 +17,7 @@ public class PeriodTest {
         @Test
         void 시작일이_종료일보다_앞서면_성공한다() {
             // when
-            Period period = Period.createPeriod(START_DATE, END_DATE);
+            Period period = Period.of(START_DATE, END_DATE);
 
             // then
             assertThat(period.getStartDate()).isEqualTo(START_DATE);
@@ -28,7 +28,7 @@ public class PeriodTest {
         void 종료일이_시작일보다_앞서면_실패한다() {
             // when & then
             assertThatThrownBy(() -> {
-                        Period.createPeriod(END_DATE, START_DATE);
+                        Period.of(END_DATE, START_DATE);
                     })
                     .isInstanceOf(CustomException.class)
                     .hasMessage(DATE_PRECEDENCE_INVALID.getMessage());
@@ -38,7 +38,7 @@ public class PeriodTest {
         void 종료일이_시작일과_같으면_실패한다() {
             // when & then
             assertThatThrownBy(() -> {
-                        Period.createPeriod(START_DATE, WRONG_END_DATE);
+                        Period.of(START_DATE, WRONG_END_DATE);
                     })
                     .isInstanceOf(CustomException.class)
                     .hasMessage(DATE_PRECEDENCE_INVALID.getMessage());

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
@@ -29,7 +29,7 @@ public class RecruitmentRoundValidatorTest {
                     SEMESTER_TYPE,
                     FEE,
                     FEE_NAME,
-                    Period.createPeriod(LocalDateTime.of(2025, 3, 2, 0, 0), LocalDateTime.of(2025, 8, 31, 0, 0)));
+                    Period.of(LocalDateTime.of(2025, 3, 2, 0, 0), LocalDateTime.of(2025, 8, 31, 0, 0)));
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundCreate(
@@ -46,7 +46,7 @@ public class RecruitmentRoundValidatorTest {
                     SemesterType.SECOND,
                     FEE,
                     FEE_NAME,
-                    Period.createPeriod(LocalDateTime.of(2024, 9, 1, 0, 0), LocalDateTime.of(2025, 2, 28, 0, 0)));
+                    Period.of(LocalDateTime.of(2024, 9, 1, 0, 0), LocalDateTime.of(2025, 2, 28, 0, 0)));
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundCreate(

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
@@ -24,7 +24,7 @@ public class RecruitmentRoundValidatorTest {
         @Test
         void 모집_시작일과_종료일의_연도가_입력된_학년도와_다르다면_실패한다() {
             // given
-            Recruitment recruitment = Recruitment.createRecruitment(
+            Recruitment recruitment = Recruitment.create(
                     2025,
                     SEMESTER_TYPE,
                     FEE,
@@ -41,7 +41,7 @@ public class RecruitmentRoundValidatorTest {
         @Test
         void 학기_시작일과_종료일의_학기가_입력된_학기와_다르다면_실패한다() {
             // given
-            Recruitment recruitment = Recruitment.createRecruitment(
+            Recruitment recruitment = Recruitment.create(
                     ACADEMIC_YEAR,
                     SemesterType.SECOND,
                     FEE,
@@ -59,7 +59,7 @@ public class RecruitmentRoundValidatorTest {
         void 모집_시작일과_종료일이_학기_시작일로부터_2주_이내에_있지_않다면_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundCreate(
@@ -72,7 +72,7 @@ public class RecruitmentRoundValidatorTest {
         void 학년도_학기_차수가_모두_중복되면_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
 
             RecruitmentRound recruitmentRound =
                     RecruitmentRound.create(RECRUITMENT_ROUND_NAME, START_TO_END_PERIOD, recruitment, ROUND_TYPE);
@@ -92,7 +92,7 @@ public class RecruitmentRoundValidatorTest {
         void RoundType_1차가_없을때_2차를_생성하려_하면_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundCreate(
@@ -105,7 +105,7 @@ public class RecruitmentRoundValidatorTest {
         void 기간이_중복되는_모집회차가_있다면_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
 
             RecruitmentRound recruitmentRound =
                     RecruitmentRound.create(RECRUITMENT_ROUND_NAME, START_TO_END_PERIOD, recruitment, ROUND_TYPE);
@@ -125,7 +125,7 @@ public class RecruitmentRoundValidatorTest {
         void 기간이_중복되는_모집회차가_있다면_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
 
             RecruitmentRound firstRound =
                     RecruitmentRound.create(RECRUITMENT_ROUND_NAME, START_TO_END_PERIOD, recruitment, ROUND_TYPE);
@@ -146,7 +146,7 @@ public class RecruitmentRoundValidatorTest {
         void 차수가_중복되는_모집회차가_있다면_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
 
             RecruitmentRound firstRound =
                     RecruitmentRound.create(RECRUITMENT_ROUND_NAME, START_TO_END_PERIOD, recruitment, ROUND_TYPE);
@@ -167,7 +167,7 @@ public class RecruitmentRoundValidatorTest {
         void 모집_시작일과_종료일이_학기_시작일로부터_2주_이내에_있지_않다면_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
 
             RecruitmentRound firstRound =
                     RecruitmentRound.create(RECRUITMENT_ROUND_NAME, START_TO_END_PERIOD, recruitment, ROUND_TYPE);
@@ -184,7 +184,7 @@ public class RecruitmentRoundValidatorTest {
         void RoundType_1차를_2차로_수정하려_하면_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
 
             RecruitmentRound firstRound =
                     RecruitmentRound.create(RECRUITMENT_ROUND_NAME, START_TO_END_PERIOD, recruitment, ROUND_TYPE);
@@ -201,7 +201,7 @@ public class RecruitmentRoundValidatorTest {
         void 모집_시작일이_지났다면_수정_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
 
             RecruitmentRound recruitmentRound =
                     RecruitmentRound.create(RECRUITMENT_ROUND_NAME, START_TO_END_PERIOD, recruitment, ROUND_TYPE);

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
@@ -6,7 +6,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
@@ -15,15 +15,11 @@ class RecruitmentTest {
         @Test
         void Period가_제대로_생성된다() {
             // given
-            Period period = Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE);
+            Period period = Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE);
 
             // when
             Recruitment recruitment = Recruitment.createRecruitment(
-                    ACADEMIC_YEAR,
-                    SEMESTER_TYPE,
-                    FEE,
-                    FEE_NAME,
-                    Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
+                    ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE));
 
             // then
             assertThat(recruitment.getSemesterPeriod().getStartDate()).isEqualTo(SEMESTER_START_DATE);

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
@@ -4,7 +4,7 @@ import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
 import static org.assertj.core.api.Assertions.*;
 
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
@@ -18,7 +18,7 @@ class RecruitmentTest {
             Period period = Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE);
 
             // when
-            Recruitment recruitment = Recruitment.createRecruitment(
+            Recruitment recruitment = Recruitment.create(
                     ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE));
 
             // then

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyAchievementServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyAchievementServiceTest.java
@@ -28,10 +28,8 @@ public class MentorStudyAchievementServiceTest extends IntegrationTest {
             // given
             LocalDateTime now = LocalDateTime.now();
             Member mentor = createMentor();
-            Study study = createStudy(
-                    mentor,
-                    Period.createPeriod(now.plusDays(5), now.plusDays(10)),
-                    Period.createPeriod(now.minusDays(5), now));
+            Study study =
+                    createStudy(mentor, Period.of(now.plusDays(5), now.plusDays(10)), Period.of(now.minusDays(5), now));
 
             Member student = createRegularMember();
             createStudyHistory(student, study);
@@ -59,10 +57,8 @@ public class MentorStudyAchievementServiceTest extends IntegrationTest {
             Member student = createRegularMember();
             LocalDateTime now = LocalDateTime.now();
             Member mentor = createMentor();
-            Study study = createStudy(
-                    mentor,
-                    Period.createPeriod(now.plusDays(5), now.plusDays(10)),
-                    Period.createPeriod(now.minusDays(5), now));
+            Study study =
+                    createStudy(mentor, Period.of(now.plusDays(5), now.plusDays(10)), Period.of(now.minusDays(5), now));
             createStudyHistory(student, study);
             createStudyAchievement(student, study, FIRST_ROUND_OUTSTANDING_STUDENT);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyAchievementServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyAchievementServiceTest.java
@@ -3,8 +3,8 @@ package com.gdschongik.gdsc.domain.study.application;
 import static com.gdschongik.gdsc.domain.study.domain.AchievementType.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyAchievement;
 import com.gdschongik.gdsc.domain.study.dto.request.OutstandingStudentRequest;

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailServiceTest.java
@@ -31,10 +31,8 @@ public class MentorStudyDetailServiceTest extends IntegrationTest {
             // given
             LocalDateTime now = LocalDateTime.now();
             Member mentor = createAssociateMember();
-            Study study = createStudy(
-                    mentor,
-                    Period.createPeriod(now.plusDays(5), now.plusDays(10)),
-                    Period.createPeriod(now.minusDays(5), now));
+            Study study =
+                    createStudy(mentor, Period.of(now.plusDays(5), now.plusDays(10)), Period.of(now.minusDays(5), now));
             StudyDetail studyDetail = createStudyDetail(study, now, now.plusDays(7));
             logoutAndReloginAs(studyDetail.getStudy().getMentor().getId(), MemberRole.ASSOCIATE);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailServiceTest.java
@@ -2,9 +2,9 @@ package com.gdschongik.gdsc.domain.study.application;
 
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.domain.study.dao.StudyDetailRepository;
 import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyDetail;

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyServiceTest.java
@@ -32,10 +32,7 @@ public class MentorStudyServiceTest extends IntegrationTest {
             LocalDateTime now = STUDY_START_DATETIME;
             Member mentor = createMentor();
             Study study = createNewStudy(
-                    mentor,
-                    4L,
-                    Period.createPeriod(now.plusDays(5), now.plusDays(10)),
-                    Period.createPeriod(now.minusDays(5), now));
+                    mentor, 4L, Period.of(now.plusDays(5), now.plusDays(10)), Period.of(now.minusDays(5), now));
             for (int i = 1; i <= 4; i++) {
                 Long week = (long) i;
                 createNewStudyDetail(week, study, now, now.plusDays(7));

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyServiceTest.java
@@ -3,9 +3,9 @@ package com.gdschongik.gdsc.domain.study.application;
 import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.domain.study.domain.Difficulty;
 import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyDetail;

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryServiceTest.java
@@ -4,9 +4,9 @@ import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.domain.study.dao.AssignmentHistoryRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryServiceTest.java
@@ -52,8 +52,8 @@ class StudentStudyHistoryServiceTest extends IntegrationTest {
             LocalDateTime now = LocalDateTime.now(); // 통합 테스트에서는 LocalDateTime.now()를 사용해야 함
             Study study = createStudy(
                     mentor,
-                    Period.createPeriod(now.minusWeeks(1), now.plusWeeks(7)), // 스터디 기간: 1주 전 ~ 7주 후
-                    Period.createPeriod(now.minusWeeks(2), now.minusWeeks(1))); // 수강신청 기간: 2주 전 ~ 1주 전
+                    Period.of(now.minusWeeks(1), now.plusWeeks(7)), // 스터디 기간: 1주 전 ~ 7주 후
+                    Period.of(now.minusWeeks(2), now.minusWeeks(1))); // 수강신청 기간: 2주 전 ~ 1주 전
             StudyDetail studyDetail =
                     createStudyDetail(study, now.minusDays(6), now.plusDays(1)); // 1주차 기간: 6일 전 ~ 1일 후
             publishAssignment(studyDetail);

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGraderTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGraderTest.java
@@ -4,7 +4,7 @@ import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.helper.FixtureHelper;

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGraderTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryGraderTest.java
@@ -28,8 +28,7 @@ class AssignmentHistoryGraderTest {
     }
 
     private Study createStudyWithMentor(Long mentorId) {
-        Period applicationPeriod =
-                Period.createPeriod(STUDY_START_DATETIME.minusDays(7), STUDY_START_DATETIME.minusDays(1));
+        Period applicationPeriod = Period.of(STUDY_START_DATETIME.minusDays(7), STUDY_START_DATETIME.minusDays(1));
         return fixtureHelper.createStudyWithMentor(mentorId, STUDY_ONGOING_PERIOD, applicationPeriod);
     }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryTest.java
@@ -20,8 +20,7 @@ class AssignmentHistoryTest {
     }
 
     private Study createStudyWithMentor(Long mentorId) {
-        Period applicationPeriod =
-                Period.createPeriod(STUDY_START_DATETIME.minusDays(7), STUDY_START_DATETIME.minusDays(1));
+        Period applicationPeriod = Period.of(STUDY_START_DATETIME.minusDays(7), STUDY_START_DATETIME.minusDays(1));
         return fixtureHelper.createStudyWithMentor(mentorId, STUDY_ONGOING_PERIOD, applicationPeriod);
     }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryTest.java
@@ -4,8 +4,8 @@ import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.FixtureHelper;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/AttendanceValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/AttendanceValidatorTest.java
@@ -27,8 +27,8 @@ public class AttendanceValidatorTest {
             Member student = fixtureHelper.createRegularMember(1L);
 
             LocalDateTime now = LocalDateTime.now();
-            Period period = Period.createPeriod(now.plusDays(10), now.plusDays(65));
-            Period applicationPeriod = Period.createPeriod(now.minusDays(10), now.plusDays(5));
+            Period period = Period.of(now.plusDays(10), now.plusDays(65));
+            Period applicationPeriod = Period.of(now.minusDays(10), now.plusDays(5));
             Study study = fixtureHelper.createStudy(student, period, applicationPeriod);
             StudyDetail studyDetail = fixtureHelper.createStudyDetail(study, now, now.plusDays(7));
 
@@ -47,8 +47,8 @@ public class AttendanceValidatorTest {
             Member student = fixtureHelper.createRegularMember(1L);
 
             LocalDateTime now = LocalDateTime.now();
-            Period period = Period.createPeriod(now.plusDays(10), now.plusDays(65));
-            Period applicationPeriod = Period.createPeriod(now.minusDays(10), now.plusDays(5));
+            Period period = Period.of(now.plusDays(10), now.plusDays(65));
+            Period applicationPeriod = Period.of(now.minusDays(10), now.plusDays(5));
             Study study = fixtureHelper.createStudy(student, period, applicationPeriod);
             StudyDetail studyDetail = fixtureHelper.createStudyDetail(study, now, now.plusDays(7));
 
@@ -67,8 +67,8 @@ public class AttendanceValidatorTest {
             Member student = fixtureHelper.createRegularMember(1L);
 
             LocalDateTime now = LocalDateTime.now();
-            Period period = Period.createPeriod(now.plusDays(10), now.plusDays(65));
-            Period applicationPeriod = Period.createPeriod(now.minusDays(10), now.plusDays(5));
+            Period period = Period.of(now.plusDays(10), now.plusDays(65));
+            Period applicationPeriod = Period.of(now.minusDays(10), now.plusDays(5));
             Study study = fixtureHelper.createStudy(student, period, applicationPeriod);
             StudyDetail studyDetail = fixtureHelper.createStudyDetail(study, now, now.plusDays(7));
 
@@ -87,8 +87,8 @@ public class AttendanceValidatorTest {
             Member student = fixtureHelper.createRegularMember(1L);
 
             LocalDateTime now = LocalDateTime.now();
-            Period period = Period.createPeriod(now.plusDays(10), now.plusDays(65));
-            Period applicationPeriod = Period.createPeriod(now.minusDays(10), now.plusDays(5));
+            Period period = Period.of(now.plusDays(10), now.plusDays(65));
+            Period applicationPeriod = Period.of(now.minusDays(10), now.plusDays(5));
             Study study = fixtureHelper.createStudy(student, period, applicationPeriod);
             StudyDetail studyDetail = fixtureHelper.createStudyDetail(study, now, now.plusDays(7));
 

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/AttendanceValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/AttendanceValidatorTest.java
@@ -4,8 +4,8 @@ import static com.gdschongik.gdsc.global.common.constant.StudyConstant.ATTENDANC
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.FixtureHelper;
 import java.time.LocalDate;

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
@@ -23,8 +23,7 @@ class StudyAssignmentHistoryValidatorTest {
     }
 
     private Study createStudyWithMentor(Long mentorId) {
-        Period applicationPeriod =
-                Period.createPeriod(STUDY_START_DATETIME.minusDays(7), STUDY_START_DATETIME.minusDays(1));
+        Period applicationPeriod = Period.of(STUDY_START_DATETIME.minusDays(7), STUDY_START_DATETIME.minusDays(1));
         return fixtureHelper.createStudyWithMentor(mentorId, STUDY_ONGOING_PERIOD, applicationPeriod);
     }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyAssignmentHistoryValidatorTest.java
@@ -4,8 +4,8 @@ import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.FixtureHelper;
 import java.time.LocalDateTime;

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailTest.java
@@ -3,8 +3,8 @@ package com.gdschongik.gdsc.domain.study.domain;
 import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.helper.FixtureHelper;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailTest.java
@@ -22,9 +22,7 @@ public class StudyDetailTest {
             Member mentor = fixtureHelper.createAssociateMember(1L);
             LocalDateTime now = LocalDateTime.now();
             Study study = fixtureHelper.createStudy(
-                    mentor,
-                    Period.createPeriod(now.plusDays(5), now.plusDays(10)),
-                    Period.createPeriod(now.minusDays(5), now));
+                    mentor, Period.of(now.plusDays(5), now.plusDays(10)), Period.of(now.minusDays(5), now));
             StudyDetail studyDetail = fixtureHelper.createStudyDetail(study, now, now.plusDays(7));
 
             // when
@@ -44,9 +42,7 @@ public class StudyDetailTest {
             Member mentor = fixtureHelper.createAssociateMember(1L);
             LocalDateTime now = LocalDateTime.now();
             Study study = fixtureHelper.createStudy(
-                    mentor,
-                    Period.createPeriod(now.plusDays(5), now.plusDays(10)),
-                    Period.createPeriod(now.minusDays(5), now));
+                    mentor, Period.of(now.plusDays(5), now.plusDays(10)), Period.of(now.minusDays(5), now));
             StudyDetail studyDetail = fixtureHelper.createStudyDetail(study, now, now.plusDays(7));
 
             // when

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailValidatorTest.java
@@ -4,8 +4,8 @@ import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.domain.study.dto.request.AssignmentCreateUpdateRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.FixtureHelper;

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailValidatorTest.java
@@ -30,9 +30,7 @@ public class StudyDetailValidatorTest {
             LocalDateTime now = LocalDateTime.now();
             Member mentor = fixtureHelper.createAssociateMember(1L);
             Study study = fixtureHelper.createStudy(
-                    mentor,
-                    Period.createPeriod(now.plusDays(5), now.plusDays(10)),
-                    Period.createPeriod(now.minusDays(5), now));
+                    mentor, Period.of(now.plusDays(5), now.plusDays(10)), Period.of(now.minusDays(5), now));
             StudyDetail studyDetail = fixtureHelper.createStudyDetail(study, now, now.plusDays(7));
             Member anotherMember = fixtureHelper.createAssociateMember(2L);
 
@@ -52,9 +50,7 @@ public class StudyDetailValidatorTest {
             LocalDateTime now = LocalDateTime.now();
             Member mentor = fixtureHelper.createAssociateMember(1L);
             Study study = fixtureHelper.createStudy(
-                    mentor,
-                    Period.createPeriod(now.plusDays(5), now.plusDays(10)),
-                    Period.createPeriod(now.minusDays(5), now));
+                    mentor, Period.of(now.plusDays(5), now.plusDays(10)), Period.of(now.minusDays(5), now));
             StudyDetail studyDetail = fixtureHelper.createStudyDetail(study, now, now.plusDays(7));
             Member anotherMember = fixtureHelper.createAssociateMember(2L);
             AssignmentCreateUpdateRequest request =
@@ -73,9 +69,7 @@ public class StudyDetailValidatorTest {
             Member mentor = fixtureHelper.createAssociateMember(1L);
             LocalDateTime now = LocalDateTime.now();
             Study study = fixtureHelper.createStudy(
-                    mentor,
-                    Period.createPeriod(now.plusDays(5), now.plusDays(10)),
-                    Period.createPeriod(now.minusDays(5), now));
+                    mentor, Period.of(now.plusDays(5), now.plusDays(10)), Period.of(now.minusDays(5), now));
             StudyDetail studyDetail = fixtureHelper.createStudyDetail(study, now, now.plusDays(7));
             AssignmentCreateUpdateRequest request =
                     new AssignmentCreateUpdateRequest(ASSIGNMENT_TITLE, DESCRIPTION_LINK, now.minusDays(2));
@@ -96,9 +90,7 @@ public class StudyDetailValidatorTest {
             LocalDateTime now = LocalDateTime.now();
             Member mentor = fixtureHelper.createAssociateMember(1L);
             Study study = fixtureHelper.createStudy(
-                    mentor,
-                    Period.createPeriod(now.plusDays(5), now.plusDays(10)),
-                    Period.createPeriod(now.minusDays(5), now));
+                    mentor, Period.of(now.plusDays(5), now.plusDays(10)), Period.of(now.minusDays(5), now));
 
             StudyDetail studyDetail = fixtureHelper.createStudyDetail(study, now, now.plusDays(10));
             Member anotherMember = fixtureHelper.createAssociateMember(2L);
@@ -121,8 +113,8 @@ public class StudyDetailValidatorTest {
             LocalDateTime assignmentCreatedDate = LocalDateTime.now().minusDays(1);
             Study study = fixtureHelper.createStudy(
                     mentor,
-                    Period.createPeriod(assignmentCreatedDate.plusDays(5), assignmentCreatedDate.plusDays(10)),
-                    Period.createPeriod(assignmentCreatedDate.minusDays(5), assignmentCreatedDate));
+                    Period.of(assignmentCreatedDate.plusDays(5), assignmentCreatedDate.plusDays(10)),
+                    Period.of(assignmentCreatedDate.minusDays(5), assignmentCreatedDate));
             StudyDetail studyDetail =
                     fixtureHelper.createStudyDetail(study, assignmentCreatedDate, assignmentCreatedDate.plusDays(1));
             studyDetail.publishAssignment(ASSIGNMENT_TITLE, assignmentCreatedDate.plusDays(1), DESCRIPTION_LINK);
@@ -143,9 +135,7 @@ public class StudyDetailValidatorTest {
             LocalDateTime now = LocalDateTime.now();
             Member mentor = fixtureHelper.createAssociateMember(1L);
             Study study = fixtureHelper.createStudy(
-                    mentor,
-                    Period.createPeriod(now.plusDays(5), now.plusDays(10)),
-                    Period.createPeriod(now.minusDays(5), now));
+                    mentor, Period.of(now.plusDays(5), now.plusDays(10)), Period.of(now.minusDays(5), now));
             StudyDetail studyDetail = fixtureHelper.createStudyDetail(study, now, now.plusDays(10));
             LocalDateTime savedDeadLine = now.minusDays(1);
             studyDetail.publishAssignment(ASSIGNMENT_TITLE, savedDeadLine, DESCRIPTION_LINK);

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryTest.java
@@ -3,8 +3,8 @@ package com.gdschongik.gdsc.domain.study.domain;
 import static com.gdschongik.gdsc.domain.study.domain.StudyHistoryStatus.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.helper.FixtureHelper;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryTest.java
@@ -24,9 +24,7 @@ public class StudyHistoryTest {
             Member mentor = fixtureHelper.createRegularMember(2L);
             LocalDateTime now = LocalDateTime.now();
             Study study = fixtureHelper.createStudy(
-                    mentor,
-                    Period.createPeriod(now.plusDays(5), now.plusDays(10)),
-                    Period.createPeriod(now.minusDays(5), now));
+                    mentor, Period.of(now.plusDays(5), now.plusDays(10)), Period.of(now.minusDays(5), now));
 
             // when
             StudyHistory studyHistory = StudyHistory.create(student, study);
@@ -46,9 +44,7 @@ public class StudyHistoryTest {
             Member mentor = fixtureHelper.createRegularMember(2L);
             LocalDateTime now = LocalDateTime.now();
             Study study = fixtureHelper.createStudy(
-                    mentor,
-                    Period.createPeriod(now.plusDays(5), now.plusDays(10)),
-                    Period.createPeriod(now.minusDays(5), now));
+                    mentor, Period.of(now.plusDays(5), now.plusDays(10)), Period.of(now.minusDays(5), now));
 
             StudyHistory studyHistory = StudyHistory.create(student, study);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidatorTest.java
@@ -4,8 +4,8 @@ import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.FixtureHelper;
 import java.time.LocalDateTime;

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidatorTest.java
@@ -27,8 +27,8 @@ public class StudyHistoryValidatorTest {
             Member mentor = fixtureHelper.createAssociateMember(1L);
 
             LocalDateTime now = LocalDateTime.now();
-            Period period = Period.createPeriod(now.plusDays(10), now.plusDays(15));
-            Period applicationPeriod = Period.createPeriod(now.minusDays(10), now.plusDays(5));
+            Period period = Period.of(now.plusDays(10), now.plusDays(15));
+            Period applicationPeriod = Period.of(now.minusDays(10), now.plusDays(5));
             Study study = fixtureHelper.createStudy(mentor, period, applicationPeriod);
 
             Member student = fixtureHelper.createGuestMember(2L);
@@ -46,8 +46,8 @@ public class StudyHistoryValidatorTest {
             Member mentor = fixtureHelper.createAssociateMember(1L);
 
             LocalDateTime now = LocalDateTime.now();
-            Period period = Period.createPeriod(now.plusDays(10), now.plusDays(15));
-            Period applicationPeriod = Period.createPeriod(now.minusDays(10), now.minusDays(5));
+            Period period = Period.of(now.plusDays(10), now.plusDays(15));
+            Period applicationPeriod = Period.of(now.minusDays(10), now.minusDays(5));
             Study study = fixtureHelper.createStudy(mentor, period, applicationPeriod);
 
             // when & then
@@ -62,8 +62,8 @@ public class StudyHistoryValidatorTest {
             Member mentor = fixtureHelper.createAssociateMember(1L);
 
             LocalDateTime now = LocalDateTime.now();
-            Period period = Period.createPeriod(now.minusDays(5), now.plusDays(15));
-            Period applicationPeriod = Period.createPeriod(now.minusDays(15), now.plusDays(5));
+            Period period = Period.of(now.minusDays(5), now.plusDays(15));
+            Period applicationPeriod = Period.of(now.minusDays(15), now.plusDays(5));
             Study study = fixtureHelper.createStudy(mentor, period, applicationPeriod);
 
             Study anotherStudy = fixtureHelper.createStudy(mentor, period, applicationPeriod);
@@ -87,8 +87,8 @@ public class StudyHistoryValidatorTest {
             Member mentor = fixtureHelper.createAssociateMember(1L);
 
             LocalDateTime now = LocalDateTime.now();
-            Period period = Period.createPeriod(now.plusDays(10), now.plusDays(15));
-            Period applicationPeriod = Period.createPeriod(now.minusDays(10), now.minusDays(5));
+            Period period = Period.of(now.plusDays(10), now.plusDays(15));
+            Period applicationPeriod = Period.of(now.minusDays(10), now.minusDays(5));
             Study study = fixtureHelper.createStudy(mentor, period, applicationPeriod);
 
             // when & then

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyTest.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.study.domain;
 
 import static com.gdschongik.gdsc.domain.member.domain.Department.D022;
-import static com.gdschongik.gdsc.domain.member.domain.Member.createGuestMember;
+import static com.gdschongik.gdsc.domain.member.domain.Member.createGuest;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
@@ -20,7 +20,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 public class StudyTest {
 
     private Member createAssociateMember(Long id) {
-        Member member = createGuestMember(OAUTH_ID);
+        Member member = createGuest(OAUTH_ID);
         member.updateBasicMemberInfo(STUDENT_ID, NAME, PHONE_NUMBER, D022, EMAIL);
         member.completeUnivEmailVerification(UNIV_EMAIL);
         member.verifyDiscord(DISCORD_USERNAME, NICKNAME);
@@ -36,11 +36,11 @@ public class StudyTest {
         @Test
         void 게스트인_회원을_멘토로_지정하면_실패한다() {
             // given
-            Member guestMember = Member.createGuestMember(OAUTH_ID);
+            Member guestMember = Member.createGuest(OAUTH_ID);
             Period applicationPeriod = Period.of(START_DATE.minusDays(10), START_DATE.minusDays(5));
 
             // when & then
-            assertThatThrownBy(() -> Study.createStudy(
+            assertThatThrownBy(() -> Study.create(
                             ACADEMIC_YEAR,
                             SEMESTER_TYPE,
                             STUDY_TITLE,
@@ -64,7 +64,7 @@ public class StudyTest {
             Period applicationPeriod = Period.of(START_DATE.plusDays(1), START_DATE.plusDays(2));
 
             // when & then
-            assertThatThrownBy(() -> Study.createStudy(
+            assertThatThrownBy(() -> Study.create(
                             ACADEMIC_YEAR,
                             SEMESTER_TYPE,
                             STUDY_TITLE,
@@ -88,7 +88,7 @@ public class StudyTest {
             Period applicationPeriod = Period.of(START_DATE.minusDays(5), START_DATE.plusDays(3));
 
             // when & then
-            assertThatThrownBy(() -> Study.createStudy(
+            assertThatThrownBy(() -> Study.create(
                             ACADEMIC_YEAR,
                             SEMESTER_TYPE,
                             STUDY_TITLE,
@@ -114,7 +114,7 @@ public class StudyTest {
             LocalTime studyEndTime = STUDY_START_TIME.minusHours(2);
 
             // when & then
-            assertThatThrownBy(() -> Study.createStudy(
+            assertThatThrownBy(() -> Study.create(
                             ACADEMIC_YEAR,
                             SEMESTER_TYPE,
                             STUDY_TITLE,
@@ -140,7 +140,7 @@ public class StudyTest {
             LocalTime studyEndTime = STUDY_END_TIME;
 
             // when & then
-            assertThatThrownBy(() -> Study.createStudy(
+            assertThatThrownBy(() -> Study.create(
                             ACADEMIC_YEAR,
                             SEMESTER_TYPE,
                             STUDY_TITLE,

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyTest.java
@@ -9,8 +9,8 @@ import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import java.time.LocalTime;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyTest.java
@@ -37,7 +37,7 @@ public class StudyTest {
         void 게스트인_회원을_멘토로_지정하면_실패한다() {
             // given
             Member guestMember = Member.createGuestMember(OAUTH_ID);
-            Period applicationPeriod = Period.createPeriod(START_DATE.minusDays(10), START_DATE.minusDays(5));
+            Period applicationPeriod = Period.of(START_DATE.minusDays(10), START_DATE.minusDays(5));
 
             // when & then
             assertThatThrownBy(() -> Study.createStudy(
@@ -60,8 +60,8 @@ public class StudyTest {
         void 신청기간_시작일이_스터디_시작일보다_늦으면_실패한다() {
             // given
             Member member = createAssociateMember(1L);
-            Period period = Period.createPeriod(START_DATE, END_DATE);
-            Period applicationPeriod = Period.createPeriod(START_DATE.plusDays(1), START_DATE.plusDays(2));
+            Period period = Period.of(START_DATE, END_DATE);
+            Period applicationPeriod = Period.of(START_DATE.plusDays(1), START_DATE.plusDays(2));
 
             // when & then
             assertThatThrownBy(() -> Study.createStudy(
@@ -84,8 +84,8 @@ public class StudyTest {
         void 온오프라인_스터디에_스터디_시각이_없으면_실패한다() {
             // given
             Member member = createAssociateMember(1L);
-            Period period = Period.createPeriod(START_DATE, END_DATE);
-            Period applicationPeriod = Period.createPeriod(START_DATE.minusDays(5), START_DATE.plusDays(3));
+            Period period = Period.of(START_DATE, END_DATE);
+            Period applicationPeriod = Period.of(START_DATE.minusDays(5), START_DATE.plusDays(3));
 
             // when & then
             assertThatThrownBy(() -> Study.createStudy(
@@ -108,8 +108,8 @@ public class StudyTest {
         void 온오프라인_스터디에_스터디_시작시각이_종료시각보다_늦으면_실패한다() {
             // given
             Member member = createAssociateMember(1L);
-            Period period = Period.createPeriod(START_DATE, END_DATE);
-            Period applicationPeriod = Period.createPeriod(START_DATE.minusDays(5), START_DATE.plusDays(3));
+            Period period = Period.of(START_DATE, END_DATE);
+            Period applicationPeriod = Period.of(START_DATE.minusDays(5), START_DATE.plusDays(3));
             LocalTime studyStartTime = STUDY_START_TIME;
             LocalTime studyEndTime = STUDY_START_TIME.minusHours(2);
 
@@ -134,8 +134,8 @@ public class StudyTest {
         void 과제_스터디에_스터디_시각이_있으면_실패한다() {
             // given
             Member member = createAssociateMember(1L);
-            Period period = Period.createPeriod(START_DATE, END_DATE);
-            Period applicationPeriod = Period.createPeriod(START_DATE.minusDays(5), START_DATE.plusDays(3));
+            Period period = Period.of(START_DATE, END_DATE);
+            Period applicationPeriod = Period.of(START_DATE.minusDays(5), START_DATE.plusDays(3));
             LocalTime studyStartTime = STUDY_START_TIME;
             LocalTime studyEndTime = STUDY_END_TIME;
 

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyValidatorTest.java
@@ -40,8 +40,8 @@ public class StudyValidatorTest {
             LocalDateTime assignmentCreatedDate = LocalDateTime.now().minusDays(1);
             Study study = fixtureHelper.createStudy(
                     mentor,
-                    Period.createPeriod(assignmentCreatedDate.plusDays(5), assignmentCreatedDate.plusDays(10)),
-                    Period.createPeriod(assignmentCreatedDate.minusDays(5), assignmentCreatedDate));
+                    Period.of(assignmentCreatedDate.plusDays(5), assignmentCreatedDate.plusDays(10)),
+                    Period.of(assignmentCreatedDate.minusDays(5), assignmentCreatedDate));
 
             // when & then
             assertThatThrownBy(() -> studyValidator.validateStudyMentor(currentMember, study))
@@ -57,13 +57,13 @@ public class StudyValidatorTest {
             LocalDateTime assignmentCreatedDate = LocalDateTime.now().minusDays(1);
             Study study = fixtureHelper.createStudy(
                     mentor,
-                    Period.createPeriod(assignmentCreatedDate.plusDays(5), assignmentCreatedDate.plusDays(10)),
-                    Period.createPeriod(assignmentCreatedDate.minusDays(5), assignmentCreatedDate));
+                    Period.of(assignmentCreatedDate.plusDays(5), assignmentCreatedDate.plusDays(10)),
+                    Period.of(assignmentCreatedDate.minusDays(5), assignmentCreatedDate));
 
             Study currentMentorStudy = fixtureHelper.createStudy(
                     currentMember,
-                    Period.createPeriod(assignmentCreatedDate.plusDays(5), assignmentCreatedDate.plusDays(10)),
-                    Period.createPeriod(assignmentCreatedDate.minusDays(5), assignmentCreatedDate));
+                    Period.of(assignmentCreatedDate.plusDays(5), assignmentCreatedDate.plusDays(10)),
+                    Period.of(assignmentCreatedDate.minusDays(5), assignmentCreatedDate));
 
             // when & then
             assertThat(currentMentorStudy.getMentor().getId()).isEqualTo(currentMember.getId());
@@ -80,8 +80,8 @@ public class StudyValidatorTest {
             LocalDateTime assignmentCreatedDate = LocalDateTime.now().minusDays(1);
             Study study = fixtureHelper.createStudy(
                     mentor,
-                    Period.createPeriod(assignmentCreatedDate.plusDays(5), assignmentCreatedDate.plusDays(10)),
-                    Period.createPeriod(assignmentCreatedDate.minusDays(5), assignmentCreatedDate));
+                    Period.of(assignmentCreatedDate.plusDays(5), assignmentCreatedDate.plusDays(10)),
+                    Period.of(assignmentCreatedDate.minusDays(5), assignmentCreatedDate));
 
             // when & then
             assertThatCode(() -> studyValidator.validateStudyMentor(admin, study))

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyValidatorTest.java
@@ -3,8 +3,8 @@ package com.gdschongik.gdsc.domain.study.domain;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.FixtureHelper;
 import java.time.LocalDateTime;

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/RecruitmentConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/RecruitmentConstant.java
@@ -1,8 +1,8 @@
 package com.gdschongik.gdsc.global.common.constant;
 
 import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/RecruitmentConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/RecruitmentConstant.java
@@ -13,7 +13,7 @@ public class RecruitmentConstant {
     public static final LocalDateTime BETWEEN_START_AND_END_DATE = LocalDateTime.of(2024, 3, 3, 0, 0);
     public static final LocalDateTime WRONG_END_DATE = LocalDateTime.of(2024, 3, 2, 0, 0);
     public static final LocalDateTime END_DATE = LocalDateTime.of(2024, 3, 5, 0, 0);
-    public static final Period START_TO_END_PERIOD = Period.createPeriod(START_DATE, END_DATE);
+    public static final Period START_TO_END_PERIOD = Period.of(START_DATE, END_DATE);
 
     public static final Money FEE = Money.from(20000L);
     public static final BigDecimal FEE_AMOUNT = BigDecimal.valueOf(20000);
@@ -24,8 +24,7 @@ public class RecruitmentConstant {
     public static final String ROUND_TWO_RECRUITMENT_NAME = "2024학년도 1학기 2차 모집";
     public static final LocalDateTime ROUND_TWO_START_DATE = LocalDateTime.of(2024, 3, 8, 0, 0);
     public static final LocalDateTime ROUND_TWO_END_DATE = LocalDateTime.of(2024, 3, 10, 0, 0);
-    public static final Period ROUND_TWO_START_TO_END_PERIOD =
-            Period.createPeriod(ROUND_TWO_START_DATE, ROUND_TWO_END_DATE);
+    public static final Period ROUND_TWO_START_TO_END_PERIOD = Period.of(ROUND_TWO_START_DATE, ROUND_TWO_END_DATE);
 
     private RecruitmentConstant() {}
 }

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/StudyConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/StudyConstant.java
@@ -27,7 +27,7 @@ public class StudyConstant {
     // Study (2024-09-01 ~ 2024-10-27)
     public static final LocalDateTime STUDY_START_DATETIME = LocalDateTime.of(2024, 9, 1, 0, 0);
     public static final LocalDateTime STUDY_END_DATETIME = STUDY_START_DATETIME.plusWeeks(8);
-    public static final Period STUDY_ONGOING_PERIOD = Period.createPeriod(STUDY_START_DATETIME, STUDY_END_DATETIME);
+    public static final Period STUDY_ONGOING_PERIOD = Period.of(STUDY_START_DATETIME, STUDY_END_DATETIME);
     public static final String STUDY_NOTION_LINK = "notionLink";
     public static final String STUDY_INTRODUCTION = "introduction";
 

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/StudyConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/StudyConstant.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.global.common.constant;
 
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.study.domain.StudyType;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -67,10 +67,10 @@ public class FixtureHelper {
             SemesterType semesterType,
             Money fee) {
         Recruitment recruitment = Recruitment.createRecruitment(
-                academicYear, semesterType, fee, FEE_NAME, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
+                academicYear, semesterType, fee, FEE_NAME, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE));
 
         return RecruitmentRound.create(
-                RECRUITMENT_ROUND_NAME, Period.createPeriod(startDate, endDate), recruitment, RoundType.FIRST);
+                RECRUITMENT_ROUND_NAME, Period.of(startDate, endDate), recruitment, RoundType.FIRST);
     }
 
     public Membership createMembership(Member member, RecruitmentRound recruitmentRound) {
@@ -103,13 +103,13 @@ public class FixtureHelper {
     }
 
     public StudyDetail createStudyDetail(Study study, LocalDateTime startDate, LocalDateTime endDate) {
-        return StudyDetail.createStudyDetail(study, 1L, ATTENDANCE_NUMBER, Period.createPeriod(startDate, endDate));
+        return StudyDetail.createStudyDetail(study, 1L, ATTENDANCE_NUMBER, Period.of(startDate, endDate));
     }
 
     public StudyDetail createNewStudyDetail(
             Long id, Study study, Long week, LocalDateTime startDate, LocalDateTime endDate) {
         StudyDetail studyDetail =
-                StudyDetail.createStudyDetail(study, week, ATTENDANCE_NUMBER, Period.createPeriod(startDate, endDate));
+                StudyDetail.createStudyDetail(study, week, ATTENDANCE_NUMBER, Period.of(startDate, endDate));
         ReflectionTestUtils.setField(studyDetail, "id", id);
         return studyDetail;
     }

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -103,13 +103,12 @@ public class FixtureHelper {
     }
 
     public StudyDetail createStudyDetail(Study study, LocalDateTime startDate, LocalDateTime endDate) {
-        return StudyDetail.createStudyDetail(study, 1L, ATTENDANCE_NUMBER, Period.of(startDate, endDate));
+        return StudyDetail.create(study, 1L, ATTENDANCE_NUMBER, Period.of(startDate, endDate));
     }
 
     public StudyDetail createNewStudyDetail(
             Long id, Study study, Long week, LocalDateTime startDate, LocalDateTime endDate) {
-        StudyDetail studyDetail =
-                StudyDetail.createStudyDetail(study, week, ATTENDANCE_NUMBER, Period.of(startDate, endDate));
+        StudyDetail studyDetail = StudyDetail.create(study, week, ATTENDANCE_NUMBER, Period.of(startDate, endDate));
         ReflectionTestUtils.setField(studyDetail, "id", id);
         return studyDetail;
     }

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -26,7 +26,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 public class FixtureHelper {
 
     public Member createGuestMember(Long id) {
-        Member member = Member.createGuestMember(OAUTH_ID);
+        Member member = Member.createGuest(OAUTH_ID);
         ReflectionTestUtils.setField(member, "id", id);
         return member;
     }
@@ -66,7 +66,7 @@ public class FixtureHelper {
             Integer academicYear,
             SemesterType semesterType,
             Money fee) {
-        Recruitment recruitment = Recruitment.createRecruitment(
+        Recruitment recruitment = Recruitment.create(
                 academicYear, semesterType, fee, FEE_NAME, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE));
 
         return RecruitmentRound.create(
@@ -74,16 +74,16 @@ public class FixtureHelper {
     }
 
     public Membership createMembership(Member member, RecruitmentRound recruitmentRound) {
-        return Membership.createMembership(member, recruitmentRound);
+        return Membership.create(member, recruitmentRound);
     }
 
     public IssuedCoupon createAndIssue(Money money, Member member) {
-        Coupon coupon = Coupon.createCoupon("테스트쿠폰", money);
-        return IssuedCoupon.issue(coupon, member);
+        Coupon coupon = Coupon.create("테스트쿠폰", money);
+        return IssuedCoupon.create(coupon, member);
     }
 
     public Study createStudy(Member mentor, Period period, Period applicationPeriod) {
-        return Study.createStudy(
+        return Study.create(
                 ACADEMIC_YEAR,
                 SEMESTER_TYPE,
                 STUDY_TITLE,

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -10,6 +10,7 @@ import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.coupon.domain.Coupon;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.member.domain.Member;
@@ -17,7 +18,6 @@ import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import java.time.LocalDateTime;

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.coupon.dao.CouponRepository;
 import com.gdschongik.gdsc.domain.coupon.dao.IssuedCouponRepository;
 import com.gdschongik.gdsc.domain.coupon.domain.Coupon;
@@ -29,7 +30,6 @@ import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
-import com.gdschongik.gdsc.domain.recruitment.domain.vo.Period;
 import com.gdschongik.gdsc.domain.study.dao.StudyAchievementRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyDetailRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -145,7 +145,7 @@ public abstract class IntegrationTest {
     }
 
     protected Member createMember() {
-        Member member = Member.createGuestMember(OAUTH_ID);
+        Member member = Member.createGuest(OAUTH_ID);
         memberRepository.save(member);
 
         member.completeUnivEmailVerification(UNIV_EMAIL);
@@ -158,7 +158,7 @@ public abstract class IntegrationTest {
     }
 
     protected Member createGuestMember() {
-        Member guestMember = Member.createGuestMember(OAUTH_ID);
+        Member guestMember = Member.createGuest(OAUTH_ID);
         return memberRepository.save(guestMember);
     }
 
@@ -211,25 +211,25 @@ public abstract class IntegrationTest {
     }
 
     protected Recruitment createRecruitment(Integer academicYear, SemesterType semesterType, Money fee) {
-        Recruitment recruitment = Recruitment.createRecruitment(
+        Recruitment recruitment = Recruitment.create(
                 academicYear, semesterType, fee, FEE_NAME, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE));
         return recruitmentRepository.save(recruitment);
     }
 
     protected Membership createMembership(Member member, RecruitmentRound recruitmentRound) {
-        Membership membership = Membership.createMembership(member, recruitmentRound);
+        Membership membership = Membership.create(member, recruitmentRound);
         return membershipRepository.save(membership);
     }
 
     protected IssuedCoupon createAndIssue(Money money, Member member) {
-        Coupon coupon = Coupon.createCoupon("테스트쿠폰", money);
+        Coupon coupon = Coupon.create("테스트쿠폰", money);
         couponRepository.save(coupon);
-        IssuedCoupon issuedCoupon = IssuedCoupon.issue(coupon, member);
+        IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
         return issuedCouponRepository.save(issuedCoupon);
     }
 
     protected Study createStudy(Member mentor, Period period, Period applicationPeriod) {
-        Study study = Study.createStudy(
+        Study study = Study.create(
                 ACADEMIC_YEAR,
                 SEMESTER_TYPE,
                 STUDY_TITLE,
@@ -246,7 +246,7 @@ public abstract class IntegrationTest {
     }
 
     protected Study createNewStudy(Member mentor, Long totalWeek, Period period, Period applicationPeriod) {
-        Study study = Study.createStudy(
+        Study study = Study.create(
                 ACADEMIC_YEAR,
                 SEMESTER_TYPE,
                 STUDY_TITLE,

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -263,14 +263,12 @@ public abstract class IntegrationTest {
     }
 
     protected StudyDetail createStudyDetail(Study study, LocalDateTime startDate, LocalDateTime endDate) {
-        StudyDetail studyDetail =
-                StudyDetail.createStudyDetail(study, 1L, ATTENDANCE_NUMBER, Period.of(startDate, endDate));
+        StudyDetail studyDetail = StudyDetail.create(study, 1L, ATTENDANCE_NUMBER, Period.of(startDate, endDate));
         return studyDetailRepository.save(studyDetail);
     }
 
     protected StudyDetail createNewStudyDetail(Long week, Study study, LocalDateTime startDate, LocalDateTime endDate) {
-        StudyDetail studyDetail =
-                StudyDetail.createStudyDetail(study, week, ATTENDANCE_NUMBER, Period.of(startDate, endDate));
+        StudyDetail studyDetail = StudyDetail.create(study, week, ATTENDANCE_NUMBER, Period.of(startDate, endDate));
         return studyDetailRepository.save(studyDetail);
     }
 

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -206,13 +206,13 @@ public abstract class IntegrationTest {
         Recruitment recruitment = createRecruitment(academicYear, semesterType, fee);
 
         RecruitmentRound recruitmentRound =
-                RecruitmentRound.create(name, Period.createPeriod(startDate, endDate), recruitment, roundType);
+                RecruitmentRound.create(name, Period.of(startDate, endDate), recruitment, roundType);
         return recruitmentRoundRepository.save(recruitmentRound);
     }
 
     protected Recruitment createRecruitment(Integer academicYear, SemesterType semesterType, Money fee) {
         Recruitment recruitment = Recruitment.createRecruitment(
-                academicYear, semesterType, fee, FEE_NAME, Period.createPeriod(SEMESTER_START_DATE, SEMESTER_END_DATE));
+                academicYear, semesterType, fee, FEE_NAME, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE));
         return recruitmentRepository.save(recruitment);
     }
 
@@ -264,13 +264,13 @@ public abstract class IntegrationTest {
 
     protected StudyDetail createStudyDetail(Study study, LocalDateTime startDate, LocalDateTime endDate) {
         StudyDetail studyDetail =
-                StudyDetail.createStudyDetail(study, 1L, ATTENDANCE_NUMBER, Period.createPeriod(startDate, endDate));
+                StudyDetail.createStudyDetail(study, 1L, ATTENDANCE_NUMBER, Period.of(startDate, endDate));
         return studyDetailRepository.save(studyDetail);
     }
 
     protected StudyDetail createNewStudyDetail(Long week, Study study, LocalDateTime startDate, LocalDateTime endDate) {
         StudyDetail studyDetail =
-                StudyDetail.createStudyDetail(study, week, ATTENDANCE_NUMBER, Period.createPeriod(startDate, endDate));
+                StudyDetail.createStudyDetail(study, week, ATTENDANCE_NUMBER, Period.of(startDate, endDate));
         return studyDetailRepository.save(studyDetail);
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #801

## 📌 작업 내용 및 특이사항
- ~~변경된 정적 팩토리 네이밍 규칙~~
    - common vo의 경우 `of`, `from` 등 java 컨벤션 사용하도록 통일
    - 그 외 domin vo, entity의 경우 `create` 접두사 사용하도록 통일
- Period VO의 위치를 common/vo 패키지로 이동
- Period를 상속 불가능하게 final로 선언
- Period가 `@EqualsAndHashCode` 를 사용하도록 변경

### 최종 정적 팩토리 네이밍 컨벤션
- 엔티티 -> `create`, `createPending`
- VO
    - 인자 하나인 경우 `from`
    - 인자 다수 개이고 모든 파라미터를 받아서 생성하면 `of`
    - 빈 VO를 만드는 경우 `emtpy`
    - 컨텍스트가 있는 경우 적절히 이름 부여 (`canceled`, `unsatisfied`)
- DTO
    - 단일 엔티티에서 DTO로 매핑하는 경우 `from`
    - 그 외 여러 인자를 받는 경우 `of`


## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

- **새로운 기능**
	- `Money` 클래스에 제로 금액을 나타내는 `ZERO` 필드 추가.
	- `Period` 클래스의 인스턴스 생성 방식 변경 (이제 `of` 메서드 사용).
	- `Member`, `Membership`, `RegularRequirement` 클래스의 정적 팩토리 메서드 이름 변경 및 일관성 향상.
  
- **버그 수정**
	- `PingpongListener` 클래스의 로그 메시지 포맷 수정.

- **문서화**
	- 코드 내 주석 및 메서드 설명 업데이트.

- **리팩토링**
	- 여러 클래스에서 `Period` 클래스의 패키지 변경 및 메서드 호출 통일성 확보. 

- **테스트**
	- 테스트 케이스에서 `Period` 및 `MoneyInfo` 인스턴스 생성 방식 변경.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->