### PR TITLE
feat: 스터디 과제 레포지터리를 수정할 수 있도록 개선

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyHistoryController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyHistoryController.java
@@ -21,7 +21,7 @@ public class StudentStudyHistoryController {
 
     private final StudentStudyHistoryService studentStudyHistoryService;
 
-    @Operation(summary = "레포지토리 입력", description = "레포지토리를 입력합니다. 이미 제출한 과제가 있다면 수정할 수 없습니다.")
+    @Operation(summary = "레포지토리 입력", description = "과제 제출 레포지토리를 입력합니다.")
     @PutMapping("/{studyId}/repository")
     public ResponseEntity<Void> updateRepository(
             @PathVariable Long studyId, @Valid @RequestBody RepositoryUpdateRequest request) throws IOException {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryService.java
@@ -61,12 +61,10 @@ public class StudentStudyHistoryService {
                 .findByStudentAndStudy(currentMember, study)
                 .orElseThrow(() -> new CustomException(STUDY_HISTORY_NOT_FOUND));
 
-        boolean isAnyAssignmentSubmitted =
-                assignmentHistoryRepository.existsSubmittedAssignmentByMemberAndStudy(currentMember, study);
         GHRepository repository = githubClient.getRepository(request.repositoryLink());
         // TODO: GHRepository 등을 wrapper로 감싸서 테스트 가능하도록 변경
         studyHistoryValidator.validateUpdateRepository(
-                isAnyAssignmentSubmitted, String.valueOf(repository.getOwner().getId()), currentMember.getOauthId());
+                String.valueOf(repository.getOwner().getId()), currentMember.getOauthId());
 
         studyHistory.updateRepositoryLink(request.repositoryLink());
         studyHistoryRepository.save(studyHistory);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepository.java
@@ -7,8 +7,6 @@ import java.util.List;
 
 public interface AssignmentHistoryCustomRepository {
 
-    boolean existsSubmittedAssignmentByMemberAndStudy(Member member, Study study);
-
     List<AssignmentHistory> findAssignmentHistoriesByStudentAndStudyId(Member member, Long studyId);
 
     List<AssignmentHistory> findByStudyIdAndMemberIds(Long studyId, List<Long> memberIds);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepository.java
@@ -2,7 +2,6 @@ package com.gdschongik.gdsc.domain.study.dao;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
-import com.gdschongik.gdsc.domain.study.domain.Study;
 import java.util.List;
 
 public interface AssignmentHistoryCustomRepository {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepositoryImpl.java
@@ -17,17 +17,6 @@ public class AssignmentHistoryCustomRepositoryImpl
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public boolean existsSubmittedAssignmentByMemberAndStudy(Member member, Study study) {
-        Integer fetchOne = queryFactory
-                .selectOne()
-                .from(assignmentHistory)
-                .where(eqMember(member), eqStudy(study), isSubmitted())
-                .fetchFirst();
-
-        return fetchOne != null;
-    }
-
-    @Override
     public List<AssignmentHistory> findAssignmentHistoriesByStudentAndStudyId(Member currentMember, Long studyId) {
         return queryFactory
                 .selectFrom(assignmentHistory)

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/AssignmentHistoryCustomRepositoryImpl.java
@@ -5,7 +5,6 @@ import static com.gdschongik.gdsc.domain.study.domain.QStudyDetail.studyDetail;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentHistory;
-import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
@@ -39,13 +39,7 @@ public class StudyHistoryValidator {
         }
     }
 
-    public void validateUpdateRepository(
-            boolean isAnyAssignmentSubmitted, String repositoryOwnerOauthId, String currentMemberOauthId) {
-        // 이미 제출한 과제가 있는 경우
-        if (isAnyAssignmentSubmitted) {
-            throw new CustomException(STUDY_HISTORY_REPOSITORY_NOT_UPDATABLE_ASSIGNMENT_ALREADY_SUBMITTED);
-        }
-
+    public void validateUpdateRepository(String repositoryOwnerOauthId, String currentMemberOauthId) {
         // 레포지토리 소유자가 현 멤버가 아닌 경우
         if (!repositoryOwnerOauthId.equals(currentMemberOauthId)) {
             throw new CustomException(STUDY_HISTORY_REPOSITORY_NOT_UPDATABLE_OWNER_MISMATCH);

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidatorTest.java
@@ -102,24 +102,12 @@ public class StudyHistoryValidatorTest {
     class 레포지토리_입력시 {
 
         @Test
-        void 이미_제출한_과제가_있다면_실패한다() {
-            // given
-            boolean isAnyAssignmentSubmitted = true;
-
-            // when & then
-            assertThatThrownBy(() -> studyHistoryValidator.validateUpdateRepository(
-                            isAnyAssignmentSubmitted, OAUTH_ID, OAUTH_ID))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(STUDY_HISTORY_REPOSITORY_NOT_UPDATABLE_ASSIGNMENT_ALREADY_SUBMITTED.getMessage());
-        }
-
-        @Test
         void 레포지토리의_소유자와_현재_멤버가_일치하지_않는다면_실패한다() {
             // given
             String wrongOauthId = "1234567";
 
             // when & then
-            assertThatThrownBy(() -> studyHistoryValidator.validateUpdateRepository(false, wrongOauthId, OAUTH_ID))
+            assertThatThrownBy(() -> studyHistoryValidator.validateUpdateRepository(wrongOauthId, OAUTH_ID))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(STUDY_HISTORY_REPOSITORY_NOT_UPDATABLE_OWNER_MISMATCH.getMessage());
         }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #811 

## 📌 작업 내용 및 특이사항
- StudyHistoryValidator 내 레포지토리 업데이트 검증 로직에서 이미 제출한 과제 여부 체크 로직 삭제
- 삭제 과정에서 `isAnyAssignmentSubmitted` 변수 제거 및 관련 레포지토리 코드 삭제
- StudyHistoryValidator 이미 제출한 과제 여부 체크 테스트 제거

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- `updateRepository` 메서드의 설명이 명확하게 수정되었습니다.
	- `StudyHistoryValidator`의 `validateUpdateRepository` 메서드에서 불필요한 매개변수가 제거되었습니다.

- **기능 변경**
	- `AssignmentHistoryCustomRepository`에서 제출된 과제가 있는지 확인하는 메서드가 제거되었습니다.
	- `StudyHistoryValidatorTest`에서 관련 테스트 케이스가 삭제되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->