### PR TITLE
chore: log level info 로 변경 및 stack trace 제거

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/GlobalExceptionHandler.java
@@ -17,19 +17,19 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
-        log.error("CustomException : {}", e.getMessage(), e);
+        log.info("CustomException : {}", e.getMessage());
         return ResponseEntity.status(e.getErrorCode().getStatus()).body(ErrorResponse.of(e.getErrorCode()));
     }
 
     @ExceptionHandler(CustomPaymentException.class)
     public ResponseEntity<ErrorResponse> handleCustomPaymentException(CustomPaymentException e) {
-        log.error("CustomPaymentException : {}, {}", e.getCode(), e.getMessage());
+        log.info("CustomPaymentException : {}, {}", e.getCode(), e.getMessage());
         return ResponseEntity.status(e.getStatus()).body(ErrorResponse.of(e.getCode(), e.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
-        log.error("INTERNAL_SERVER_ERROR : {}", e.getMessage(), e);
+        log.error("INTERNAL_SERVER_ERROR : {}", e.getMessage());
         return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
                 .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
     }
@@ -37,7 +37,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(
             MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        log.error("METHOD_ARGUMENT_NOT_VALID : {}", e.getMessage(), e);
+        log.info("METHOD_ARGUMENT_NOT_VALID : {}", e.getMessage());
         String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
         return ResponseEntity.status(status.value())
                 .body(ErrorResponse.of(ErrorCode.METHOD_ARGUMENT_NOT_VALID, errorMessage));


### PR DESCRIPTION
## 🌱 관련 이슈
- close #823 

## 📌 작업 내용 및 특이사항
- 에러 로그 출력 부분에서 stack trace 제거
- 의도된 에러에 대한 로깅 레벨을 info 로 처리

## 📝 참고사항
- 로깅과 sentry 에 대해 이것 저것 알아보고 테스트 해보느라 시간이 걸렸습니다..
  예상가능한 에러에 대해서는 info 레벨로 로깅하는 것이 일반적이라고 하여 로깅 레벨을 변경하고 센트리는 기존대로 erorr 레벨에 대해 알림을 받도록 하였습니다. internal server error 에 대해서만 error 레벨을 유지했는데, 여기에서도 스택 트레이스를 제거하면 정보를 센트리에서 확인하지 못할까 싶어서 찾아보고  테스트해봤는데, stack trace 에 대한 출력 없이도 sentry 에서 stack trace 조회가 가능하여 error 레벨에서도 스택 트레이스  출력을 제거 했습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
	- 예외 처리 로깅 레벨을 오류(error)에서 정보(info)로 변경
	- 다양한 예외 핸들러의 로그 심각도 수준 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->