### PR TITLE
refactor: enum 및 변수명 `canceled`로 통일

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyStatus.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public enum StudyStatus {
     NONE("생성"),
     OPEN("개설"),
-    CANCELLED("휴강");
+    CANCELED("휴강");
 
     private final String value;
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
@@ -1,7 +1,6 @@
 package com.gdschongik.gdsc.domain.study.domain.vo;
 
 import static com.gdschongik.gdsc.domain.study.domain.StudyStatus.*;
-import static com.gdschongik.gdsc.domain.study.domain.StudyStatus.CANCELLED;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.study.domain.StudyStatus;
@@ -60,7 +59,7 @@ public class Assignment {
     }
 
     public static Assignment canceled() {
-        return Assignment.builder().status(CANCELLED).build();
+        return Assignment.builder().status(CANCELED).build();
     }
 
     public void validateSubmittable(LocalDateTime now) {
@@ -68,8 +67,8 @@ public class Assignment {
             throw new CustomException(ASSIGNMENT_SUBMIT_NOT_PUBLISHED);
         }
 
-        if (status == CANCELLED) {
-            throw new CustomException(ASSIGNMENT_SUBMIT_CANCELLED);
+        if (status == CANCELED) {
+            throw new CustomException(ASSIGNMENT_SUBMIT_CANCELED);
         }
 
         if (now.isAfter(deadline)) {
@@ -83,8 +82,8 @@ public class Assignment {
         return status == OPEN;
     }
 
-    public boolean isCancelled() {
-        return status == CANCELLED;
+    public boolean isCanceled() {
+        return status == CANCELED;
     }
 
     public boolean isNone() {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Curriculum.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Curriculum.java
@@ -61,7 +61,7 @@ public class Curriculum {
         return status == StudyStatus.OPEN;
     }
 
-    public boolean isCancelled() {
-        return status == StudyStatus.CANCELLED;
+    public boolean isCanceled() {
+        return status == StudyStatus.CANCELED;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmissionStatusResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmissionStatusResponse.java
@@ -11,13 +11,13 @@ public enum AssignmentSubmissionStatusResponse {
     NOT_SUBMITTED("미제출"),
     FAILURE("제출 실패"),
     SUCCESS("제출 성공"),
-    CANCELLED("휴강");
+    CANCELED("휴강");
 
     private final String value;
 
     public static AssignmentSubmissionStatusResponse of(AssignmentHistory assignmentHistory, StudyDetail studyDetail) {
-        if (studyDetail.getAssignment().isCancelled()) {
-            return CANCELLED;
+        if (studyDetail.getAssignment().isCanceled()) {
+            return CANCELED;
         }
         if (assignmentHistory == null) {
             return NOT_SUBMITTED;

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmittableDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AssignmentSubmittableDto.java
@@ -24,8 +24,8 @@ public record AssignmentSubmittableDto(
     public static AssignmentSubmittableDto of(StudyDetail studyDetail, AssignmentHistory assignmentHistory) {
         Assignment assignment = studyDetail.getAssignment();
 
-        if (assignment.isCancelled()) {
-            return cancelledAssignment(studyDetail, assignment);
+        if (assignment.isCanceled()) {
+            return canceledAssignment(studyDetail, assignment);
         }
 
         if (assignmentHistory == null) {
@@ -45,7 +45,7 @@ public record AssignmentSubmittableDto(
                 assignmentHistory.getCommittedAt());
     }
 
-    private static AssignmentSubmittableDto cancelledAssignment(StudyDetail studyDetail, Assignment assignment) {
+    private static AssignmentSubmittableDto canceledAssignment(StudyDetail studyDetail, Assignment assignment) {
         return new AssignmentSubmittableDto(
                 studyDetail.getId(),
                 assignment.getStatus(),

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AttendanceStatusResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/AttendanceStatusResponse.java
@@ -12,13 +12,13 @@ public enum AttendanceStatusResponse {
     ATTENDED("출석"),
     NOT_ATTENDED("미출석"),
     BEFORE_ATTENDANCE("출석전"),
-    CANCELLED("휴강");
+    CANCELED("휴강");
 
     private final String value;
 
     public static AttendanceStatusResponse of(StudyDetail studyDetail, LocalDate now, boolean isAttended) {
-        if (studyDetail.getCurriculum().isCancelled()) {
-            return CANCELLED;
+        if (studyDetail.getCurriculum().isCanceled()) {
+            return CANCELED;
         }
 
         if (studyDetail.getAttendanceDay().isAfter(now)) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyStudentResponse.java
@@ -35,10 +35,10 @@ public record StudyStudentResponse(
                 .toList();
 
         long successAssignmentsCount = countAssignmentByStatus(assignments, SUCCESS);
-        long cancelledAssignmentsCount = countAssignmentByStatus(assignments, CANCELLED);
+        long canceledAssignmentsCount = countAssignmentByStatus(assignments, CANCELED);
 
         long attendedCount = countAttendanceByStatus(attendances, AttendanceStatusResponse.ATTENDED);
-        long cancelledAttendanceCount = countAttendanceByStatus(attendances, AttendanceStatusResponse.CANCELLED);
+        long canceledAttendanceCount = countAttendanceByStatus(attendances, AttendanceStatusResponse.CANCELED);
 
         return new StudyStudentResponse(
                 studyHistory.getStudent().getId(),
@@ -51,8 +51,8 @@ public record StudyStudentResponse(
                 isOutstandingStudent(FIRST_ROUND_OUTSTANDING_STUDENT, studyAchievements),
                 isOutstandingStudent(SECOND_ROUND_OUTSTANDING_STUDENT, studyAchievements),
                 studyTodos,
-                calculateRateOrZero(successAssignmentsCount, assignments.size() - cancelledAssignmentsCount),
-                calculateRateOrZero(attendedCount, attendances.size() - cancelledAttendanceCount));
+                calculateRateOrZero(successAssignmentsCount, assignments.size() - canceledAssignmentsCount),
+                calculateRateOrZero(attendedCount, attendances.size() - canceledAttendanceCount));
     }
 
     private static boolean isOutstandingStudent(

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyTodoResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dto/response/StudyTodoResponse.java
@@ -22,13 +22,13 @@ public record StudyTodoResponse(
         @Schema(description = "과제 제출 상태 (과제타입일 때만 사용)") AssignmentSubmissionStatusResponse assignmentSubmissionStatus) {
 
     public static StudyTodoResponse createAttendanceType(StudyDetail studyDetail, LocalDate now, boolean isAttended) {
-        if (studyDetail.getCurriculum().isCancelled()) {
+        if (studyDetail.getCurriculum().isCanceled()) {
             return new StudyTodoResponse(
                     studyDetail.getId(),
                     studyDetail.getWeek(),
                     ATTENDANCE,
                     null,
-                    AttendanceStatusResponse.CANCELLED,
+                    AttendanceStatusResponse.CANCELED,
                     null,
                     null);
         }
@@ -43,7 +43,7 @@ public record StudyTodoResponse(
     }
 
     public static StudyTodoResponse createAssignmentType(StudyDetail studyDetail, AssignmentHistory assignmentHistory) {
-        if (studyDetail.getAssignment().isCancelled()) {
+        if (studyDetail.getAssignment().isCanceled()) {
             return new StudyTodoResponse(
                     studyDetail.getId(),
                     studyDetail.getWeek(),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -162,7 +162,7 @@ public enum ErrorCode {
     ASSIGNMENT_STUDY_NOT_APPLIED(HttpStatus.CONFLICT, "해당 스터디에 대한 수강신청 기록이 존재하지 않습니다."),
     ASSIGNMENT_SUBMIT_NOT_STARTED(HttpStatus.CONFLICT, "아직 과제가 시작되지 않았습니다."),
     ASSIGNMENT_SUBMIT_NOT_PUBLISHED(HttpStatus.CONFLICT, "아직 과제가 등록되지 않았습니다."),
-    ASSIGNMENT_SUBMIT_CANCELLED(HttpStatus.CONFLICT, "과제 휴강 주간에는 과제를 제출할 수 없습니다."),
+    ASSIGNMENT_SUBMIT_CANCELED(HttpStatus.CONFLICT, "과제 휴강 주간에는 과제를 제출할 수 없습니다."),
     ASSIGNMENT_SUBMIT_DEADLINE_PASSED(HttpStatus.CONFLICT, "과제 마감 기한이 지났습니다."),
 
     // Github

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailServiceTest.java
@@ -40,9 +40,9 @@ public class MentorStudyDetailServiceTest extends IntegrationTest {
             mentorStudyDetailService.cancelStudyAssignment(studyDetail.getId());
 
             // then
-            StudyDetail cancelledStudyDetail =
+            StudyDetail canceledStudyDetail =
                     studyDetailRepository.findById(studyDetail.getId()).get();
-            assertThat(cancelledStudyDetail.getAssignment().getStatus()).isEqualTo(StudyStatus.CANCELLED);
+            assertThat(canceledStudyDetail.getAssignment().getStatus()).isEqualTo(StudyStatus.CANCELED);
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailTest.java
@@ -29,7 +29,7 @@ public class StudyDetailTest {
             studyDetail.cancelAssignment();
 
             // then
-            assertThat(studyDetail.getAssignment().getStatus()).isEqualTo(StudyStatus.CANCELLED);
+            assertThat(studyDetail.getAssignment().getStatus()).isEqualTo(StudyStatus.CANCELED);
         }
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #799

## 📌 작업 내용 및 특이사항
- cancelled와 canceled가 혼용되고 있어서 canceled로 통일했습니다.

## 📝 참고사항
- main으로 머지할 때 db에 enum값 수정해줘야 합니다~

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- "취소됨" 상태를 "취소됨"으로 변경하여 일관성을 유지했습니다.
- **버그 수정**
	- 상태 확인 메서드와 관련된 모든 참조를 "취소됨"에서 "취소됨"으로 업데이트했습니다.
- **문서화**
	- 관련된 모든 변수 및 메서드 이름을 "취소됨"에서 "취소됨"으로 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->