### PR TITLE
refactor: StudyTodoResponse 이름 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyDetailController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyDetailController.java
@@ -4,7 +4,7 @@ import com.gdschongik.gdsc.domain.study.application.StudentStudyDetailService;
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentDashboardResponse;
 import com.gdschongik.gdsc.domain.study.dto.response.AssignmentHistoryStatusResponse;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyStudentCurriculumResponse;
-import com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyTaskResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -33,8 +33,8 @@ public class StudentStudyDetailController {
 
     @Operation(summary = "내 할일 리스트 조회", description = "해당 스터디의 내 할일 리스트를 조회합니다")
     @GetMapping("/todo")
-    public ResponseEntity<List<StudyTodoResponse>> getStudyTodoList(@RequestParam(name = "studyId") Long studyId) {
-        List<StudyTodoResponse> response = studentStudyDetailService.getStudyTodoList(studyId);
+    public ResponseEntity<List<StudyTaskResponse>> getStudyTodoList(@RequestParam(name = "studyId") Long studyId) {
+        List<StudyTaskResponse> response = studentStudyDetailService.getStudyTodoList(studyId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
@@ -21,7 +21,7 @@ import com.gdschongik.gdsc.domain.study.dto.request.StudyCurriculumCreateRequest
 import com.gdschongik.gdsc.domain.study.dto.request.StudyUpdateRequest;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyResponse;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyStudentResponse;
-import com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyTaskResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.ExcelUtil;
 import com.gdschongik.gdsc.global.util.MemberUtil;
@@ -87,15 +87,15 @@ public class MentorStudyService {
             List<AssignmentHistory> currentAssignmentHistories =
                     assignmentHistoryMap.getOrDefault(studyHistory.getStudent().getId(), new ArrayList<>());
 
-            List<StudyTodoResponse> studyTodos = new ArrayList<>();
+            List<StudyTaskResponse> studyTasks = new ArrayList<>();
             studyDetails.forEach(studyDetail -> {
-                studyTodos.add(StudyTodoResponse.createAttendanceType(
+                studyTasks.add(StudyTaskResponse.createAttendanceType(
                         studyDetail, LocalDate.now(), isAttended(currentAttendances, studyDetail)));
-                studyTodos.add(StudyTodoResponse.createAssignmentType(
+                studyTasks.add(StudyTaskResponse.createAssignmentType(
                         studyDetail, getSubmittedAssignment(currentAssignmentHistories, studyDetail)));
             });
 
-            response.add(StudyStudentResponse.of(studyHistory, currentStudyAchievements, studyTodos));
+            response.add(StudyStudentResponse.of(studyHistory, currentStudyAchievements, studyTasks));
         });
 
         return new PageImpl<>(response, pageable, studyHistories.getTotalElements());
@@ -224,15 +224,15 @@ public class MentorStudyService {
             List<AssignmentHistory> currentAssignmentHistories =
                     assignmentHistoryMap.getOrDefault(studyHistory.getStudent().getId(), new ArrayList<>());
 
-            List<StudyTodoResponse> studyTodos = new ArrayList<>();
+            List<StudyTaskResponse> studyTasks = new ArrayList<>();
             studyDetails.forEach(studyDetail -> {
-                studyTodos.add(StudyTodoResponse.createAttendanceType(
+                studyTasks.add(StudyTaskResponse.createAttendanceType(
                         studyDetail, LocalDate.now(), isAttended(currentAttendances, studyDetail)));
-                studyTodos.add(StudyTodoResponse.createAssignmentType(
+                studyTasks.add(StudyTaskResponse.createAssignmentType(
                         studyDetail, getSubmittedAssignment(currentAssignmentHistories, studyDetail)));
             });
 
-            content.add(StudyStudentResponse.of(studyHistory, currentStudyAchievements, studyTodos));
+            content.add(StudyStudentResponse.of(studyHistory, currentStudyAchievements, studyTasks));
         });
 
         return excelUtil.createStudyExcel(study, content);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
@@ -54,7 +54,7 @@ public class StudentStudyDetailService {
     }
 
     @Transactional(readOnly = true)
-    public List<StudyTodoResponse> getStudyTodoList(Long studyId) {
+    public List<StudyTaskResponse> getStudyTodoList(Long studyId) {
         Member member = memberUtil.getCurrentMember();
         final List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyIdOrderByWeekAsc(studyId);
         final List<AssignmentHistory> assignmentHistories =
@@ -62,19 +62,19 @@ public class StudentStudyDetailService {
         final List<Attendance> attendances = attendanceRepository.findByMemberAndStudyId(member, studyId);
 
         LocalDate now = LocalDate.now();
-        List<StudyTodoResponse> response = new ArrayList<>();
+        List<StudyTaskResponse> response = new ArrayList<>();
         // 출석체크 정보 (개설 상태이고, 오늘이 출석체크날짜인 것)
         studyDetails.stream()
                 .filter(studyDetail -> studyDetail.getCurriculum().isOpen()
                         && studyDetail.getAttendanceDay().equals(now))
-                .forEach(studyDetail -> response.add(StudyTodoResponse.createAttendanceType(
+                .forEach(studyDetail -> response.add(StudyTaskResponse.createAttendanceType(
                         studyDetail, now, isAttended(attendances, studyDetail))));
 
         // 과제 정보 (오늘이 과제 제출 기간에 포함된 과제 정보)
         studyDetails.stream()
                 .filter(studyDetail -> studyDetail.getAssignment().isOpen()
                         && studyDetail.getAssignment().isDeadlineRemaining())
-                .forEach(studyDetail -> response.add(StudyTodoResponse.createAssignmentType(
+                .forEach(studyDetail -> response.add(StudyTaskResponse.createAssignmentType(
                         studyDetail, getSubmittedAssignment(assignmentHistories, studyDetail))));
         return response;
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentResponse.java
@@ -2,7 +2,7 @@ package com.gdschongik.gdsc.domain.study.dto.response;
 
 import static com.gdschongik.gdsc.domain.study.domain.AchievementType.*;
 import static com.gdschongik.gdsc.domain.study.dto.response.AssignmentSubmissionStatusResponse.*;
-import static com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse.StudyTodoType.*;
+import static com.gdschongik.gdsc.domain.study.dto.response.StudyTaskResponse.StudyTaskType.*;
 
 import com.gdschongik.gdsc.domain.study.domain.AchievementType;
 import com.gdschongik.gdsc.domain.study.domain.StudyAchievement;
@@ -21,17 +21,17 @@ public record StudyStudentResponse(
         @Schema(description = "수료 상태") StudyHistoryStatus studyHistoryStatus,
         @Schema(description = "1차 우수 스터디원") boolean isFirstRoundOutstandingStudent,
         @Schema(description = "2차 우수 스터디원") boolean isSecondRoundOutstandingStudent,
-        @Schema(description = "과제 및 출석 이력") List<StudyTodoResponse> studyTodos,
+        @Schema(description = "과제 및 출석 이력") List<StudyTaskResponse> studyTasks,
         @Schema(description = "과제 수행률") double assignmentRate,
         @Schema(description = "출석률") double attendanceRate) {
     public static StudyStudentResponse of(
-            StudyHistory studyHistory, List<StudyAchievement> studyAchievements, List<StudyTodoResponse> studyTodos) {
-        List<StudyTodoResponse> assignments = studyTodos.stream()
-                .filter(studyTodoResponse -> studyTodoResponse.todoType() == ASSIGNMENT)
+            StudyHistory studyHistory, List<StudyAchievement> studyAchievements, List<StudyTaskResponse> studyTasks) {
+        List<StudyTaskResponse> assignments = studyTasks.stream()
+                .filter(studyTaskResponse -> studyTaskResponse.taskType() == ASSIGNMENT)
                 .toList();
 
-        List<StudyTodoResponse> attendances = studyTodos.stream()
-                .filter(studyTodoResponse -> studyTodoResponse.todoType() == ATTENDANCE)
+        List<StudyTaskResponse> attendances = studyTasks.stream()
+                .filter(studyTaskResponse -> studyTaskResponse.taskType() == ATTENDANCE)
                 .toList();
 
         long successAssignmentsCount = countAssignmentByStatus(assignments, SUCCESS);
@@ -50,7 +50,7 @@ public record StudyStudentResponse(
                 studyHistory.getStudyHistoryStatus(),
                 isOutstandingStudent(FIRST_ROUND_OUTSTANDING_STUDENT, studyAchievements),
                 isOutstandingStudent(SECOND_ROUND_OUTSTANDING_STUDENT, studyAchievements),
-                studyTodos,
+                studyTasks,
                 calculateRateOrZero(successAssignmentsCount, assignments.size() - cancelledAssignmentsCount),
                 calculateRateOrZero(attendedCount, attendances.size() - cancelledAttendanceCount));
     }
@@ -62,15 +62,15 @@ public record StudyStudentResponse(
     }
 
     private static long countAssignmentByStatus(
-            List<StudyTodoResponse> assignments, AssignmentSubmissionStatusResponse status) {
+            List<StudyTaskResponse> assignments, AssignmentSubmissionStatusResponse status) {
         return assignments.stream()
-                .filter(studyTodoResponse -> studyTodoResponse.assignmentSubmissionStatus() == status)
+                .filter(studyTaskResponse -> studyTaskResponse.assignmentSubmissionStatus() == status)
                 .count();
     }
 
-    private static long countAttendanceByStatus(List<StudyTodoResponse> attendances, AttendanceStatusResponse status) {
+    private static long countAttendanceByStatus(List<StudyTaskResponse> attendances, AttendanceStatusResponse status) {
         return attendances.stream()
-                .filter(studyTodoResponse -> studyTodoResponse.attendanceStatus() == status)
+                .filter(studyTaskResponse -> studyTaskResponse.attendanceStatus() == status)
                 .count();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyTaskResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyTaskResponse.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 public record StudyTaskResponse(
         Long studyDetailId,
         @Schema(description = "현 주차수") Long week,
-        @Schema(description = "할일 타입") StudyTaskType taskType,
+        @Schema(description = "태스크 타입") StudyTaskType taskType,
         @Schema(description = "마감 시각") LocalDateTime deadLine,
         @Schema(description = "출석 상태 (출석타입일 때만 사용)") AttendanceStatusResponse attendanceStatus,
         @Schema(description = "과제 제목 (과제타입일 때만 사용)") String assignmentTitle,

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyTaskResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyTaskResponse.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.study.dto.response;
 
-import static com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse.StudyTodoType.ASSIGNMENT;
-import static com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse.StudyTodoType.ATTENDANCE;
+import static com.gdschongik.gdsc.domain.study.dto.response.StudyTaskResponse.StudyTaskType.ASSIGNMENT;
+import static com.gdschongik.gdsc.domain.study.dto.response.StudyTaskResponse.StudyTaskType.ATTENDANCE;
 
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
 import com.gdschongik.gdsc.domain.study.domain.StudyDetail;
@@ -11,19 +11,18 @@ import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-// todo: 활용이 다양해졌으므로 rename 필요
-public record StudyTodoResponse(
+public record StudyTaskResponse(
         Long studyDetailId,
         @Schema(description = "현 주차수") Long week,
-        @Schema(description = "할일 타입") StudyTodoType todoType,
+        @Schema(description = "할일 타입") StudyTaskType taskType,
         @Schema(description = "마감 시각") LocalDateTime deadLine,
         @Schema(description = "출석 상태 (출석타입일 때만 사용)") AttendanceStatusResponse attendanceStatus,
         @Schema(description = "과제 제목 (과제타입일 때만 사용)") String assignmentTitle,
         @Schema(description = "과제 제출 상태 (과제타입일 때만 사용)") AssignmentSubmissionStatusResponse assignmentSubmissionStatus) {
 
-    public static StudyTodoResponse createAttendanceType(StudyDetail studyDetail, LocalDate now, boolean isAttended) {
+    public static StudyTaskResponse createAttendanceType(StudyDetail studyDetail, LocalDate now, boolean isAttended) {
         if (studyDetail.getCurriculum().isCancelled()) {
-            return new StudyTodoResponse(
+            return new StudyTaskResponse(
                     studyDetail.getId(),
                     studyDetail.getWeek(),
                     ATTENDANCE,
@@ -32,7 +31,7 @@ public record StudyTodoResponse(
                     null,
                     null);
         }
-        return new StudyTodoResponse(
+        return new StudyTaskResponse(
                 studyDetail.getId(),
                 studyDetail.getWeek(),
                 ATTENDANCE,
@@ -42,9 +41,9 @@ public record StudyTodoResponse(
                 null);
     }
 
-    public static StudyTodoResponse createAssignmentType(StudyDetail studyDetail, AssignmentHistory assignmentHistory) {
+    public static StudyTaskResponse createAssignmentType(StudyDetail studyDetail, AssignmentHistory assignmentHistory) {
         if (studyDetail.getAssignment().isCancelled()) {
-            return new StudyTodoResponse(
+            return new StudyTaskResponse(
                     studyDetail.getId(),
                     studyDetail.getWeek(),
                     ASSIGNMENT,
@@ -54,7 +53,7 @@ public record StudyTodoResponse(
                     AssignmentSubmissionStatusResponse.of(null, studyDetail));
         }
 
-        return new StudyTodoResponse(
+        return new StudyTaskResponse(
                 studyDetail.getId(),
                 studyDetail.getWeek(),
                 ASSIGNMENT,
@@ -65,16 +64,16 @@ public record StudyTodoResponse(
     }
 
     public boolean isAttendance() {
-        return todoType == ATTENDANCE;
+        return taskType == ATTENDANCE;
     }
 
     public boolean isAssignment() {
-        return todoType == ASSIGNMENT;
+        return taskType == ASSIGNMENT;
     }
 
     @Getter
     @RequiredArgsConstructor
-    public enum StudyTodoType {
+    public enum StudyTaskType {
         ATTENDANCE("출석"),
         ASSIGNMENT("과제");
 

--- a/src/main/java/com/gdschongik/gdsc/global/util/ExcelUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/ExcelUtil.java
@@ -8,7 +8,7 @@ import com.gdschongik.gdsc.domain.member.domain.Department;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyStudentResponse;
-import com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyTaskResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
 import jakarta.annotation.Nullable;
@@ -90,16 +90,16 @@ public class ExcelUtil {
                     .setCellValue(student.isSecondRoundOutstandingStudent() ? "O" : "X");
             studentRow.createCell(cellIndex.getAndIncrement()).setCellValue(student.attendanceRate());
             studentRow.createCell(cellIndex.getAndIncrement()).setCellValue(student.assignmentRate());
-            student.studyTodos().stream()
-                    .filter(StudyTodoResponse::isAssignment)
-                    .forEach(todo -> studentRow
+            student.studyTasks().stream()
+                    .filter(StudyTaskResponse::isAssignment)
+                    .forEach(task -> studentRow
                             .createCell(cellIndex.getAndIncrement())
-                            .setCellValue(todo.assignmentSubmissionStatus().getValue()));
-            student.studyTodos().stream()
-                    .filter(StudyTodoResponse::isAttendance)
-                    .forEach(todo -> studentRow
+                            .setCellValue(task.assignmentSubmissionStatus().getValue()));
+            student.studyTasks().stream()
+                    .filter(StudyTaskResponse::isAttendance)
+                    .forEach(task -> studentRow
                             .createCell(cellIndex.getAndIncrement())
-                            .setCellValue(todo.attendanceStatus().getValue()));
+                            .setCellValue(task.attendanceStatus().getValue()));
         });
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #795

## 📌 작업 내용 및 특이사항
- #796 에서 언급한것처럼 StudyTodoResponse의 쓰임이 많아져서 이름 변경이 필요합니다.
StudyTaskResponse로 바꾸고 관련 변수들고 todo를 task로 수정했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- "StudyTodoResponse"가 "StudyTaskResponse"로 이름이 변경되어, 학습 관련 작업 처리에서 더 명확한 용어 사용.

- **버그 수정**
	- 관련 메서드에서 "StudyTodoResponse"의 모든 참조가 "StudyTaskResponse"로 업데이트됨.

- **문서화**
	- 엑셀 생성 및 시트 처리 메서드에서 "StudyTaskResponse"를 사용하도록 변경됨.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->