### PR TITLE
feat: 스터디 통계 조회 API 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyDetailController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyDetailController.java
@@ -5,6 +5,7 @@ import com.gdschongik.gdsc.domain.study.dto.request.AssignmentCreateUpdateReques
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentResponse;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyCurriculumResponse;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyMentorAttendanceResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyStatisticsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -78,6 +79,13 @@ public class MentorStudyDetailController {
     public ResponseEntity<List<StudyMentorAttendanceResponse>> getAttendanceNumbers(
             @RequestParam(name = "studyId") Long studyId) {
         List<StudyMentorAttendanceResponse> response = mentorStudyDetailService.getAttendanceNumbers(studyId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "스터디 통계 조회", description = "멘토가 자신의 스터디 출석률, 과제 제출률, 수료율에 대한 통계를 조회합니다. 휴강 주차는 계산에서 제외합니다.")
+    @GetMapping("/statistics")
+    public ResponseEntity<StudyStatisticsResponse> getStudyStatistics(@RequestParam(name = "studyId") Long studyId) {
+        StudyStatisticsResponse response = mentorStudyDetailService.getStudyStatistics(studyId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
@@ -4,10 +4,22 @@ import static com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionStatus
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.study.dao.*;
-import com.gdschongik.gdsc.domain.study.domain.*;
+import com.gdschongik.gdsc.domain.study.dao.AssignmentHistoryRepository;
+import com.gdschongik.gdsc.domain.study.dao.AttendanceRepository;
+import com.gdschongik.gdsc.domain.study.dao.StudyDetailRepository;
+import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;
+import com.gdschongik.gdsc.domain.study.dao.StudyRepository;
+import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
+import com.gdschongik.gdsc.domain.study.domain.StudyDetailValidator;
+import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
+import com.gdschongik.gdsc.domain.study.domain.StudyValidator;
 import com.gdschongik.gdsc.domain.study.dto.request.AssignmentCreateUpdateRequest;
-import com.gdschongik.gdsc.domain.study.dto.response.*;
+import com.gdschongik.gdsc.domain.study.dto.response.AssignmentResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyCurriculumResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyMentorAttendanceResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyStatisticsResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyWeekStatisticsResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.time.LocalDate;

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
@@ -156,7 +156,7 @@ public class MentorStudyDetailService {
         return studyDetails.stream()
                 .map((studyDetail -> {
                     boolean isCanceledWeek = !studyDetail.getCurriculum().isOpen();
-                    boolean isCanceledAssignment = !studyDetail.getAssignment().isOpen() | isCanceledWeek;
+                    boolean isCanceledAssignment = !studyDetail.getAssignment().isOpen() || isCanceledWeek;
 
                     if (totalStudentCount == 0) {
                         return StudyWeekStatisticsResponse.of(

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
@@ -1,5 +1,7 @@
 package com.gdschongik.gdsc.domain.study.application;
 
+import static com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionStatus.FAILURE;
+import static com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionStatus.SUCCESS;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
@@ -156,7 +158,7 @@ public class MentorStudyDetailService {
                     }
 
                     long attendanceCount = attendanceRepository.countByStudyDetailId(studyDetail.getId());
-                    long assignmentCount = assignmentHistoryRepository.countByStudyDetailId(studyDetail.getId());
+                    long assignmentCount = assignmentHistoryRepository.countByStudyDetailIdAndSubmissionStatusEquals(studyDetail.getId(), SUCCESS);
 
                     return StudyWeekStatisticsResponse.createOpenedWeekStatistics(
                             studyDetail.getWeek(),
@@ -178,7 +180,7 @@ public class MentorStudyDetailService {
                         weekStatistics -> weekStatistics.isCanceledWeek() ? 0 : weekStatistics.attendanceRate())
                 .sum();
 
-        return Math.round(attendanceRateSum / (double) openedWeekCount * 100);
+        return Math.round(attendanceRateSum / (double) openedWeekCount);
     }
 
     private long calculateAverageWeekAssignmentSubmitRate(
@@ -193,6 +195,6 @@ public class MentorStudyDetailService {
                                 weekStatistics.isCanceledWeek() ? 0 : weekStatistics.assignmentSubmitRate())
                         .sum();
 
-        return Math.round(assignmentSubmitRateSum / (double) openedWeekCount * 100);
+        return Math.round(assignmentSubmitRateSum / (double) openedWeekCount);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
@@ -1,7 +1,6 @@
 package com.gdschongik.gdsc.domain.study.application;
 
 import static com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionStatus.SUCCESS;
-import static com.gdschongik.gdsc.domain.study.dto.response.StudyWeekStatisticsResponse.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
@@ -160,14 +159,14 @@ public class MentorStudyDetailService {
                     boolean isCanceledAssignment = !studyDetail.getAssignment().isOpen() | isCanceledWeek;
 
                     if (totalStudentCount == 0) {
-                        return of(studyDetail.getWeek(), 0L, 0L, isCanceledAssignment, isCanceledWeek);
+                        return StudyWeekStatisticsResponse.of(studyDetail.getWeek(), 0L, 0L, isCanceledAssignment, isCanceledWeek);
                     }
 
                     long attendanceCount = attendanceRepository.countByStudyDetailId(studyDetail.getId());
                     long assignmentCount = assignmentHistoryRepository.countByStudyDetailIdAndSubmissionStatusEquals(
                             studyDetail.getId(), SUCCESS);
 
-                    return of(
+                    return StudyWeekStatisticsResponse.of(
                             studyDetail.getWeek(),
                             isCanceledWeek ? 0 : Math.round(attendanceCount / (double) totalStudentCount * 100),
                             isCanceledAssignment ? 0 : Math.round(assignmentCount / (double) totalStudentCount * 100),

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.study.application;
 
 import static com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionStatus.SUCCESS;
+import static com.gdschongik.gdsc.domain.study.dto.response.StudyWeekStatisticsResponse.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
@@ -161,18 +162,18 @@ public class MentorStudyDetailService {
         return studyDetails.stream()
                 .map((studyDetail -> {
                     if (!studyDetail.getCurriculum().isOpen()) {
-                        return StudyWeekStatisticsResponse.createCanceledWeekStatistics(studyDetail.getWeek());
+                        return canceledWeekStatisticsFrom(studyDetail.getWeek());
                     }
 
                     if (totalStudentCount == 0) {
-                        return StudyWeekStatisticsResponse.createOpenedWeekStatistics(studyDetail.getWeek(), 0L, 0L);
+                        return openedWeekStatisticsOf(studyDetail.getWeek(), 0L, 0L);
                     }
 
                     long attendanceCount = attendanceRepository.countByStudyDetailId(studyDetail.getId());
                     long assignmentCount = assignmentHistoryRepository.countByStudyDetailIdAndSubmissionStatusEquals(
                             studyDetail.getId(), SUCCESS);
 
-                    return StudyWeekStatisticsResponse.createOpenedWeekStatistics(
+                    return openedWeekStatisticsOf(
                             studyDetail.getWeek(),
                             Math.round(attendanceCount / (double) totalStudentCount * 100),
                             Math.round(assignmentCount / (double) totalStudentCount * 100));

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
@@ -141,7 +141,8 @@ public class MentorStudyDetailService {
                 .toList();
 
         long averageAttendanceRate = calculateAverageWeekAttendanceRate(studyWeekStatisticsResponses);
-        long averageAssignmentSubmissionRate = calculateAverageWeekAssignmentSubmissionRate(studyWeekStatisticsResponses);
+        long averageAssignmentSubmissionRate =
+                calculateAverageWeekAssignmentSubmissionRate(studyWeekStatisticsResponses);
 
         return StudyStatisticsResponse.of(
                 totalStudentCount,

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
@@ -159,7 +159,8 @@ public class MentorStudyDetailService {
                     boolean isCanceledAssignment = !studyDetail.getAssignment().isOpen() | isCanceledWeek;
 
                     if (totalStudentCount == 0) {
-                        return StudyWeekStatisticsResponse.of(studyDetail.getWeek(), 0L, 0L, isCanceledAssignment, isCanceledWeek);
+                        return StudyWeekStatisticsResponse.of(
+                                studyDetail.getWeek(), 0L, 0L, isCanceledAssignment, isCanceledWeek);
                     }
 
                     long attendanceCount = attendanceRepository.countByStudyDetailId(studyDetail.getId());

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
@@ -131,7 +131,7 @@ public class MentorStudyDetailService {
         studyValidator.validateStudyMentor(currentMember, study);
 
         List<StudyHistory> studyHistories = studyHistoryRepository.findAllByStudyId(studyId);
-        long wholeStudentCount = studyHistories.size();
+        long totalStudentCount = studyHistories.size();
         long studyCompleteStudentCount =
                 studyHistories.stream().filter(StudyHistory::isComplete).count();
 
@@ -141,14 +141,14 @@ public class MentorStudyDetailService {
                 .count();
 
         List<StudyWeekStatisticsResponse> studyWeekStatisticsResponses =
-                calculateStudyWeekStatistics(studyDetails, wholeStudentCount);
+                calculateStudyWeekStatistics(studyDetails, totalStudentCount);
 
         long averageAttendanceRate = calculateAverageWeekAttendanceRate(studyWeekStatisticsResponses, openedWeekCount);
         long averageAssignmentSubmitRate =
                 calculateAverageWeekAssignmentSubmitRate(studyWeekStatisticsResponses, openedWeekCount);
 
         return StudyStatisticsResponse.of(
-                wholeStudentCount,
+                totalStudentCount,
                 studyCompleteStudentCount,
                 averageAttendanceRate,
                 averageAssignmentSubmitRate,
@@ -156,7 +156,7 @@ public class MentorStudyDetailService {
     }
 
     private List<StudyWeekStatisticsResponse> calculateStudyWeekStatistics(
-            List<StudyDetail> studyDetails, Long wholeStudentCount) {
+            List<StudyDetail> studyDetails, Long totalStudentCount) {
 
         return studyDetails.stream()
                 .map((studyDetail -> {
@@ -164,7 +164,7 @@ public class MentorStudyDetailService {
                         return StudyWeekStatisticsResponse.createCanceledWeekStatistics(studyDetail.getWeek());
                     }
 
-                    if (wholeStudentCount == 0) {
+                    if (totalStudentCount == 0) {
                         return StudyWeekStatisticsResponse.createOpenedWeekStatistics(studyDetail.getWeek(), 0L, 0L);
                     }
 
@@ -174,8 +174,8 @@ public class MentorStudyDetailService {
 
                     return StudyWeekStatisticsResponse.createOpenedWeekStatistics(
                             studyDetail.getWeek(),
-                            Math.round(attendanceCount / (double) wholeStudentCount * 100),
-                            Math.round(assignmentCount / (double) wholeStudentCount * 100));
+                            Math.round(attendanceCount / (double) totalStudentCount * 100),
+                            Math.round(assignmentCount / (double) totalStudentCount * 100));
                 }))
                 .toList();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
@@ -183,7 +183,7 @@ public class MentorStudyDetailService {
     private long calculateAverageWeekAttendanceRate(List<StudyWeekStatisticsResponse> studyWeekStatisticsResponses) {
 
         double averageAttendanceRate = studyWeekStatisticsResponses.stream()
-                .filter(weekStatisticsResponse -> !weekStatisticsResponse.isCanceledWeek())
+                .filter(weekStatisticsResponse -> !weekStatisticsResponse.isCurriculumCanceled())
                 .mapToLong(StudyWeekStatisticsResponse::attendanceRate)
                 .average()
                 .orElse(0);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
@@ -3,13 +3,10 @@ package com.gdschongik.gdsc.domain.study.application;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.study.dao.StudyDetailRepository;
-import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
-import com.gdschongik.gdsc.domain.study.domain.StudyDetailValidator;
+import com.gdschongik.gdsc.domain.study.dao.*;
+import com.gdschongik.gdsc.domain.study.domain.*;
 import com.gdschongik.gdsc.domain.study.dto.request.AssignmentCreateUpdateRequest;
-import com.gdschongik.gdsc.domain.study.dto.response.AssignmentResponse;
-import com.gdschongik.gdsc.domain.study.dto.response.StudyCurriculumResponse;
-import com.gdschongik.gdsc.domain.study.dto.response.StudyMentorAttendanceResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.*;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.time.LocalDate;
@@ -27,6 +24,11 @@ public class MentorStudyDetailService {
     private final MemberUtil memberUtil;
     private final StudyDetailRepository studyDetailRepository;
     private final StudyDetailValidator studyDetailValidator;
+    private final StudyHistoryRepository studyHistoryRepository;
+    private final AttendanceRepository attendanceRepository;
+    private final AssignmentHistoryRepository assignmentHistoryRepository;
+    private final StudyValidator studyValidator;
+    private final StudyRepository studyRepository;
 
     @Transactional(readOnly = true)
     public List<AssignmentResponse> getWeeklyAssignments(Long studyId) {
@@ -107,5 +109,90 @@ public class MentorStudyDetailService {
                 .map(StudyMentorAttendanceResponse::from)
                 .limit(2)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public StudyStatisticsResponse getStudyStatistics(Long studyId) {
+        Member currentMember = memberUtil.getCurrentMember();
+        Study study = studyRepository.findById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
+        studyValidator.validateStudyMentor(currentMember, study);
+
+        List<StudyHistory> studyHistories = studyHistoryRepository.findAllByStudyId(studyId);
+        long wholeStudentCount = studyHistories.size();
+        long studyCompleteStudentCount =
+                studyHistories.stream().filter(StudyHistory::isComplete).count();
+
+        List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyIdOrderByWeekAsc(studyId);
+        long openedWeekCount = studyDetails.stream()
+                .filter(studyDetail -> studyDetail.getCurriculum().isOpen())
+                .count();
+
+        List<StudyWeekStatisticsResponse> studyWeekStatisticsResponses =
+                calculateStudyWeekStatistics(studyDetails, wholeStudentCount);
+
+        long averageAttendanceRate = calculateAverageWeekAttendanceRate(studyWeekStatisticsResponses, openedWeekCount);
+        long averageAssignmentSubmitRate =
+                calculateAverageWeekAssignmentSubmitRate(studyWeekStatisticsResponses, openedWeekCount);
+
+        return StudyStatisticsResponse.of(
+                wholeStudentCount,
+                studyCompleteStudentCount,
+                averageAttendanceRate,
+                averageAssignmentSubmitRate,
+                studyWeekStatisticsResponses);
+    }
+
+    private List<StudyWeekStatisticsResponse> calculateStudyWeekStatistics(
+            List<StudyDetail> studyDetails, Long wholeStudentCount) {
+
+        return studyDetails.stream()
+                .map((studyDetail -> {
+                    if (!studyDetail.getCurriculum().isOpen()) {
+                        return StudyWeekStatisticsResponse.createCanceledWeekStatistics(studyDetail.getWeek());
+                    }
+
+                    if (wholeStudentCount == 0) {
+                        return StudyWeekStatisticsResponse.createOpenedWeekStatistics(studyDetail.getWeek(), 0L, 0L);
+                    }
+
+                    long attendanceCount = attendanceRepository.countByStudyDetailId(studyDetail.getId());
+                    long assignmentCount = assignmentHistoryRepository.countByStudyDetailId(studyDetail.getId());
+
+                    return StudyWeekStatisticsResponse.createOpenedWeekStatistics(
+                            studyDetail.getWeek(),
+                            Math.round(attendanceCount / (double) wholeStudentCount * 100),
+                            Math.round(assignmentCount / (double) wholeStudentCount * 100));
+                }))
+                .toList();
+    }
+
+    private long calculateAverageWeekAttendanceRate(
+            List<StudyWeekStatisticsResponse> studyWeekStatisticsResponses, long openedWeekCount) {
+
+        if (openedWeekCount == 0) {
+            return 0;
+        }
+
+        long attendanceRateSum = studyWeekStatisticsResponses.stream()
+                .mapToLong(
+                        weekStatistics -> weekStatistics.isCanceledWeek() ? 0 : weekStatistics.attendanceRate())
+                .sum();
+
+        return Math.round(attendanceRateSum / (double) openedWeekCount * 100);
+    }
+
+    private long calculateAverageWeekAssignmentSubmitRate(
+            List<StudyWeekStatisticsResponse> studyWeekStatisticsResponses, long openedWeekCount) {
+
+        if (openedWeekCount == 0) {
+            return 0;
+        }
+
+        long assignmentSubmitRateSum = studyWeekStatisticsResponses.stream()
+                        .mapToLong(weekStatistics ->
+                                weekStatistics.isCanceledWeek() ? 0 : weekStatistics.assignmentSubmitRate())
+                        .sum();
+
+        return Math.round(assignmentSubmitRateSum / (double) openedWeekCount * 100);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
@@ -134,7 +134,7 @@ public class MentorStudyDetailService {
 
         long totalStudentCount = studyHistories.size();
         long studyCompletedStudentCount =
-                studyHistories.stream().filter(StudyHistory::isComplete).count();
+                studyHistories.stream().filter(StudyHistory::isCompleted).count();
 
         List<StudyWeekStatisticsResponse> studyWeekStatisticsResponses = studyDetails.stream()
                 .map((studyDetail -> calculateWeekStatistics(studyDetail, totalStudentCount)))

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
@@ -1,6 +1,5 @@
 package com.gdschongik.gdsc.domain.study.application;
 
-import static com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionStatus.FAILURE;
 import static com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionStatus.SUCCESS;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
@@ -158,7 +157,8 @@ public class MentorStudyDetailService {
                     }
 
                     long attendanceCount = attendanceRepository.countByStudyDetailId(studyDetail.getId());
-                    long assignmentCount = assignmentHistoryRepository.countByStudyDetailIdAndSubmissionStatusEquals(studyDetail.getId(), SUCCESS);
+                    long assignmentCount = assignmentHistoryRepository.countByStudyDetailIdAndSubmissionStatusEquals(
+                            studyDetail.getId(), SUCCESS);
 
                     return StudyWeekStatisticsResponse.createOpenedWeekStatistics(
                             studyDetail.getWeek(),
@@ -176,8 +176,7 @@ public class MentorStudyDetailService {
         }
 
         long attendanceRateSum = studyWeekStatisticsResponses.stream()
-                .mapToLong(
-                        weekStatistics -> weekStatistics.isCanceledWeek() ? 0 : weekStatistics.attendanceRate())
+                .mapToLong(weekStatistics -> weekStatistics.isCanceledWeek() ? 0 : weekStatistics.attendanceRate())
                 .sum();
 
         return Math.round(attendanceRateSum / (double) openedWeekCount);
@@ -191,9 +190,9 @@ public class MentorStudyDetailService {
         }
 
         long assignmentSubmitRateSum = studyWeekStatisticsResponses.stream()
-                        .mapToLong(weekStatistics ->
-                                weekStatistics.isCanceledWeek() ? 0 : weekStatistics.assignmentSubmitRate())
-                        .sum();
+                .mapToLong(
+                        weekStatistics -> weekStatistics.isCanceledWeek() ? 0 : weekStatistics.assignmentSubmitRate())
+                .sum();
 
         return Math.round(assignmentSubmitRateSum / (double) openedWeekCount);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryRepository.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.domain.study.dao;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
+import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionStatus;
 import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,5 +11,5 @@ public interface AssignmentHistoryRepository
         extends JpaRepository<AssignmentHistory, Long>, AssignmentHistoryCustomRepository {
     Optional<AssignmentHistory> findByMemberAndStudyDetail(Member member, StudyDetail studyDetail);
 
-    long countByStudyDetailId(Long studyDetailId);
+    long countByStudyDetailIdAndSubmissionStatusEquals(Long studyDetailId, AssignmentSubmissionStatus status);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryRepository.java
@@ -9,4 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface AssignmentHistoryRepository
         extends JpaRepository<AssignmentHistory, Long>, AssignmentHistoryCustomRepository {
     Optional<AssignmentHistory> findByMemberAndStudyDetail(Member member, StudyDetail studyDetail);
+
+    long countByStudyDetailId(Long studyDetailId);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AttendanceRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AttendanceRepository extends JpaRepository<Attendance, Long>, AttendanceCustomRepository {
     boolean existsByStudentIdAndStudyDetailId(Long studentId, Long studyDetailId);
+
+    long countByStudyDetailId(Long studyDetailId);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -83,7 +83,7 @@ public class StudyHistory extends BaseEntity {
         return study.isWithinApplicationAndCourse();
     }
 
-    public boolean isComplete() {
+    public boolean isCompleted() {
         return studyHistoryStatus == COMPLETED;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -82,4 +82,8 @@ public class StudyHistory extends BaseEntity {
     public boolean isWithinApplicationAndCourse() {
         return study.isWithinApplicationAndCourse();
     }
+
+    public boolean isComplete() {
+        return studyHistoryStatus == COMPLETED;
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStatisticsResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStatisticsResponse.java
@@ -6,10 +6,10 @@ import java.util.List;
 public record StudyStatisticsResponse(
         @Schema(description = "스터디 전체 수강생 수") Long totalStudentCount,
         @Schema(description = "스터디 수료 수강생 수") Long completeStudentCount,
-        @Schema(description = "출석률 평균") Long averageAttendanceRate,
-        @Schema(description = "과제 제출률 평균") Long averageAssignmentSubmitRate,
+        @Schema(description = "평균 출석률") Long averageAttendanceRate,
+        @Schema(description = "평균 과제 제출률") Long averageAssignmentSubmitRate,
         @Schema(description = "스터디 수료율") Long studyCompleteRate,
-        @Schema(description = "주차별 출석 및 과제 통계") List<StudyWeekStatisticsResponse> studyWeekStatisticsResponses) {
+        @Schema(description = "주차별 출석률 및 과제 제출률") List<StudyWeekStatisticsResponse> studyWeekStatisticsResponses) {
 
     public static StudyStatisticsResponse of(
             Long totalStudentCount,

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStatisticsResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStatisticsResponse.java
@@ -1,0 +1,28 @@
+package com.gdschongik.gdsc.domain.study.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record StudyStatisticsResponse(
+        @Schema(description = "스터디 전체 수강생 수") Long totalStudentCount,
+        @Schema(description = "스터디 수료 수강생 수") Long completeStudentCount,
+        @Schema(description = "출석률 평균") Long averageAttendanceRate,
+        @Schema(description = "과제 제출률 평균") Long averageAssignmentSubmitRate,
+        @Schema(description = "스터디 수료율") Long studyCompleteRate,
+        @Schema(description = "주차별 출석 및 과제 통계") List<StudyWeekStatisticsResponse> studyWeekStatisticsResponses) {
+
+    public static StudyStatisticsResponse of(
+            Long totalStudentCount,
+            Long completeStudentCount,
+            Long averageAttendanceRate,
+            Long averageAssignmentSubmitRate,
+            List<StudyWeekStatisticsResponse> studyWeekStatisticsResponses) {
+        return new StudyStatisticsResponse(
+                totalStudentCount,
+                completeStudentCount,
+                averageAttendanceRate,
+                averageAssignmentSubmitRate,
+                Math.round(completeStudentCount / (double) totalStudentCount * 100),
+                studyWeekStatisticsResponses);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStatisticsResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStatisticsResponse.java
@@ -22,7 +22,7 @@ public record StudyStatisticsResponse(
                 completeStudentCount,
                 averageAttendanceRate,
                 averageAssignmentSubmitRate,
-                Math.round(completeStudentCount / (double) totalStudentCount * 100),
+                totalStudentCount == 0 ? 0 : Math.round(completeStudentCount / (double) totalStudentCount * 100),
                 studyWeekStatisticsResponses);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStatisticsResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStatisticsResponse.java
@@ -7,7 +7,7 @@ public record StudyStatisticsResponse(
         @Schema(description = "스터디 전체 수강생 수") Long totalStudentCount,
         @Schema(description = "스터디 수료 수강생 수") Long completeStudentCount,
         @Schema(description = "평균 출석률") Long averageAttendanceRate,
-        @Schema(description = "평균 과제 제출률") Long averageAssignmentSubmitRate,
+        @Schema(description = "평균 과제 제출률") Long averageAssignmentSubmissionRate,
         @Schema(description = "스터디 수료율") Long studyCompleteRate,
         @Schema(description = "주차별 출석률 및 과제 제출률") List<StudyWeekStatisticsResponse> studyWeekStatisticsResponses) {
 
@@ -15,13 +15,13 @@ public record StudyStatisticsResponse(
             Long totalStudentCount,
             Long completeStudentCount,
             Long averageAttendanceRate,
-            Long averageAssignmentSubmitRate,
+            Long averageAssignmentSubmissionRate,
             List<StudyWeekStatisticsResponse> studyWeekStatisticsResponses) {
         return new StudyStatisticsResponse(
                 totalStudentCount,
                 completeStudentCount,
                 averageAttendanceRate,
-                averageAssignmentSubmitRate,
+                averageAssignmentSubmissionRate,
                 totalStudentCount == 0 ? 0 : Math.round(completeStudentCount / (double) totalStudentCount * 100),
                 studyWeekStatisticsResponses);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyWeekStatisticsResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyWeekStatisticsResponse.java
@@ -5,23 +5,23 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record StudyWeekStatisticsResponse(
         @Schema(description = "스터디 주차") Long week,
         @Schema(description = "출석률") Long attendanceRate,
-        @Schema(description = "과제 제출률") Long assignmentSubmitRate,
-        @Schema(description = "과제 휴강 여부") boolean isCanceledAssignment,
+        @Schema(description = "과제 제출률") Long assignmentSubmissionRate,
+        @Schema(description = "과제 휴강 여부") boolean isAssignmentCanceled,
         @Schema(description = "스터디 휴강 여부") boolean isCanceledWeek) {
 
-    public static StudyWeekStatisticsResponse openedOf(Long week, Long attendanceRate, Long assignmentSubmitRate) {
-        return new StudyWeekStatisticsResponse(week, attendanceRate, assignmentSubmitRate, false, false);
+    public static StudyWeekStatisticsResponse opened(Long week, Long attendanceRate, Long assignmentSubmissionRate) {
+        return new StudyWeekStatisticsResponse(week, attendanceRate, assignmentSubmissionRate, false, false);
     }
 
-    public static StudyWeekStatisticsResponse emptyOf(Long week, boolean isCanceledAssignment, boolean isCanceledWeek) {
+    public static StudyWeekStatisticsResponse empty(Long week, boolean isCanceledAssignment, boolean isCanceledWeek) {
         return new StudyWeekStatisticsResponse(week, 0L, 0L, isCanceledAssignment, isCanceledWeek);
     }
 
-    public static StudyWeekStatisticsResponse canceledWeekFrom(Long week) {
-        return StudyWeekStatisticsResponse.emptyOf(week, true, true);
+    public static StudyWeekStatisticsResponse canceledWeek(Long week) {
+        return StudyWeekStatisticsResponse.empty(week, true, true);
     }
 
-    public static StudyWeekStatisticsResponse canceledAssignmentOf(Long week, Long attendanceRate) {
+    public static StudyWeekStatisticsResponse assignmentCanceled(Long week, Long attendanceRate) {
         return new StudyWeekStatisticsResponse(week, attendanceRate, 0L, true, false);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyWeekStatisticsResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyWeekStatisticsResponse.java
@@ -7,14 +7,15 @@ public record StudyWeekStatisticsResponse(
         @Schema(description = "출석률") Long attendanceRate,
         @Schema(description = "과제 제출률") Long assignmentSubmissionRate,
         @Schema(description = "과제 휴강 여부") boolean isAssignmentCanceled,
-        @Schema(description = "스터디 휴강 여부") boolean isCanceledWeek) {
+        @Schema(description = "수업 휴강 여부") boolean isCurriculumCanceled) {
 
     public static StudyWeekStatisticsResponse opened(Long week, Long attendanceRate, Long assignmentSubmissionRate) {
         return new StudyWeekStatisticsResponse(week, attendanceRate, assignmentSubmissionRate, false, false);
     }
 
-    public static StudyWeekStatisticsResponse empty(Long week, boolean isCanceledAssignment, boolean isCanceledWeek) {
-        return new StudyWeekStatisticsResponse(week, 0L, 0L, isCanceledAssignment, isCanceledWeek);
+    public static StudyWeekStatisticsResponse empty(
+            Long week, boolean isAssignmentCanceled, boolean isCurriculumCanceled) {
+        return new StudyWeekStatisticsResponse(week, 0L, 0L, isAssignmentCanceled, isCurriculumCanceled);
     }
 
     public static StudyWeekStatisticsResponse canceledWeek(Long week) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyWeekStatisticsResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyWeekStatisticsResponse.java
@@ -6,14 +6,16 @@ public record StudyWeekStatisticsResponse(
         @Schema(description = "스터디 주차") Long week,
         @Schema(description = "출석률") Long attendanceRate,
         @Schema(description = "과제 제출률") Long assignmentSubmitRate,
-        @Schema(description = "휴강 여부") boolean isCanceledWeek) {
+        @Schema(description = "과제 휴강 여부") boolean isCanceledAssignment,
+        @Schema(description = "스터디 휴강 여부") boolean isCanceledWeek) {
 
-    public static StudyWeekStatisticsResponse openedWeekStatisticsOf(
-            Long studyWeek, Long attendanceRate, Long assignmentSubmitRate) {
-        return new StudyWeekStatisticsResponse(studyWeek, attendanceRate, assignmentSubmitRate, false);
-    }
-
-    public static StudyWeekStatisticsResponse canceledWeekStatisticsFrom(Long studyWeek) {
-        return new StudyWeekStatisticsResponse(studyWeek, 0L, 0L, true);
+    public static StudyWeekStatisticsResponse of(
+            Long studyWeek,
+            Long attendanceRate,
+            Long assignmentSubmitRate,
+            boolean isCanceledAssignment,
+            boolean isCanceledWeek) {
+        return new StudyWeekStatisticsResponse(
+                studyWeek, attendanceRate, assignmentSubmitRate, isCanceledAssignment, isCanceledWeek);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyWeekStatisticsResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyWeekStatisticsResponse.java
@@ -6,7 +6,7 @@ public record StudyWeekStatisticsResponse(
         @Schema(description = "스터디 주차") Long studyWeek,
         @Schema(description = "현재 주차 출석률") Long attendanceRate,
         @Schema(description = "현재 주차 과제 제출률") Long assignmentSubmitRate,
-        @Schema(description = "스터디 주차 휴강 여부") boolean isCanceledWeek) {
+        @Schema(description = "현재 주차 휴강 여부") boolean isCanceledWeek) {
 
     public static StudyWeekStatisticsResponse createOpenedWeekStatistics(
             Long studyWeek, Long attendanceRate, Long assignmentSubmitRate) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyWeekStatisticsResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyWeekStatisticsResponse.java
@@ -3,17 +3,17 @@ package com.gdschongik.gdsc.domain.study.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record StudyWeekStatisticsResponse(
-        @Schema(description = "스터디 주차") Long studyWeek,
-        @Schema(description = "현재 주차 출석률") Long attendanceRate,
-        @Schema(description = "현재 주차 과제 제출률") Long assignmentSubmitRate,
-        @Schema(description = "현재 주차 휴강 여부") boolean isCanceledWeek) {
+        @Schema(description = "스터디 주차") Long week,
+        @Schema(description = "출석률") Long attendanceRate,
+        @Schema(description = "과제 제출률") Long assignmentSubmitRate,
+        @Schema(description = "휴강 여부") boolean isCanceledWeek) {
 
-    public static StudyWeekStatisticsResponse createOpenedWeekStatistics(
+    public static StudyWeekStatisticsResponse openedWeekStatisticsOf(
             Long studyWeek, Long attendanceRate, Long assignmentSubmitRate) {
         return new StudyWeekStatisticsResponse(studyWeek, attendanceRate, assignmentSubmitRate, false);
     }
 
-    public static StudyWeekStatisticsResponse createCanceledWeekStatistics(Long studyWeek) {
+    public static StudyWeekStatisticsResponse canceledWeekStatisticsFrom(Long studyWeek) {
         return new StudyWeekStatisticsResponse(studyWeek, 0L, 0L, true);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyWeekStatisticsResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyWeekStatisticsResponse.java
@@ -9,13 +9,19 @@ public record StudyWeekStatisticsResponse(
         @Schema(description = "과제 휴강 여부") boolean isCanceledAssignment,
         @Schema(description = "스터디 휴강 여부") boolean isCanceledWeek) {
 
-    public static StudyWeekStatisticsResponse of(
-            Long studyWeek,
-            Long attendanceRate,
-            Long assignmentSubmitRate,
-            boolean isCanceledAssignment,
-            boolean isCanceledWeek) {
-        return new StudyWeekStatisticsResponse(
-                studyWeek, attendanceRate, assignmentSubmitRate, isCanceledAssignment, isCanceledWeek);
+    public static StudyWeekStatisticsResponse openedOf(Long week, Long attendanceRate, Long assignmentSubmitRate) {
+        return new StudyWeekStatisticsResponse(week, attendanceRate, assignmentSubmitRate, false, false);
+    }
+
+    public static StudyWeekStatisticsResponse emptyOf(Long week, boolean isCanceledAssignment, boolean isCanceledWeek) {
+        return new StudyWeekStatisticsResponse(week, 0L, 0L, isCanceledAssignment, isCanceledWeek);
+    }
+
+    public static StudyWeekStatisticsResponse canceledWeekFrom(Long week) {
+        return StudyWeekStatisticsResponse.emptyOf(week, true, true);
+    }
+
+    public static StudyWeekStatisticsResponse canceledAssignmentOf(Long week, Long attendanceRate) {
+        return new StudyWeekStatisticsResponse(week, attendanceRate, 0L, true, false);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyWeekStatisticsResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyWeekStatisticsResponse.java
@@ -1,0 +1,19 @@
+package com.gdschongik.gdsc.domain.study.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record StudyWeekStatisticsResponse(
+        @Schema(description = "스터디 주차") Long studyWeek,
+        @Schema(description = "현재 주차 출석률") Long attendanceRate,
+        @Schema(description = "현재 주차 과제 제출률") Long assignmentSubmitRate,
+        @Schema(description = "스터디 주차 휴강 여부") boolean isCanceledWeek) {
+
+    public static StudyWeekStatisticsResponse createOpenedWeekStatistics(
+            Long studyWeek, Long attendanceRate, Long assignmentSubmitRate) {
+        return new StudyWeekStatisticsResponse(studyWeek, attendanceRate, assignmentSubmitRate, false);
+    }
+
+    public static StudyWeekStatisticsResponse createCanceledWeekStatistics(Long studyWeek) {
+        return new StudyWeekStatisticsResponse(studyWeek, 0L, 0L, true);
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #786 

## 📌 작업 내용 및 특이사항
- 스터디 통계 조회 API 작성

## 📝 참고사항
- 수료율의 경우, 스터디 수료 여부 필드를 이용하여 계산하였습니다.
- 스터디 평균 출석률과 과제 제출률은 각 주차별 출석률, 과제 제출률의 계산 결과를 평균하였습니다.
- 각 주차별 과제 제출률은 제출에 성공한 과제만 평균냈습니다.
- 평균을 낼 때 휴강주차는 평균 계산에서 제외하였습니다.

- 피그마에 화면 기획을 보면 '수료 스터디 인원 수' 와 '수료 가능한 스터디 인원 수' 정보가 필요한데, 혁님이 '수료 가능한 스터디 인원 수'는 스터디 전체 인원으로 고려하면 된다고 하셔서 response에 별도 필드를 만들지 않았습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 연구 통계를 조회할 수 있는 새로운 API 엔드포인트 추가.
	- 연구 세션에 대한 통계 정보를 포함하는 `StudyStatisticsResponse` 및 `StudyWeekStatisticsResponse` 데이터 구조 도입.
	- 주간 통계 계산을 위한 새로운 메소드 추가.
	- 출석 및 과제 제출 상태를 기반으로 한 통계 계산 기능 추가.
	- 특정 연구 세부사항에 대한 출석 및 과제 기록 수를 계산하는 새로운 메소드 추가.
	- 연구 이력의 완료 상태를 확인하는 `isCompleted()` 메소드 추가.
- **버그 수정**
	- 연구 이력의 완료 상태를 확인하는 `isCompleted()` 메소드 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->