### PR TITLE
refactor: now를 도메인 밖에서 주입하도록 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
@@ -83,9 +83,9 @@ public class IssuedCoupon extends BaseEntity {
 
     // 상태 변경 로직
 
-    public void use() {
+    public void use(LocalDateTime now) {
         validateUsable();
-        usedAt = LocalDateTime.now();
+        usedAt = now;
     }
 
     public void revoke() {

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
@@ -19,6 +19,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import org.hibernate.annotations.Comment;
 
 @Entity
@@ -83,7 +84,7 @@ public class IssuedCoupon extends BaseEntity {
 
     // 상태 변경 로직
 
-    public void use(LocalDateTime now) {
+    public void use(@NonNull LocalDateTime now) {
         validateUsable();
         usedAt = now;
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -18,6 +18,7 @@ import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.global.util.EnvironmentUtil;
 import com.gdschongik.gdsc.global.util.ExcelUtil;
 import com.gdschongik.gdsc.global.util.MemberUtil;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -74,7 +75,7 @@ public class AdminMemberService {
         List<RecruitmentRound> recruitmentRounds = recruitmentRoundRepository.findAllByAcademicYearAndSemesterType(
                 request.academicYear(), request.semesterType());
 
-        memberValidator.validateMemberDemote(recruitmentRounds);
+        memberValidator.validateMemberDemote(recruitmentRounds, LocalDateTime.now());
 
         List<Member> regularMembers = memberRepository.findAllByRole(MemberRole.REGULAR);
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -74,8 +74,9 @@ public class AdminMemberService {
     public void demoteAllRegularMembersToAssociate(MemberDemoteRequest request) {
         List<RecruitmentRound> recruitmentRounds = recruitmentRoundRepository.findAllByAcademicYearAndSemesterType(
                 request.academicYear(), request.semesterType());
+        LocalDateTime now = LocalDateTime.now();
 
-        memberValidator.validateMemberDemote(recruitmentRounds, LocalDateTime.now());
+        memberValidator.validateMemberDemote(recruitmentRounds, now);
 
         List<Member> regularMembers = memberRepository.findAllByRole(MemberRole.REGULAR);
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -280,8 +280,8 @@ public class Member extends BaseEntity {
 
     // 기타 상태 변경 로직
 
-    public void updateLastLoginAt() {
-        this.lastLoginAt = LocalDateTime.now();
+    public void updateLastLoginAt(LocalDateTime now) {
+        this.lastLoginAt = now;
     }
 
     public void updateDiscordId(String discordId) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberValidator.java
@@ -5,12 +5,13 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @DomainService
 public class MemberValidator {
 
-    public void validateMemberDemote(List<RecruitmentRound> recruitmentRounds) {
+    public void validateMemberDemote(List<RecruitmentRound> recruitmentRounds, LocalDateTime now) {
 
         // 해당 학기에 모집회차가 존재하는지 검증
         if (recruitmentRounds.isEmpty()) {
@@ -18,6 +19,6 @@ public class MemberValidator {
         }
 
         // 해당 학기의 모든 모집회차가 아직 시작되지 않았는지 검증
-        recruitmentRounds.forEach(RecruitmentRound::validatePeriodNotStarted);
+        recruitmentRounds.forEach(recruitmentRound -> recruitmentRound.validatePeriodNotStarted(now));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
@@ -1,7 +1,6 @@
 package com.gdschongik.gdsc.domain.order.application;
 
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
-import static java.time.LocalDateTime.*;
 
 import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.coupon.dao.IssuedCouponRepository;
@@ -24,6 +23,7 @@ import com.gdschongik.gdsc.infra.feign.payment.client.PaymentClient;
 import com.gdschongik.gdsc.infra.feign.payment.dto.request.PaymentCancelRequest;
 import com.gdschongik.gdsc.infra.feign.payment.dto.request.PaymentConfirmRequest;
 import com.gdschongik.gdsc.infra.feign.payment.dto.response.PaymentResponse;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -94,8 +94,10 @@ public class OrderService {
         var paymentRequest = new PaymentConfirmRequest(request.paymentKey(), order.getNanoId(), request.amount());
         PaymentResponse response = paymentClient.confirm(paymentRequest);
 
+        LocalDateTime now = LocalDateTime.now();
+
         order.complete(request.paymentKey(), response.approvedAt());
-        optionalIssuedCoupon.ifPresent(issuedCoupon -> issuedCoupon.use(now()));
+        optionalIssuedCoupon.ifPresent(issuedCoupon -> issuedCoupon.use(now));
 
         orderRepository.save(order);
 
@@ -164,8 +166,10 @@ public class OrderService {
 
         orderValidator.validateFreeOrderCreate(membership, optionalIssuedCoupon, currentMember);
 
+        LocalDateTime now = LocalDateTime.now();
+
         Order order = Order.createFree(request.orderNanoId(), membership, optionalIssuedCoupon.orElse(null), moneyInfo);
-        optionalIssuedCoupon.ifPresent(issuedCoupon -> issuedCoupon.use(now()));
+        optionalIssuedCoupon.ifPresent(issuedCoupon -> issuedCoupon.use(now));
 
         orderRepository.save(order);
 

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -100,13 +100,9 @@ public class AdminRecruitmentService {
 
         recruitmentRounds.remove(recruitmentRound);
 
+        LocalDateTime now = LocalDateTime.now();
         recruitmentRoundValidator.validateRecruitmentRoundUpdate(
-                request.startDate(),
-                request.endDate(),
-                LocalDateTime.now(),
-                request.roundType(),
-                recruitmentRound,
-                recruitmentRounds);
+                request.startDate(), request.endDate(), now, request.roundType(), recruitmentRound, recruitmentRounds);
 
         recruitmentRound.updateRecruitmentRound(
                 request.name(), Period.of(request.startDate(), request.endDate()), request.roundType());

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -16,6 +16,7 @@ import com.gdschongik.gdsc.domain.recruitment.dto.request.RecruitmentRoundUpdate
 import com.gdschongik.gdsc.domain.recruitment.dto.response.AdminRecruitmentResponse;
 import com.gdschongik.gdsc.domain.recruitment.dto.response.AdminRecruitmentRoundResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -100,7 +101,12 @@ public class AdminRecruitmentService {
         recruitmentRounds.remove(recruitmentRound);
 
         recruitmentRoundValidator.validateRecruitmentRoundUpdate(
-                request.startDate(), request.endDate(), request.roundType(), recruitmentRound, recruitmentRounds);
+                request.startDate(),
+                request.endDate(),
+                LocalDateTime.now(),
+                request.roundType(),
+                recruitmentRound,
+                recruitmentRounds);
 
         recruitmentRound.updateRecruitmentRound(
                 request.name(), Period.of(request.startDate(), request.endDate()), request.roundType());

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
@@ -84,8 +84,7 @@ public class RecruitmentRound extends BaseSemesterEntity {
         this.roundType = roundType;
     }
 
-    public void validatePeriodNotStarted() {
-        LocalDateTime now = LocalDateTime.now();
+    public void validatePeriodNotStarted(LocalDateTime now) {
         if (now.isAfter(period.getStartDate())) {
             throw new CustomException(RECRUITMENT_ROUND_STARTDATE_ALREADY_PASSED);
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidator.java
@@ -34,6 +34,7 @@ public class RecruitmentRoundValidator {
     public void validateRecruitmentRoundUpdate(
             LocalDateTime startDate,
             LocalDateTime endDate,
+            LocalDateTime now,
             RoundType roundType,
             RecruitmentRound currentRecruitmentRound,
             List<RecruitmentRound> otherRecruitmentRounds) {
@@ -41,7 +42,7 @@ public class RecruitmentRoundValidator {
         validatePeriodOverlap(otherRecruitmentRounds, startDate, endDate);
         validateRoundOverlap(otherRecruitmentRounds, roundType);
         validateRoundOneToTwo(currentRecruitmentRound.getRoundType(), roundType);
-        currentRecruitmentRound.validatePeriodNotStarted();
+        currentRecruitmentRound.validatePeriodNotStarted(now);
     }
 
     private void validatePeriodWithinTwoWeeks(LocalDateTime startDate, LocalDateTime endDate, Recruitment recruitment) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
@@ -23,6 +23,7 @@ import com.gdschongik.gdsc.domain.study.dto.response.StudyWeekStatisticsResponse
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -79,7 +80,7 @@ public class MentorStudyDetailService {
                 .findById(studyDetailId)
                 .orElseThrow(() -> new CustomException(STUDY_DETAIL_NOT_FOUND));
 
-        studyDetailValidator.validatePublishStudyAssignment(currentMember, studyDetail, request);
+        studyDetailValidator.validatePublishStudyAssignment(currentMember, studyDetail, request, LocalDateTime.now());
 
         studyDetail.publishAssignment(request.title(), request.deadLine(), request.descriptionNotionLink());
         StudyDetail savedStudyDetail = studyDetailRepository.save(studyDetail);
@@ -96,7 +97,7 @@ public class MentorStudyDetailService {
                 .findById(studyDetailId)
                 .orElseThrow(() -> new CustomException(STUDY_DETAIL_NOT_FOUND));
 
-        studyDetailValidator.validateUpdateStudyAssignment(currentMember, studyDetail, request);
+        studyDetailValidator.validateUpdateStudyAssignment(currentMember, studyDetail, request, LocalDateTime.now());
 
         studyDetail.updateAssignment(request.title(), request.deadLine(), request.descriptionNotionLink());
         StudyDetail savedStudyDetail = studyDetailRepository.save(studyDetail);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyDetailService.java
@@ -79,8 +79,9 @@ public class MentorStudyDetailService {
         StudyDetail studyDetail = studyDetailRepository
                 .findById(studyDetailId)
                 .orElseThrow(() -> new CustomException(STUDY_DETAIL_NOT_FOUND));
+        LocalDateTime now = LocalDateTime.now();
 
-        studyDetailValidator.validatePublishStudyAssignment(currentMember, studyDetail, request, LocalDateTime.now());
+        studyDetailValidator.validatePublishStudyAssignment(currentMember, studyDetail, request, now);
 
         studyDetail.publishAssignment(request.title(), request.deadLine(), request.descriptionNotionLink());
         StudyDetail savedStudyDetail = studyDetailRepository.save(studyDetail);
@@ -96,8 +97,9 @@ public class MentorStudyDetailService {
         StudyDetail studyDetail = studyDetailRepository
                 .findById(studyDetailId)
                 .orElseThrow(() -> new CustomException(STUDY_DETAIL_NOT_FOUND));
+        LocalDateTime now = LocalDateTime.now();
 
-        studyDetailValidator.validateUpdateStudyAssignment(currentMember, studyDetail, request, LocalDateTime.now());
+        studyDetailValidator.validateUpdateStudyAssignment(currentMember, studyDetail, request, now);
 
         studyDetail.updateAssignment(request.title(), request.deadLine(), request.descriptionNotionLink());
         StudyDetail savedStudyDetail = studyDetailRepository.save(studyDetail);
@@ -116,10 +118,11 @@ public class MentorStudyDetailService {
     @Transactional(readOnly = true)
     public List<StudyMentorAttendanceResponse> getAttendanceNumbers(Long studyId) {
         List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyIdOrderByWeekAsc(studyId);
+        LocalDate now = LocalDate.now();
 
         // 출석일이 오늘 or 오늘이후인 StudyDetail
         return studyDetails.stream()
-                .filter(studyDetail -> studyDetail.isAttendanceDayNotPassed(LocalDate.now()))
+                .filter(studyDetail -> studyDetail.isAttendanceDayNotPassed(now))
                 .map(StudyMentorAttendanceResponse::from)
                 .limit(2)
                 .toList();

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
@@ -67,6 +67,7 @@ public class MentorStudyService {
         Member currentMember = memberUtil.getCurrentMember();
         Study study = studyRepository.findById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
         studyValidator.validateStudyMentor(currentMember, study);
+        LocalDate now = LocalDate.now();
 
         List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyId(studyId);
         Page<StudyHistory> studyHistories = studyHistoryRepository.findByStudyId(studyId, pageable);
@@ -90,7 +91,7 @@ public class MentorStudyService {
             List<StudyTaskResponse> studyTasks = new ArrayList<>();
             studyDetails.forEach(studyDetail -> {
                 studyTasks.add(StudyTaskResponse.createAttendanceType(
-                        studyDetail, LocalDate.now(), isAttended(currentAttendances, studyDetail)));
+                        studyDetail, now, isAttended(currentAttendances, studyDetail)));
                 studyTasks.add(StudyTaskResponse.createAssignmentType(
                         studyDetail, getSubmittedAssignment(currentAssignmentHistories, studyDetail)));
             });
@@ -204,6 +205,7 @@ public class MentorStudyService {
         Member currentMember = memberUtil.getCurrentMember();
         Study study = studyRepository.findById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
         studyValidator.validateStudyMentor(currentMember, study);
+        LocalDate now = LocalDate.now();
 
         List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyId(studyId);
         List<StudyHistory> studyHistories = studyHistoryRepository.findAllByStudyId(studyId);
@@ -227,7 +229,7 @@ public class MentorStudyService {
             List<StudyTaskResponse> studyTasks = new ArrayList<>();
             studyDetails.forEach(studyDetail -> {
                 studyTasks.add(StudyTaskResponse.createAttendanceType(
-                        studyDetail, LocalDate.now(), isAttended(currentAttendances, studyDetail)));
+                        studyDetail, now, isAttended(currentAttendances, studyDetail)));
                 studyTasks.add(StudyTaskResponse.createAssignmentType(
                         studyDetail, getSubmittedAssignment(currentAssignmentHistories, studyDetail)));
             });

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyDetailService.java
@@ -1,7 +1,5 @@
 package com.gdschongik.gdsc.domain.study.application;
 
-import static java.time.LocalDateTime.*;
-
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.dao.AssignmentHistoryRepository;
 import com.gdschongik.gdsc.domain.study.dao.AttendanceRepository;
@@ -16,6 +14,7 @@ import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -41,8 +40,8 @@ public class StudentStudyDetailService {
         List<AssignmentHistory> assignmentHistories =
                 assignmentHistoryRepository.findAssignmentHistoriesByStudentAndStudyId(currentMember, studyId);
         List<StudyDetail> studyDetails = studyDetailRepository.findAllByStudyIdOrderByWeekAsc(studyId).stream()
-                .filter(studyDetail ->
-                        studyDetail.getAssignment().isOpen() && studyDetail.isAssignmentDeadlineRemaining(now()))
+                .filter(studyDetail -> studyDetail.getAssignment().isOpen()
+                        && studyDetail.isAssignmentDeadlineRemaining(LocalDateTime.now()))
                 .toList();
 
         boolean isAnySubmitted = assignmentHistories.stream().anyMatch(AssignmentHistory::isSubmitted);
@@ -74,7 +73,7 @@ public class StudentStudyDetailService {
         // 과제 정보 (오늘이 과제 제출 기간에 포함된 과제 정보)
         studyDetails.stream()
                 .filter(studyDetail -> studyDetail.getAssignment().isOpen()
-                        && studyDetail.getAssignment().isDeadlineRemaining(now()))
+                        && studyDetail.getAssignment().isDeadlineRemaining(LocalDateTime.now()))
                 .forEach(studyDetail -> response.add(StudyTaskResponse.createAssignmentType(
                         studyDetail, getSubmittedAssignment(assignmentHistories, studyDetail))));
         return response;
@@ -92,7 +91,7 @@ public class StudentStudyDetailService {
                         studyDetail,
                         getSubmittedAssignment(assignmentHistories, studyDetail),
                         isAttended(attendances, studyDetail),
-                        now()))
+                        LocalDateTime.now()))
                 .toList();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
@@ -108,10 +108,10 @@ public class StudentStudyService {
     @Transactional(readOnly = true)
     public StudentMyCurrentStudyResponse getMyCurrentStudy() {
         Member currentMember = memberUtil.getCurrentMember();
-        StudyHistory studyHistory = studyHistoryRepository.findAllByStudent(currentMember).stream()
-                .filter(sh -> sh.isWithinApplicationAndCourse(LocalDateTime.now()))
+        StudyHistory currentStudyhistory = studyHistoryRepository.findAllByStudent(currentMember).stream()
+                .filter(studyHistory -> studyHistory.isWithinApplicationAndCourse(LocalDateTime.now()))
                 .findFirst()
                 .orElse(null);
-        return StudentMyCurrentStudyResponse.from(studyHistory);
+        return StudentMyCurrentStudyResponse.from(currentStudyhistory);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
@@ -42,8 +42,9 @@ public class StudentStudyService {
     public StudyApplicableResponse getAllApplicableStudies() {
         Member currentMember = memberUtil.getCurrentMember();
         List<StudyHistory> studyHistories = studyHistoryRepository.findAllByStudent(currentMember);
+        LocalDateTime now = LocalDateTime.now();
         Optional<Study> appliedStudy = studyHistories.stream()
-                .filter(studyHistory -> studyHistory.isWithinApplicationAndCourse(LocalDateTime.now()))
+                .filter(studyHistory -> studyHistory.isWithinApplicationAndCourse(now))
                 .map(StudyHistory::getStudy)
                 .findFirst();
         List<StudyResponse> studyResponses = studyRepository.findAll().stream()
@@ -60,8 +61,9 @@ public class StudentStudyService {
         Member currentMember = memberUtil.getCurrentMember();
 
         List<StudyHistory> currentMemberStudyHistories = studyHistoryRepository.findAllByStudent(currentMember);
+        LocalDateTime now = LocalDateTime.now();
 
-        studyHistoryValidator.validateApplyStudy(study, currentMemberStudyHistories, LocalDateTime.now());
+        studyHistoryValidator.validateApplyStudy(study, currentMemberStudyHistories, now);
 
         StudyHistory studyHistory = StudyHistory.create(currentMember, study);
         studyHistoryRepository.save(studyHistory);
@@ -92,12 +94,13 @@ public class StudentStudyService {
                 .orElseThrow(() -> new CustomException(STUDY_DETAIL_NOT_FOUND));
         final Member currentMember = memberUtil.getCurrentMember();
         final Study study = studyDetail.getStudy();
+        LocalDate now = LocalDate.now();
         final boolean isAlreadyAttended =
                 attendanceRepository.existsByStudentIdAndStudyDetailId(currentMember.getId(), studyDetailId);
         boolean isAppliedToStudy = studyHistoryRepository.existsByStudentAndStudy(currentMember, study);
 
         attendanceValidator.validateAttendance(
-                studyDetail, request.attendanceNumber(), LocalDate.now(), isAlreadyAttended, isAppliedToStudy);
+                studyDetail, request.attendanceNumber(), now, isAlreadyAttended, isAppliedToStudy);
 
         Attendance attendance = Attendance.of(currentMember, studyDetail);
         attendanceRepository.save(attendance);
@@ -108,8 +111,9 @@ public class StudentStudyService {
     @Transactional(readOnly = true)
     public StudentMyCurrentStudyResponse getMyCurrentStudy() {
         Member currentMember = memberUtil.getCurrentMember();
+        LocalDateTime now = LocalDateTime.now();
         StudyHistory currentStudyhistory = studyHistoryRepository.findAllByStudent(currentMember).stream()
-                .filter(studyHistory -> studyHistory.isWithinApplicationAndCourse(LocalDateTime.now()))
+                .filter(studyHistory -> studyHistory.isWithinApplicationAndCourse(now))
                 .findFirst()
                 .orElse(null);
         return StudentMyCurrentStudyResponse.from(currentStudyhistory);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
@@ -17,6 +17,7 @@ import com.gdschongik.gdsc.domain.study.dto.response.StudyResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +43,7 @@ public class StudentStudyService {
         Member currentMember = memberUtil.getCurrentMember();
         List<StudyHistory> studyHistories = studyHistoryRepository.findAllByStudent(currentMember);
         Optional<Study> appliedStudy = studyHistories.stream()
-                .filter(StudyHistory::isWithinApplicationAndCourse)
+                .filter(studyHistory -> studyHistory.isWithinApplicationAndCourse(LocalDateTime.now()))
                 .map(StudyHistory::getStudy)
                 .findFirst();
         List<StudyResponse> studyResponses = studyRepository.findAll().stream()
@@ -60,7 +61,7 @@ public class StudentStudyService {
 
         List<StudyHistory> currentMemberStudyHistories = studyHistoryRepository.findAllByStudent(currentMember);
 
-        studyHistoryValidator.validateApplyStudy(study, currentMemberStudyHistories);
+        studyHistoryValidator.validateApplyStudy(study, currentMemberStudyHistories, LocalDateTime.now());
 
         StudyHistory studyHistory = StudyHistory.create(currentMember, study);
         studyHistoryRepository.save(studyHistory);
@@ -108,7 +109,7 @@ public class StudentStudyService {
     public StudentMyCurrentStudyResponse getMyCurrentStudy() {
         Member currentMember = memberUtil.getCurrentMember();
         StudyHistory studyHistory = studyHistoryRepository.findAllByStudent(currentMember).stream()
-                .filter(StudyHistory::isWithinApplicationAndCourse)
+                .filter(sh -> sh.isWithinApplicationAndCourse(LocalDateTime.now()))
                 .findFirst()
                 .orElse(null);
         return StudentMyCurrentStudyResponse.from(studyHistory);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
@@ -175,8 +175,7 @@ public class Study extends BaseSemesterEntity {
         return applicationPeriod.isOpen();
     }
 
-    public boolean isWithinApplicationAndCourse() {
-        LocalDateTime now = LocalDateTime.now();
+    public boolean isWithinApplicationAndCourse(LocalDateTime now) {
         return applicationPeriod.getStartDate().isBefore(now)
                 && period.getEndDate().isAfter(now);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
@@ -97,12 +97,12 @@ public class StudyDetail extends BaseEntity {
 
     // 데이터 전달 로직
 
-    public boolean isAssignmentDeadlineRemaining() {
-        return assignment.isDeadlineRemaining();
+    public boolean isAssignmentDeadlineRemaining(LocalDateTime now) {
+        return assignment.isDeadlineRemaining(now);
     }
 
-    public boolean isAssignmentDeadlineThisWeek() {
-        return assignment.isDeadLineThisWeek();
+    public boolean isAssignmentDeadlineThisWeek(LocalDate now) {
+        return assignment.isDeadLineThisWeek(now);
     }
 
     // 스터디 시작일자 + 현재 주차 * 7 + (스터디 요일 - 스터디 기간 시작 요일)

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailValidator.java
@@ -17,9 +17,9 @@ public class StudyDetailValidator {
     }
 
     public void validatePublishStudyAssignment(
-            Member member, StudyDetail studyDetail, AssignmentCreateUpdateRequest request) {
+            Member member, StudyDetail studyDetail, AssignmentCreateUpdateRequest request, LocalDateTime now) {
         validateStudyMentorAuthorization(member, studyDetail);
-        validateDeadLine(request.deadLine(), studyDetail.getPeriod().getStartDate());
+        validateDeadLine(request.deadLine(), studyDetail.getPeriod().getStartDate(), now);
     }
 
     // 해당 스터디의 멘토가 아니라면 스터디에 대한 권한이 없다.
@@ -29,17 +29,17 @@ public class StudyDetailValidator {
         }
     }
 
-    private void validateDeadLine(LocalDateTime deadline, LocalDateTime studyStartDate) {
-        if (deadline.isBefore(LocalDateTime.now()) || deadline.isBefore(studyStartDate)) {
+    private void validateDeadLine(LocalDateTime deadline, LocalDateTime studyStartDate, LocalDateTime now) {
+        if (deadline.isBefore(now) || deadline.isBefore(studyStartDate)) {
             throw new CustomException(ASSIGNMENT_DEADLINE_INVALID);
         }
     }
 
     public void validateUpdateStudyAssignment(
-            Member currentMember, StudyDetail studyDetail, AssignmentCreateUpdateRequest request) {
+            Member currentMember, StudyDetail studyDetail, AssignmentCreateUpdateRequest request, LocalDateTime now) {
 
         validateStudyMentorAuthorization(currentMember, studyDetail);
-        validateUpdateDeadline(LocalDateTime.now(), studyDetail.getAssignment().getDeadline(), request.deadLine());
+        validateUpdateDeadline(now, studyDetail.getAssignment().getDeadline(), request.deadLine());
     }
 
     /**

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -17,6 +17,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PreRemove;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -86,8 +87,8 @@ public class StudyHistory extends BaseEntity {
     }
 
     // 데이터 전달 로직
-    public boolean isWithinApplicationAndCourse() {
-        return study.isWithinApplicationAndCourse();
+    public boolean isWithinApplicationAndCourse(LocalDateTime now) {
+        return study.isWithinApplicationAndCourse(now);
     }
 
     public boolean isCompleted() {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidator.java
@@ -4,12 +4,13 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @DomainService
 public class StudyHistoryValidator {
 
-    public void validateApplyStudy(Study study, List<StudyHistory> currentMemberStudyHistories) {
+    public void validateApplyStudy(Study study, List<StudyHistory> currentMemberStudyHistories, LocalDateTime now) {
         // 이미 해당 스터디에 수강신청한 경우
         boolean isStudyHistoryDuplicate = currentMemberStudyHistories.stream()
                 .anyMatch(studyHistory -> studyHistory.getStudy().equals(study));
@@ -24,8 +25,8 @@ public class StudyHistoryValidator {
         }
 
         // 이미 듣고 있는 스터디가 있는 경우
-        boolean hasAppliedStudy =
-                currentMemberStudyHistories.stream().anyMatch(StudyHistory::isWithinApplicationAndCourse);
+        boolean hasAppliedStudy = currentMemberStudyHistories.stream()
+                .anyMatch(studyHistory -> studyHistory.isWithinApplicationAndCourse(now));
 
         if (hasAppliedStudy) {
             throw new CustomException(STUDY_HISTORY_ONGOING_ALREADY_EXISTS);

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/vo/Assignment.java
@@ -90,15 +90,12 @@ public class Assignment {
         return status == NONE;
     }
 
-    public boolean isDeadlineRemaining() {
-        LocalDateTime now = LocalDateTime.now();
+    public boolean isDeadlineRemaining(LocalDateTime now) {
         return now.isBefore(deadline);
     }
 
-    public boolean isDeadLineThisWeek() {
+    public boolean isDeadLineThisWeek(LocalDate now) {
         // 현재 날짜와 마감일의 날짜 부분을 비교할 것이므로 LocalDate로 변환
-        // TODO: now를 내부에서 선언하지 않고 파라미터로 받아서 테스트 가능하도록 변경
-        LocalDate now = LocalDate.now();
         LocalDate startOfWeek = now.with(DayOfWeek.MONDAY); // 이번 주 월요일
         LocalDate endOfWeek = now.with(DayOfWeek.SUNDAY); // 이번 주 일요일
 

--- a/src/main/java/com/gdschongik/gdsc/global/security/CustomUserService.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/CustomUserService.java
@@ -19,9 +19,10 @@ public class CustomUserService extends DefaultOAuth2UserService {
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
+        LocalDateTime now = LocalDateTime.now();
 
         Member member = fetchOrCreate(oAuth2User);
-        member.updateLastLoginAt(LocalDateTime.now());
+        member.updateLastLoginAt(now);
         memberRepository.save(member);
 
         return new CustomOAuth2User(oAuth2User, member);

--- a/src/main/java/com/gdschongik/gdsc/global/security/CustomUserService.java
+++ b/src/main/java/com/gdschongik/gdsc/global/security/CustomUserService.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.global.security;
 
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -20,7 +21,7 @@ public class CustomUserService extends DefaultOAuth2UserService {
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
         Member member = fetchOrCreate(oAuth2User);
-        member.updateLastLoginAt();
+        member.updateLastLoginAt(LocalDateTime.now());
         memberRepository.save(member);
 
         return new CustomOAuth2User(oAuth2User, member);

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/application/CouponServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/application/CouponServiceTest.java
@@ -11,6 +11,7 @@ import com.gdschongik.gdsc.domain.coupon.dto.request.CouponCreateRequest;
 import com.gdschongik.gdsc.domain.coupon.dto.request.CouponIssueRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.IntegrationTest;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -181,7 +182,7 @@ class CouponServiceTest extends IntegrationTest {
             couponService.createIssuedCoupon(issueRequest);
 
             issuedCouponRepository.findById(1L).ifPresent(coupon -> {
-                coupon.use();
+                coupon.use(LocalDateTime.now());
                 issuedCouponRepository.save(coupon);
             });
 

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.*;
 import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -23,9 +24,10 @@ class IssuedCouponTest {
             Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE));
             Member member = Member.createGuest(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
+            LocalDateTime now = LocalDateTime.now();
 
             // when
-            issuedCoupon.use();
+            issuedCoupon.use(now);
 
             // then
             assertThat(issuedCoupon.hasUsed()).isTrue();
@@ -37,10 +39,11 @@ class IssuedCouponTest {
             Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE));
             Member member = Member.createGuest(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
-            issuedCoupon.use();
+            LocalDateTime now = LocalDateTime.now();
+            issuedCoupon.use(now);
 
             // when & then
-            assertThatThrownBy(issuedCoupon::use)
+            assertThatThrownBy(() -> issuedCoupon.use(now))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(COUPON_NOT_USABLE_ALREADY_USED.getMessage());
         }
@@ -52,9 +55,10 @@ class IssuedCouponTest {
             Member member = Member.createGuest(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
             issuedCoupon.revoke();
+            LocalDateTime now = LocalDateTime.now();
 
             // when & then
-            assertThatThrownBy(issuedCoupon::use)
+            assertThatThrownBy(() -> issuedCoupon.use(now))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(COUPON_NOT_USABLE_REVOKED.getMessage());
         }
@@ -97,7 +101,7 @@ class IssuedCouponTest {
             Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE));
             Member member = Member.createGuest(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
-            issuedCoupon.use();
+            issuedCoupon.use(LocalDateTime.now());
 
             // when & then
             assertThatThrownBy(issuedCoupon::revoke)

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
@@ -32,7 +32,7 @@ public class MemberValidatorTest {
             List<RecruitmentRound> recruitmentRounds = List.of(recruitmentRound);
 
             // when & then
-            assertThatThrownBy(() -> memberValidator.validateMemberDemote(recruitmentRounds))
+            assertThatThrownBy(() -> memberValidator.validateMemberDemote(recruitmentRounds, now))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(RECRUITMENT_ROUND_STARTDATE_ALREADY_PASSED.getMessage());
         }
@@ -41,9 +41,10 @@ public class MemberValidatorTest {
         void 해당_학기에_모집회차가_존재하지_않는다면_실패한다() {
             // given
             List<RecruitmentRound> recruitmentRounds = List.of();
+            LocalDateTime now = LocalDateTime.now();
 
             // when & then
-            assertThatThrownBy(() -> memberValidator.validateMemberDemote(recruitmentRounds))
+            assertThatThrownBy(() -> memberValidator.validateMemberDemote(recruitmentRounds, now))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(RECRUITMENT_ROUND_NOT_FOUND.getMessage());
         }

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
@@ -193,7 +193,7 @@ class OrderValidatorTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
-            issuedCoupon.use();
+            issuedCoupon.use(LocalDateTime.now());
 
             MoneyInfo moneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON);
 
@@ -319,7 +319,7 @@ class OrderValidatorTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
-            issuedCoupon.use(); // 쿠폰을 사용 불가능한 상태로 만듦
+            issuedCoupon.use(LocalDateTime.now()); // 쿠폰을 사용 불가능한 상태로 만듦
 
             Order order = Order.createPending(
                     "nanoId", membership, issuedCoupon, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
@@ -553,7 +553,7 @@ class OrderValidatorTest {
                     Money.ZERO);
             Membership membership = createMembership(currentMember, recruitmentRound);
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
-            issuedCoupon.use();
+            issuedCoupon.use(LocalDateTime.now());
             Optional<IssuedCoupon> optionalIssuedCoupon = Optional.of(issuedCoupon);
 
             // when & then

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
@@ -137,7 +137,12 @@ public class RecruitmentRoundValidatorTest {
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundUpdate(
-                            START_DATE, ROUND_TWO_END_DATE, RoundType.SECOND, secondRound, List.of(firstRound)))
+                            START_DATE,
+                            ROUND_TWO_END_DATE,
+                            LocalDateTime.now(),
+                            RoundType.SECOND,
+                            secondRound,
+                            List.of(firstRound)))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(PERIOD_OVERLAP.getMessage());
         }
@@ -158,7 +163,12 @@ public class RecruitmentRoundValidatorTest {
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundUpdate(
-                            ROUND_TWO_START_DATE, ROUND_TWO_END_DATE, ROUND_TYPE, secondRound, List.of(firstRound)))
+                            ROUND_TWO_START_DATE,
+                            ROUND_TWO_END_DATE,
+                            LocalDateTime.now(),
+                            ROUND_TYPE,
+                            secondRound,
+                            List.of(firstRound)))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(RECRUITMENT_ROUND_TYPE_OVERLAP.getMessage());
         }
@@ -175,7 +185,12 @@ public class RecruitmentRoundValidatorTest {
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundUpdate(
-                            START_DATE, LocalDateTime.of(2024, 4, 10, 0, 0), ROUND_TYPE, firstRound, List.of()))
+                            START_DATE,
+                            LocalDateTime.of(2024, 4, 10, 0, 0),
+                            LocalDateTime.now(),
+                            ROUND_TYPE,
+                            firstRound,
+                            List.of()))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(RECRUITMENT_PERIOD_NOT_WITHIN_TWO_WEEKS.getMessage());
         }
@@ -192,7 +207,7 @@ public class RecruitmentRoundValidatorTest {
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundUpdate(
-                            START_DATE, END_DATE, RoundType.SECOND, firstRound, List.of()))
+                            START_DATE, END_DATE, LocalDateTime.now(), RoundType.SECOND, firstRound, List.of()))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ROUND_ONE_DOES_NOT_EXIST.getMessage());
         }
@@ -210,7 +225,7 @@ public class RecruitmentRoundValidatorTest {
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundUpdate(
-                            START_DATE, END_DATE, ROUND_TYPE, recruitmentRound, List.of()))
+                            START_DATE, END_DATE, LocalDateTime.now(), ROUND_TYPE, recruitmentRound, List.of()))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(RECRUITMENT_ROUND_STARTDATE_ALREADY_PASSED.getMessage());
         }

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyDetailValidatorTest.java
@@ -57,8 +57,8 @@ public class StudyDetailValidatorTest {
                     new AssignmentCreateUpdateRequest(ASSIGNMENT_TITLE, DESCRIPTION_LINK, now.plusDays(2));
 
             // when & then
-            assertThatThrownBy(() ->
-                            studyDetailValidator.validatePublishStudyAssignment(anotherMember, studyDetail, request))
+            assertThatThrownBy(() -> studyDetailValidator.validatePublishStudyAssignment(
+                            anotherMember, studyDetail, request, now))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(STUDY_DETAIL_UPDATE_RESTRICTED_TO_MENTOR.getMessage());
         }
@@ -75,7 +75,8 @@ public class StudyDetailValidatorTest {
                     new AssignmentCreateUpdateRequest(ASSIGNMENT_TITLE, DESCRIPTION_LINK, now.minusDays(2));
 
             // when & then
-            assertThatThrownBy(() -> studyDetailValidator.validatePublishStudyAssignment(mentor, studyDetail, request))
+            assertThatThrownBy(() ->
+                            studyDetailValidator.validatePublishStudyAssignment(mentor, studyDetail, request, now))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ASSIGNMENT_DEADLINE_INVALID.getMessage());
         }
@@ -100,8 +101,8 @@ public class StudyDetailValidatorTest {
                     new AssignmentCreateUpdateRequest(ASSIGNMENT_TITLE, DESCRIPTION_LINK, now.plusDays(3));
 
             // when & then
-            assertThatThrownBy(() ->
-                            studyDetailValidator.validateUpdateStudyAssignment(anotherMember, studyDetail, request))
+            assertThatThrownBy(() -> studyDetailValidator.validateUpdateStudyAssignment(
+                            anotherMember, studyDetail, request, now))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(STUDY_DETAIL_UPDATE_RESTRICTED_TO_MENTOR.getMessage());
         }
@@ -124,7 +125,8 @@ public class StudyDetailValidatorTest {
                     new AssignmentCreateUpdateRequest(ASSIGNMENT_TITLE, DESCRIPTION_LINK, assignmentUpdateDate);
 
             // when & then
-            assertThatThrownBy(() -> studyDetailValidator.validateUpdateStudyAssignment(mentor, studyDetail, request))
+            assertThatThrownBy(() -> studyDetailValidator.validateUpdateStudyAssignment(
+                            mentor, studyDetail, request, LocalDateTime.now()))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(STUDY_DETAIL_ASSIGNMENT_INVALID_DEADLINE.getMessage());
         }
@@ -145,7 +147,8 @@ public class StudyDetailValidatorTest {
                     new AssignmentCreateUpdateRequest(ASSIGNMENT_TITLE, DESCRIPTION_LINK, updatedDeadLine);
 
             // when & then
-            assertThatThrownBy(() -> studyDetailValidator.validateUpdateStudyAssignment(mentor, studyDetail, request))
+            assertThatThrownBy(
+                            () -> studyDetailValidator.validateUpdateStudyAssignment(mentor, studyDetail, request, now))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(STUDY_DETAIL_ASSIGNMENT_INVALID_DEADLINE.getMessage());
         }

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryValidatorTest.java
@@ -35,7 +35,7 @@ public class StudyHistoryValidatorTest {
             StudyHistory studyHistory = StudyHistory.create(student, study);
 
             // when & then
-            assertThatThrownBy(() -> studyHistoryValidator.validateApplyStudy(study, List.of(studyHistory)))
+            assertThatThrownBy(() -> studyHistoryValidator.validateApplyStudy(study, List.of(studyHistory), now))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(STUDY_HISTORY_DUPLICATE.getMessage());
         }
@@ -51,7 +51,7 @@ public class StudyHistoryValidatorTest {
             Study study = fixtureHelper.createStudy(mentor, period, applicationPeriod);
 
             // when & then
-            assertThatThrownBy(() -> studyHistoryValidator.validateApplyStudy(study, List.of()))
+            assertThatThrownBy(() -> studyHistoryValidator.validateApplyStudy(study, List.of(), now))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(STUDY_NOT_APPLICABLE.getMessage());
         }
@@ -72,7 +72,7 @@ public class StudyHistoryValidatorTest {
             StudyHistory studyHistory = StudyHistory.create(student, anotherStudy);
 
             // when & then
-            assertThatThrownBy(() -> studyHistoryValidator.validateApplyStudy(study, List.of(studyHistory)))
+            assertThatThrownBy(() -> studyHistoryValidator.validateApplyStudy(study, List.of(studyHistory), now))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(STUDY_HISTORY_ONGOING_ALREADY_EXISTS.getMessage());
         }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #815

## 📌 작업 내용 및 특이사항
- 도메인에서 `LocalDate.now()`나 `LocalDateTime.now()`를 직접 호출하지 않고 받아서 쓰도록 수정했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 쿠폰, 멤버, 스터디, 모집 라운드 등 다양한 도메인에서 시간 기반 유효성 검사 로직 개선
	- 메서드들이 현재 시간을 외부에서 주입할 수 있도록 변경되어 테스트 용이성 향상

- **버그 수정**
	- 시간 관련 검증 로직의 유연성을 높여 더 정확한 상태 체크 가능
	- 메서드들이 하드코딩된 현재 시간 대신 파라미터로 시간을 받도록 변경

- **리팩토링**
	- 도메인 클래스의 메서드 시그니처를 일관되게 업데이트
	- 테스트 가능성을 개선하기 위해 시간 관련 로직 재설계

<!-- end of auto-generated comment: release notes by coderabbit.ai -->