### PR TITLE
feat: 스터디 수료 시 회비 할인 쿠폰 발급 기능 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponEventHandler.java
@@ -1,0 +1,23 @@
+package com.gdschongik.gdsc.domain.coupon.application;
+
+import com.gdschongik.gdsc.domain.study.domain.StudyHistoriesCompletedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponEventHandler {
+    // TODO: 여기서는 쿠폰 외 도메인의 이벤트를 받아서 쿠폰 서비스를 호출. 다른 핸들러는 반대로 되어있으므로 수정 필요
+
+    private final CouponService couponService;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleStudyHistoryCompletedEvent(StudyHistoriesCompletedEvent event) {
+        log.info("[CouponEventHandler] 스터디 수료 이벤트 수신: studyHistoryIds={}", event.studyHistoryIds());
+        couponService.createAndIssueCouponByStudyHistories(event.studyHistoryIds());
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/util/CouponNameUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/util/CouponNameUtil.java
@@ -1,0 +1,16 @@
+package com.gdschongik.gdsc.domain.coupon.util;
+
+import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.global.util.formatter.SemesterFormatter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CouponNameUtil {
+
+    public String generateStudyCompletionCouponName(Study study) {
+        String academicYearAndSemesterName = SemesterFormatter.format(study);
+        return academicYearAndSemesterName + " " + study.getTitle() + " 수료 쿠폰";
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyHistoryService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyHistoryService.java
@@ -43,6 +43,8 @@ public class MentorStudyHistoryService {
 
         studyHistories.forEach(StudyHistory::complete);
 
+        studyHistoryRepository.saveAll(studyHistories);
+
         log.info(
                 "[MentorStudyHistoryService] 스터디 수료 처리: studyId={}, studentIds={}",
                 request.studyId(),
@@ -62,6 +64,8 @@ public class MentorStudyHistoryService {
                 studyHistories.size(), request.studentIds().size());
 
         studyHistories.forEach(StudyHistory::withdrawCompletion);
+
+        studyHistoryRepository.saveAll(studyHistories);
 
         log.info(
                 "[MentorStudyHistoryService] 스터디 수료 철회: studyId={}, studentIds={}",

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyHistoryService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyHistoryService.java
@@ -6,6 +6,7 @@ import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyRepository;
 import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.domain.study.domain.StudyHistoriesCompletedEvent;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistoryValidator;
 import com.gdschongik.gdsc.domain.study.domain.StudyValidator;
@@ -15,6 +16,7 @@ import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MentorStudyHistoryService {
 
+    private final ApplicationEventPublisher applicationEventPublisher;
     private final MemberUtil memberUtil;
     private final StudyValidator studyValidator;
     private final StudyHistoryValidator studyHistoryValidator;
@@ -43,7 +46,8 @@ public class MentorStudyHistoryService {
 
         studyHistories.forEach(StudyHistory::complete);
 
-        studyHistoryRepository.saveAll(studyHistories);
+        applicationEventPublisher.publishEvent(new StudyHistoriesCompletedEvent(
+                studyHistories.stream().map(StudyHistory::getId).toList()));
 
         log.info(
                 "[MentorStudyHistoryService] 스터디 수료 처리: studyId={}, studentIds={}",

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoriesCompletedEvent.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoriesCompletedEvent.java
@@ -1,0 +1,6 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+import java.util.List;
+import lombok.NonNull;
+
+public record StudyHistoriesCompletedEvent(@NonNull List<Long> studyHistoryIds) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -77,7 +77,6 @@ public class StudyHistory extends BaseEntity {
      */
     public void complete() {
         studyHistoryStatus = COMPLETED;
-        registerEvent(new StudyHistoryCompletedEvent(this.id));
     }
 
     /**

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -84,6 +84,7 @@ public class StudyHistory extends BaseEntity {
      */
     public void withdrawCompletion() {
         studyHistoryStatus = NONE;
+        registerEvent(new StudyHistoryCompletionWithdrawnEvent(this.id));
     }
 
     // 데이터 전달 로직

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -76,6 +76,7 @@ public class StudyHistory extends BaseEntity {
      */
     public void complete() {
         studyHistoryStatus = COMPLETED;
+        registerEvent(new StudyHistoryCompletedEvent(this.id));
     }
 
     /**

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryCompletedEvent.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryCompletedEvent.java
@@ -1,3 +1,0 @@
-package com.gdschongik.gdsc.domain.study.domain;
-
-public record StudyHistoryCompletedEvent(long studyHistoryId) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryCompletedEvent.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryCompletedEvent.java
@@ -1,0 +1,3 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+public record StudyHistoryCompletedEvent(long studyHistoryId) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryCompletionWithdrawnEvent.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryCompletionWithdrawnEvent.java
@@ -1,5 +1,5 @@
 package com.gdschongik.gdsc.domain.study.domain;
 
 public record StudyHistoryCompletionWithdrawnEvent(long studyHistoryId) {
-    // TODO: 이벤트 내부 필드의 식별자 값은 항상 not null이므로, primitive 타입으로 사용하도록 변경1
+    // TODO: 이벤트 내부 필드의 식별자 값은 항상 not null이므로, primitive 타입으로 사용하도록 변경
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryCompletionWithdrawnEvent.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryCompletionWithdrawnEvent.java
@@ -1,0 +1,5 @@
+package com.gdschongik.gdsc.domain.study.domain;
+
+public record StudyHistoryCompletionWithdrawnEvent(long studyHistoryId) {
+    // TODO: 이벤트 내부 필드의 식별자 값은 항상 not null이므로, primitive 타입으로 사용하도록 변경1
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryCompletionWithdrawnEvent.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistoryCompletionWithdrawnEvent.java
@@ -2,4 +2,5 @@ package com.gdschongik.gdsc.domain.study.domain;
 
 public record StudyHistoryCompletionWithdrawnEvent(long studyHistoryId) {
     // TODO: 이벤트 내부 필드의 식별자 값은 항상 not null이므로, primitive 타입으로 사용하도록 변경
+    // TODO: 스터디 철회 시 기존에 발행된 쿠폰 회수하는 로직 구현
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/util/CouponNameUtilTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/util/CouponNameUtilTest.java
@@ -1,0 +1,42 @@
+package com.gdschongik.gdsc.domain.coupon.util;
+
+import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.vo.Period;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.helper.FixtureHelper;
+import org.junit.jupiter.api.Test;
+
+class CouponNameUtilTest {
+
+    CouponNameUtil couponNameUtil = new CouponNameUtil();
+    FixtureHelper fixtureHelper = new FixtureHelper();
+
+    @Test
+    void 스터디_수료_쿠폰_이름이_생성된다() {
+        // given
+        Member mentor = fixtureHelper.createMentor(1L);
+        Study study = Study.create(
+                2025,
+                SemesterType.FIRST,
+                "기초 백엔드 스터디",
+                mentor,
+                STUDY_ONGOING_PERIOD,
+                Period.of(START_DATE.minusDays(10), START_DATE.minusDays(5)),
+                TOTAL_WEEK,
+                ONLINE_STUDY,
+                DAY_OF_WEEK,
+                STUDY_START_TIME,
+                STUDY_END_TIME);
+
+        // when
+        String couponName = couponNameUtil.generateStudyCompletionCouponName(study);
+
+        // then
+        assertThat(couponName).isEqualTo("2025-1 기초 백엔드 스터디 수료 쿠폰");
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #817

## 📌 작업 내용 및 특이사항
- 작업하다가 사이즈가 점점 커지는 것 같아서 일단 컷하고 올립니다... 핵심만 정리해놨으니 체크해주세용
- 먼저 #827 의 내용을 선반영해두었습니다. 해당 내용은 투두 코멘트에서 확인 가능합니다
    - 827 내용 읽기 귀찮으시다면,, 이제 `XXXEventHandler` 와 `XXXService` 가 한 쌍이 된다는 것만 확인해주세요.
- 스터디 수료 이벤트의 경우 각 수료 건이 하나의 이벤트로 처리되지 않고, 묶음 이벤트로 발행됩니다.
    - 처음에는 아무 생각 없이 단건 이벤트로 뽑았는데, 이러면 수료자가 100명이면 이벤트 100개가 한번에 발행되는 거라 이건 좀 아니다 싶었고요,  대신에 하나의 수료 이벤트로 만들고 수료자 멤버 ID 리스트를 내부 필드로 가지기로 했습니다. 이럼 수료자가 많아지더라도 이벤트 하나로 처리 가능합니다. 
- 쿠폰 이름 생성 유틸리티 -> 쿠폰 서비스에 두기엔 뭔가 비즈로직스러워서 유틸리티로 뽑아냈습니다. 일단 테스트도 추가해놨습니다. 

## 📝 참고사항
### 분할 수료 처리에 대한 문제 (1)
- 구현에 따르면 요청이 성공할 때마다 1개의 쿠폰 + i명의 수료자에 대한 i개의 발급쿠폰이 생성됩니다.
- 보통 하나의 스터디에 대하여 하나의 수료 쿠폰만 존재할 것으로 기대됩니다.
- 하지만 n번에 걸쳐 수료 처리를 하게 되면, n개의 쿠폰이 생성됩니다.
- 이러한 상황이 발생하지 않도록 (스터디 - 스터디 쿠폰 ID) 쌍을 저장 후, 없으면 생성하고 / 있으면 해당 쿠폰을 사용하도록 만들어야 합니다.
### 분할 수료 처리에 대한 문제 (2)
- 이를 구현하기 위해서 두 가지 방법을 생각할 수 있습니다.
- 하나는 스터디-쿠폰 중간 테이블을 만드는 것입니다.
    - 장점은 현재 쿠폰 테이블 스키마를 수정할 필요가 없습니다.
    - 단점은 확장성이 떨어집니다. 쿠폰 정책이 추가될 때마다 쿠폰-XX 중간 테이블이 매번 생겨야 합니다.
- 다른 하나는 쿠폰에 발급방식 / 카테고리 / 연관 식별자 등의 필드를 추가하는 것입니다.
    - 기존 수동 발급했던 수료 쿠폰의 경우 `(MANUAL, STUDY, null)` 과 같이 마이그레이션 후, 2번 스터디에 대한 수료 쿠폰의 경우 `(AUTO, STUDY, 2L)` 와 같이 저장하는 것이죠.
    - 특정 스터디에 대하여 대응되는 수료 쿠폰 역시 식별이 가능하므로 문제를 해결할 수 있습니다.
    - 장점은 확장성이 좋습니다. 쿠폰 정책이 많아지더라도 그에 맞춰 카테고리 enum만 늘려주면 된다는 것입니다. 
    - 단점은 초기 스키마 설계가 어렵다는 겁니다.
- 일단은 2번으로 진행해보려고 합니다. *** 
- #839 -> #840 순으로 작업 예정
### 수료 철회 시 발급된 쿠폰 회수
- 보시면 알겠지만 마찬가지로 '이 스터디에 대하여 어떤 쿠폰이 대응되는지' 를 식별할 수 없으면 회수도 불가능합니다.
- #840 -> #841 순으로 작업 예정
- 전부 완료되면 #842 에서 테스트 코드까지 작성해서 마무리할 예정

## 📚 기타
-
