### PR TITLE
feat: 우수 스터디원 처리시 중복된 요청에 대한 검증 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyAchievementService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyAchievementService.java
@@ -9,6 +9,7 @@ import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyRepository;
 import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyAchievement;
+import com.gdschongik.gdsc.domain.study.domain.StudyAchievementValidator;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistoryValidator;
 import com.gdschongik.gdsc.domain.study.domain.StudyValidator;
 import com.gdschongik.gdsc.domain.study.dto.request.OutstandingStudentRequest;
@@ -28,6 +29,7 @@ public class MentorStudyAchievementService {
     private final MemberUtil memberUtil;
     private final StudyValidator studyValidator;
     private final StudyHistoryValidator studyHistoryValidator;
+    private final StudyAchievementValidator studyAchievementValidator;
     private final StudyRepository studyRepository;
     private final StudyHistoryRepository studyHistoryRepository;
     private final StudyAchievementRepository studyAchievementRepository;
@@ -37,12 +39,16 @@ public class MentorStudyAchievementService {
     public void designateOutstandingStudent(Long studyId, OutstandingStudentRequest request) {
         Member currentMember = memberUtil.getCurrentMember();
         Study study = studyRepository.findById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
-        Long countByStudyIdAndStudentIds =
+        long countByStudyIdAndStudentIds =
                 studyHistoryRepository.countByStudyIdAndStudentIds(studyId, request.studentIds());
+        long countStudyAchievementsAlreadyExist =
+                studyAchievementRepository.countByStudyIdAndAchievementTypeAndStudentIds(
+                        studyId, request.achievementType(), request.studentIds());
 
         studyValidator.validateStudyMentor(currentMember, study);
         studyHistoryValidator.validateAppliedToStudy(
                 countByStudyIdAndStudentIds, request.studentIds().size());
+        studyAchievementValidator.validateDesignateOutstandingStudent(countStudyAchievementsAlreadyExist);
 
         List<Member> outstandingStudents = memberRepository.findAllById(request.studentIds());
         List<StudyAchievement> studyAchievements = outstandingStudents.stream()
@@ -60,10 +66,14 @@ public class MentorStudyAchievementService {
         Study study = studyRepository.findById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
         long countByStudyIdAndStudentIds =
                 studyHistoryRepository.countByStudyIdAndStudentIds(studyId, request.studentIds());
+        long countStudyAchievements = studyAchievementRepository.countByStudyIdAndAchievementTypeAndStudentIds(
+                studyId, request.achievementType(), request.studentIds());
 
         studyValidator.validateStudyMentor(currentMember, study);
         studyHistoryValidator.validateAppliedToStudy(
                 countByStudyIdAndStudentIds, request.studentIds().size());
+        studyAchievementValidator.validateWithdrawOutstandingStudent(
+                countStudyAchievements, request.studentIds().size());
 
         studyAchievementRepository.deleteByStudyAndAchievementTypeAndMemberIds(
                 studyId, request.achievementType(), request.studentIds());

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyAchievementService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyAchievementService.java
@@ -41,14 +41,14 @@ public class MentorStudyAchievementService {
         Study study = studyRepository.findById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
         long countByStudyIdAndStudentIds =
                 studyHistoryRepository.countByStudyIdAndStudentIds(studyId, request.studentIds());
-        long countStudyAchievementsAlreadyExist =
+        long studyAchievementsAlreadyExistCount =
                 studyAchievementRepository.countByStudyIdAndAchievementTypeAndStudentIds(
                         studyId, request.achievementType(), request.studentIds());
 
         studyValidator.validateStudyMentor(currentMember, study);
         studyHistoryValidator.validateAppliedToStudy(
                 countByStudyIdAndStudentIds, request.studentIds().size());
-        studyAchievementValidator.validateDesignateOutstandingStudent(countStudyAchievementsAlreadyExist);
+        studyAchievementValidator.validateDesignateOutstandingStudent(studyAchievementsAlreadyExistCount);
 
         List<Member> outstandingStudents = memberRepository.findAllById(request.studentIds());
         List<StudyAchievement> studyAchievements = outstandingStudents.stream()

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyAchievementService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyAchievementService.java
@@ -66,14 +66,10 @@ public class MentorStudyAchievementService {
         Study study = studyRepository.findById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
         long countByStudyIdAndStudentIds =
                 studyHistoryRepository.countByStudyIdAndStudentIds(studyId, request.studentIds());
-        long countStudyAchievements = studyAchievementRepository.countByStudyIdAndAchievementTypeAndStudentIds(
-                studyId, request.achievementType(), request.studentIds());
 
         studyValidator.validateStudyMentor(currentMember, study);
         studyHistoryValidator.validateAppliedToStudy(
                 countByStudyIdAndStudentIds, request.studentIds().size());
-        studyAchievementValidator.validateWithdrawOutstandingStudent(
-                countStudyAchievements, request.studentIds().size());
 
         studyAchievementRepository.deleteByStudyAndAchievementTypeAndMemberIds(
                 studyId, request.achievementType(), request.studentIds());

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAchievementCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAchievementCustomRepository.java
@@ -9,4 +9,7 @@ public interface StudyAchievementCustomRepository {
 
     void deleteByStudyAndAchievementTypeAndMemberIds(
             Long studyId, AchievementType achievementType, List<Long> memberIds);
+
+    long countByStudyIdAndAchievementTypeAndStudentIds(
+            Long studyId, AchievementType achievementType, List<Long> studentIds);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAchievementCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAchievementCustomRepositoryImpl.java
@@ -27,14 +27,29 @@ public class StudyAchievementCustomRepositoryImpl implements StudyAchievementCus
             Long studyId, AchievementType achievementType, List<Long> memberIds) {
         queryFactory
                 .delete(studyAchievement)
-                .where(
-                        eqStudyId(studyId),
-                        studyAchievement.achievementType.eq(achievementType),
-                        studyAchievement.student.id.in(memberIds))
+                .where(eqStudyId(studyId), eqAchievementType(achievementType), containsStudentId(memberIds))
                 .execute();
+    }
+
+    @Override
+    public long countByStudyIdAndAchievementTypeAndStudentIds(
+            Long studyId, AchievementType achievementType, List<Long> studentIds) {
+        return (long) queryFactory
+                .select(studyAchievement.count())
+                .from(studyAchievement)
+                .where(eqStudyId(studyId), eqAchievementType(achievementType), containsStudentId(studentIds))
+                .fetchOne();
     }
 
     private BooleanExpression eqStudyId(Long studyId) {
         return studyId != null ? studyAchievement.study.id.eq(studyId) : null;
+    }
+
+    private BooleanExpression eqAchievementType(AchievementType achievementType) {
+        return achievementType != null ? studyAchievement.achievementType.eq(achievementType) : null;
+    }
+
+    private BooleanExpression containsStudentId(List<Long> memberIds) {
+        return memberIds != null ? studyAchievement.student.id.in(memberIds) : null;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAchievementCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyAchievementCustomRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.gdschongik.gdsc.domain.study.domain.StudyAchievement;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -34,11 +35,11 @@ public class StudyAchievementCustomRepositoryImpl implements StudyAchievementCus
     @Override
     public long countByStudyIdAndAchievementTypeAndStudentIds(
             Long studyId, AchievementType achievementType, List<Long> studentIds) {
-        return (long) queryFactory
+        return Objects.requireNonNull(queryFactory
                 .select(studyAchievement.count())
                 .from(studyAchievement)
                 .where(eqStudyId(studyId), eqAchievementType(achievementType), containsStudentId(studentIds))
-                .fetchOne();
+                .fetchOne());
     }
 
     private BooleanExpression eqStudyId(Long studyId) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAchievementValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAchievementValidator.java
@@ -14,11 +14,4 @@ public class StudyAchievementValidator {
             throw new CustomException(STUDY_ACHIEVEMENT_ALREADY_EXISTS);
         }
     }
-
-    public void validateWithdrawOutstandingStudent(long countStudyAchievements, long countRequestedStudent) {
-        // 요청한 우수 스터디원 수와 실제 우수 스터디원 수가 다른 경우
-        if (countStudyAchievements != countRequestedStudent) {
-            throw new CustomException(STUDY_ACHIEVEMENT_COUNT_MISMATCH);
-        }
-    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAchievementValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAchievementValidator.java
@@ -1,0 +1,24 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.global.annotation.DomainService;
+import com.gdschongik.gdsc.global.exception.CustomException;
+
+@DomainService
+public class StudyAchievementValidator {
+
+    public void validateDesignateOutstandingStudent(long countStudyAchievementsAlreadyExist) {
+        // 이미 우수 스터디원으로 지정된 스터디원이 있는 경우
+        if (countStudyAchievementsAlreadyExist > 0) {
+            throw new CustomException(STUDY_ACHIEVEMENT_ALREADY_EXISTS);
+        }
+    }
+
+    public void validateWithdrawOutstandingStudent(long countStudyAchievements, long countRequestedStudent) {
+        // 요청한 우수 스터디원 수와 실제 우수 스터디원 수가 다른 경우
+        if (countStudyAchievements != countRequestedStudent) {
+            throw new CustomException(STUDY_ACHIEVEMENT_COUNT_MISMATCH);
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -128,6 +128,10 @@ public enum ErrorCode {
     // StudyAnnouncement
     STUDY_ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 공지입니다."),
 
+    // StudyAchievement
+    STUDY_ACHIEVEMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 우수 스터디원으로 지정된 스터디원이 존재합니다."),
+    STUDY_ACHIEVEMENT_COUNT_MISMATCH(HttpStatus.CONFLICT, "요청한 우수 스터디원 수와 실제 우수 스터디원 수가 다릅니다."),
+
     // Attendance
     ATTENDANCE_DATE_INVALID(HttpStatus.CONFLICT, "강의일이 아니면 출석체크할 수 없습니다."),
     ATTENDANCE_NUMBER_MISMATCH(HttpStatus.CONFLICT, "출석번호가 일치하지 않습니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -130,7 +130,6 @@ public enum ErrorCode {
 
     // StudyAchievement
     STUDY_ACHIEVEMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 우수 스터디원으로 지정된 스터디원이 존재합니다."),
-    STUDY_ACHIEVEMENT_COUNT_MISMATCH(HttpStatus.CONFLICT, "요청한 우수 스터디원 수와 실제 우수 스터디원 수가 다릅니다."),
 
     // Attendance
     ATTENDANCE_DATE_INVALID(HttpStatus.CONFLICT, "강의일이 아니면 출석체크할 수 없습니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #821

## 📌 작업 내용 및 특이사항
- 우수 스터디원으로 지정하면 StudyAchievement 테이블에 하나의 레코드가 추가됩니다.
따닥 방지용으로 Unique Constraint 걸어뒀는데, 이게 따닥을 막는 과정에서 500 에러를 던지고 있습니다.
- 우수 스터디원 처리시 처리하고 싶은 멤버들의 Id 리스트를 받는데, 이미 지정된게 하나라도 있으면 예외를 발생하도록 검증을 추가했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 학생의 우수성을 지정하기 위한 검증 로직 추가.
	- 새로운 메서드가 추가되어 특정 조건에 따른 성취 기록 수를 계산.
	- 새로운 클래스 `StudyAchievementValidator`가 도입되어 우수 학생 지정을 위한 검증 기능 제공.
	- 새로운 오류 코드 `STUDY_ACHIEVEMENT_ALREADY_EXISTS` 추가.

- **버그 수정**
	- 성취 기록 삭제 메서드의 쿼리 조건 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->