### PR TITLE
feat: 쿠폰 도메인에 메타데이터 필드 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponService.java
@@ -1,6 +1,5 @@
 package com.gdschongik.gdsc.domain.coupon.application;
 
-import static com.gdschongik.gdsc.domain.coupon.domain.IssuanceType.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.vo.Money;
@@ -49,8 +48,8 @@ public class CouponService {
     @Transactional
     public void createCoupon(CouponCreateRequest request) {
         Optional<Study> study = Optional.ofNullable(request.studyId()).flatMap(studyRepository::findById);
-        Coupon coupon = Coupon.create(
-                request.name(), Money.from(request.discountAmount()), request.couponType(), MANUAL, study.orElse(null));
+        Coupon coupon = Coupon.createManual(
+                request.name(), Money.from(request.discountAmount()), request.couponType(), study.orElse(null));
         couponRepository.save(coupon);
         log.info("[CouponService] 쿠폰 생성: name={}, discountAmount={}", request.name(), request.discountAmount());
     }
@@ -112,7 +111,7 @@ public class CouponService {
 
         String couponName = couponNameUtil.generateStudyCompletionCouponName(study);
         // TODO: 요청할 때마다 새로운 쿠폰 생성되는 문제 수정: 스터디마다 하나의 쿠폰만 존재하도록 쿠폰 타입 및 참조 식별자 추가
-        Coupon coupon = Coupon.create(couponName, Money.from(5000L), CouponType.STUDY_COMPLETION, AUTOMATIC, study);
+        Coupon coupon = Coupon.createAutomatic(couponName, Money.from(5000L), CouponType.STUDY_COMPLETION, study);
         couponRepository.save(coupon);
 
         List<IssuedCoupon> issuedCoupons = students.stream()

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponService.java
@@ -50,11 +50,7 @@ public class CouponService {
     public void createCoupon(CouponCreateRequest request) {
         Optional<Study> study = Optional.ofNullable(request.studyId()).flatMap(studyRepository::findById);
         Coupon coupon = Coupon.create(
-                request.name(),
-                Money.from(request.discountAmount()),
-                request.couponType(),
-                AUTOMATIC,
-                study.orElse(null));
+                request.name(), Money.from(request.discountAmount()), request.couponType(), MANUAL, study.orElse(null));
         couponRepository.save(coupon);
         log.info("[CouponService] 쿠폰 생성: name={}, discountAmount={}", request.name(), request.discountAmount());
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponService.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.coupon.application;
 
-import static com.gdschongik.gdsc.domain.coupon.domain.IssuanceMethodType.*;
+import static com.gdschongik.gdsc.domain.coupon.domain.IssuanceType.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.vo.Money;

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponService.java
@@ -1,11 +1,13 @@
 package com.gdschongik.gdsc.domain.coupon.application;
 
+import static com.gdschongik.gdsc.domain.coupon.domain.IssuanceMethodType.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.coupon.dao.CouponRepository;
 import com.gdschongik.gdsc.domain.coupon.dao.IssuedCouponRepository;
 import com.gdschongik.gdsc.domain.coupon.domain.Coupon;
+import com.gdschongik.gdsc.domain.coupon.domain.CouponType;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.coupon.dto.request.CouponCreateRequest;
 import com.gdschongik.gdsc.domain.coupon.dto.request.CouponIssueRequest;
@@ -16,10 +18,13 @@ import com.gdschongik.gdsc.domain.coupon.util.CouponNameUtil;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;
+import com.gdschongik.gdsc.domain.study.dao.StudyRepository;
+import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -36,13 +41,20 @@ public class CouponService {
     private final CouponNameUtil couponNameUtil;
     private final MemberUtil memberUtil;
     private final StudyHistoryRepository studyHistoryRepository;
+    private final StudyRepository studyRepository;
     private final CouponRepository couponRepository;
     private final IssuedCouponRepository issuedCouponRepository;
     private final MemberRepository memberRepository;
 
     @Transactional
     public void createCoupon(CouponCreateRequest request) {
-        Coupon coupon = Coupon.create(request.name(), Money.from(request.discountAmount()));
+        Optional<Study> study = Optional.ofNullable(request.studyId()).flatMap(studyRepository::findById);
+        Coupon coupon = Coupon.create(
+                request.name(),
+                Money.from(request.discountAmount()),
+                request.couponType(),
+                AUTOMATIC,
+                study.orElse(null));
         couponRepository.save(coupon);
         log.info("[CouponService] 쿠폰 생성: name={}, discountAmount={}", request.name(), request.discountAmount());
     }
@@ -100,11 +112,11 @@ public class CouponService {
                 .map(studyHistory -> studyHistory.getStudent().getId())
                 .toList();
         List<Member> students = memberRepository.findAllById(studentIds);
+        Study study = studyHistories.get(0).getStudy();
 
-        String couponName = couponNameUtil.generateStudyCompletionCouponName(
-                studyHistories.get(0).getStudy());
+        String couponName = couponNameUtil.generateStudyCompletionCouponName(study);
         // TODO: 요청할 때마다 새로운 쿠폰 생성되는 문제 수정: 스터디마다 하나의 쿠폰만 존재하도록 쿠폰 타입 및 참조 식별자 추가
-        Coupon coupon = Coupon.create(couponName, Money.from(5000L));
+        Coupon coupon = Coupon.create(couponName, Money.from(5000L), CouponType.STUDY_COMPLETION, AUTOMATIC, study);
         couponRepository.save(coupon);
 
         List<IssuedCoupon> issuedCoupons = students.stream()

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
@@ -41,38 +41,29 @@ public class Coupon extends BaseEntity {
     private CouponType couponType;
 
     @Enumerated(EnumType.STRING)
-    private IssuanceMethodType issuanceMethodType;
+    private IssuanceType issuanceType;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "study_id")
     private Study study;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Coupon(
-            String name,
-            Money discountAmount,
-            CouponType couponType,
-            IssuanceMethodType issuanceMethodType,
-            Study study) {
+    private Coupon(String name, Money discountAmount, CouponType couponType, IssuanceType issuanceType, Study study) {
         this.name = name;
         this.discountAmount = discountAmount;
         this.couponType = couponType;
-        this.issuanceMethodType = issuanceMethodType;
+        this.issuanceType = issuanceType;
         this.study = study;
     }
 
     public static Coupon create(
-            String name,
-            Money discountAmount,
-            CouponType couponType,
-            IssuanceMethodType issuanceMethodType,
-            Study study) {
+            String name, Money discountAmount, CouponType couponType, IssuanceType issuanceType, Study study) {
         validateDiscountAmountPositive(discountAmount);
         return Coupon.builder()
                 .name(name)
                 .discountAmount(discountAmount)
                 .couponType(couponType)
-                .issuanceMethodType(issuanceMethodType)
+                .issuanceType(issuanceType)
                 .study(study)
                 .build();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
@@ -56,14 +56,24 @@ public class Coupon extends BaseEntity {
         this.study = study;
     }
 
-    public static Coupon create(
-            String name, Money discountAmount, CouponType couponType, IssuanceType issuanceType, Study study) {
+    public static Coupon createAutomatic(String name, Money discountAmount, CouponType couponType, Study study) {
         validateDiscountAmountPositive(discountAmount);
         return Coupon.builder()
                 .name(name)
                 .discountAmount(discountAmount)
                 .couponType(couponType)
-                .issuanceType(issuanceType)
+                .issuanceType(IssuanceType.AUTOMATIC)
+                .study(study)
+                .build();
+    }
+
+    public static Coupon createManual(String name, Money discountAmount, CouponType couponType, Study study) {
+        validateDiscountAmountPositive(discountAmount);
+        return Coupon.builder()
+                .name(name)
+                .discountAmount(discountAmount)
+                .couponType(couponType)
+                .issuanceType(IssuanceType.MANUAL)
                 .study(study)
                 .build();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
@@ -4,13 +4,19 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,12 +37,31 @@ public class Coupon extends BaseEntity {
     @Embedded
     private Money discountAmount;
 
+    @Enumerated(EnumType.STRING)
+    private CouponType couponType;
+
+    @Enumerated(EnumType.STRING)
+    private IssuanceMethodType issuanceMethodType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_id")
+    private Study study;
+
     @Builder(access = AccessLevel.PRIVATE)
-    private Coupon(String name, Money discountAmount) {
+    private Coupon(
+            String name,
+            Money discountAmount,
+            CouponType couponType,
+            IssuanceMethodType issuanceMethodType,
+            Study study) {
         this.name = name;
         this.discountAmount = discountAmount;
+        this.couponType = couponType;
+        this.issuanceMethodType = issuanceMethodType;
+        this.study = study;
     }
 
+    // todo: 파라미터 수정 필요. api 수정시 같이 처리
     public static Coupon create(String name, Money discountAmount) {
         validateDiscountAmountPositive(discountAmount);
         return Coupon.builder().name(name).discountAmount(discountAmount).build();

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
@@ -61,10 +61,20 @@ public class Coupon extends BaseEntity {
         this.study = study;
     }
 
-    // todo: 파라미터 수정 필요. api 수정시 같이 처리
-    public static Coupon create(String name, Money discountAmount) {
+    public static Coupon create(
+            String name,
+            Money discountAmount,
+            CouponType couponType,
+            IssuanceMethodType issuanceMethodType,
+            Study study) {
         validateDiscountAmountPositive(discountAmount);
-        return Coupon.builder().name(name).discountAmount(discountAmount).build();
+        return Coupon.builder()
+                .name(name)
+                .discountAmount(discountAmount)
+                .couponType(couponType)
+                .issuanceMethodType(issuanceMethodType)
+                .study(study)
+                .build();
     }
 
     // 검증 로직

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/CouponType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/CouponType.java
@@ -1,0 +1,13 @@
+package com.gdschongik.gdsc.domain.coupon.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CouponType {
+    ADMIN("어드민"),
+    STUDY_COMPLETION("스터디 수료");
+
+    private final String value;
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuanceMethodType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuanceMethodType.java
@@ -1,0 +1,13 @@
+package com.gdschongik.gdsc.domain.coupon.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum IssuanceMethodType {
+    AUTOMATIC("자동 발급"),
+    MANUAL("수동 발급");
+
+    private final String value;
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuanceType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuanceType.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum IssuanceMethodType {
+public enum IssuanceType {
     AUTOMATIC("자동 발급"),
     MANUAL("수동 발급");
 

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/dto/request/CouponCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/dto/request/CouponCreateRequest.java
@@ -1,7 +1,14 @@
 package com.gdschongik.gdsc.domain.coupon.dto.request;
 
+import com.gdschongik.gdsc.domain.coupon.domain.CouponType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
 
-public record CouponCreateRequest(@NotBlank String name, @Positive BigDecimal discountAmount) {}
+public record CouponCreateRequest(
+        @NotBlank String name,
+        @Positive BigDecimal discountAmount,
+        CouponType couponType,
+        @Nullable @Schema(description = "스터디 관련 쿠폰이 아니라면 null을 가집니다.") Long studyId) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/dto/request/CouponCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/dto/request/CouponCreateRequest.java
@@ -4,11 +4,12 @@ import com.gdschongik.gdsc.domain.coupon.domain.CouponType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
 
 public record CouponCreateRequest(
         @NotBlank String name,
         @Positive BigDecimal discountAmount,
-        CouponType couponType,
+        @NotNull(message = "쿠폰 타입은 null이 될 수 없습니다.") CouponType couponType,
         @Nullable @Schema(description = "스터디 관련 쿠폰이 아니라면 null을 가집니다.") Long studyId) {}

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/application/CouponServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/application/CouponServiceTest.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.domain.coupon.application;
 
+import static com.gdschongik.gdsc.domain.coupon.domain.CouponType.*;
 import static com.gdschongik.gdsc.global.common.constant.CouponConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static java.math.BigDecimal.*;
@@ -34,7 +35,7 @@ class CouponServiceTest extends IntegrationTest {
         @Test
         void 성공한다() {
             // given
-            CouponCreateRequest request = new CouponCreateRequest(COUPON_NAME, ONE);
+            CouponCreateRequest request = new CouponCreateRequest(COUPON_NAME, ONE, ADMIN, null);
 
             // when
             couponService.createCoupon(request);
@@ -46,7 +47,7 @@ class CouponServiceTest extends IntegrationTest {
         @Test
         void 할인금액이_양수가_아니라면_실패한다() {
             // given
-            CouponCreateRequest request = new CouponCreateRequest(COUPON_NAME, ZERO);
+            CouponCreateRequest request = new CouponCreateRequest(COUPON_NAME, ZERO, ADMIN, null);
 
             // when & then
             assertThatThrownBy(() -> couponService.createCoupon(request))
@@ -61,7 +62,7 @@ class CouponServiceTest extends IntegrationTest {
         @Test
         void 성공한다() {
             // given
-            CouponCreateRequest request = new CouponCreateRequest(COUPON_NAME, ONE);
+            CouponCreateRequest request = new CouponCreateRequest(COUPON_NAME, ONE, ADMIN, null);
             couponService.createCoupon(request);
 
             createMember();
@@ -79,7 +80,7 @@ class CouponServiceTest extends IntegrationTest {
         @Test
         void 존재하지_않는_유저이면_제외하고_성공한다() {
             // given
-            CouponCreateRequest request = new CouponCreateRequest(COUPON_NAME, ONE);
+            CouponCreateRequest request = new CouponCreateRequest(COUPON_NAME, ONE, ADMIN, null);
             couponService.createCoupon(request);
 
             createMember();
@@ -97,7 +98,7 @@ class CouponServiceTest extends IntegrationTest {
         @Test
         void 존재하지_않는_쿠폰이면_실패한다() {
             // given
-            CouponCreateRequest request = new CouponCreateRequest(COUPON_NAME, ONE);
+            CouponCreateRequest request = new CouponCreateRequest(COUPON_NAME, ONE, ADMIN, null);
             couponService.createCoupon(request);
 
             createMember();
@@ -118,7 +119,7 @@ class CouponServiceTest extends IntegrationTest {
         @Test
         void 성공한다() {
             // given
-            CouponCreateRequest request = new CouponCreateRequest(COUPON_NAME, ONE);
+            CouponCreateRequest request = new CouponCreateRequest(COUPON_NAME, ONE, ADMIN, null);
             couponService.createCoupon(request);
 
             createMember();
@@ -137,7 +138,7 @@ class CouponServiceTest extends IntegrationTest {
         @Test
         void 존재하지_않는_발급쿠폰이면_실패한다() {
             // given
-            CouponCreateRequest request = new CouponCreateRequest(COUPON_NAME, ONE);
+            CouponCreateRequest request = new CouponCreateRequest(COUPON_NAME, ONE, ADMIN, null);
             couponService.createCoupon(request);
 
             createMember();
@@ -153,7 +154,7 @@ class CouponServiceTest extends IntegrationTest {
         @Test
         void 이미_회수한_발급쿠폰이면_실패한다() {
             // given
-            CouponCreateRequest request = new CouponCreateRequest(COUPON_NAME, ONE);
+            CouponCreateRequest request = new CouponCreateRequest(COUPON_NAME, ONE, ADMIN, null);
             couponService.createCoupon(request);
 
             createMember();
@@ -174,7 +175,7 @@ class CouponServiceTest extends IntegrationTest {
         @Test
         void 이미_사용한_발급쿠폰이면_실패한다() {
             // given
-            CouponCreateRequest request = new CouponCreateRequest(COUPON_NAME, ONE);
+            CouponCreateRequest request = new CouponCreateRequest(COUPON_NAME, ONE, ADMIN, null);
             couponService.createCoupon(request);
 
             createMember();

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/CouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/CouponTest.java
@@ -1,5 +1,7 @@
 package com.gdschongik.gdsc.domain.coupon.domain;
 
+import static com.gdschongik.gdsc.domain.coupon.domain.CouponType.*;
+import static com.gdschongik.gdsc.domain.coupon.domain.IssuanceMethodType.*;
 import static com.gdschongik.gdsc.global.common.constant.CouponConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static java.math.BigDecimal.*;
@@ -18,7 +20,7 @@ class CouponTest {
         @Test
         void 성공한다() {
             // when
-            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE));
+            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE), ADMIN, AUTOMATIC, null);
 
             // then
             assertThat(coupon).isNotNull();
@@ -30,7 +32,7 @@ class CouponTest {
             Money discountAmount = Money.from(ZERO);
 
             // when & then
-            assertThatThrownBy(() -> Coupon.create(COUPON_NAME, discountAmount))
+            assertThatThrownBy(() -> Coupon.create(COUPON_NAME, discountAmount, ADMIN, AUTOMATIC, null))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(COUPON_DISCOUNT_AMOUNT_NOT_POSITIVE.getMessage());
         }

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/CouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/CouponTest.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.coupon.domain;
 
 import static com.gdschongik.gdsc.domain.coupon.domain.CouponType.*;
-import static com.gdschongik.gdsc.domain.coupon.domain.IssuanceMethodType.*;
+import static com.gdschongik.gdsc.domain.coupon.domain.IssuanceType.*;
 import static com.gdschongik.gdsc.global.common.constant.CouponConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static java.math.BigDecimal.*;

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/CouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/CouponTest.java
@@ -1,7 +1,6 @@
 package com.gdschongik.gdsc.domain.coupon.domain;
 
 import static com.gdschongik.gdsc.domain.coupon.domain.CouponType.*;
-import static com.gdschongik.gdsc.domain.coupon.domain.IssuanceType.*;
 import static com.gdschongik.gdsc.global.common.constant.CouponConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static java.math.BigDecimal.*;
@@ -20,7 +19,7 @@ class CouponTest {
         @Test
         void 성공한다() {
             // when
-            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE), ADMIN, AUTOMATIC, null);
+            Coupon coupon = Coupon.createAutomatic(COUPON_NAME, Money.from(ONE), ADMIN, null);
 
             // then
             assertThat(coupon).isNotNull();
@@ -32,7 +31,7 @@ class CouponTest {
             Money discountAmount = Money.from(ZERO);
 
             // when & then
-            assertThatThrownBy(() -> Coupon.create(COUPON_NAME, discountAmount, ADMIN, AUTOMATIC, null))
+            assertThatThrownBy(() -> Coupon.createAutomatic(COUPON_NAME, discountAmount, ADMIN, null))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(COUPON_DISCOUNT_AMOUNT_NOT_POSITIVE.getMessage());
         }

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.coupon.domain;
 
 import static com.gdschongik.gdsc.domain.coupon.domain.CouponType.*;
-import static com.gdschongik.gdsc.domain.coupon.domain.IssuanceMethodType.*;
+import static com.gdschongik.gdsc.domain.coupon.domain.IssuanceType.*;
 import static com.gdschongik.gdsc.global.common.constant.CouponConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
@@ -1,7 +1,6 @@
 package com.gdschongik.gdsc.domain.coupon.domain;
 
 import static com.gdschongik.gdsc.domain.coupon.domain.CouponType.*;
-import static com.gdschongik.gdsc.domain.coupon.domain.IssuanceType.*;
 import static com.gdschongik.gdsc.global.common.constant.CouponConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
@@ -23,7 +22,7 @@ class IssuedCouponTest {
         @Test
         void 성공하면_사용여부는_true이다() {
             // given
-            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE), ADMIN, AUTOMATIC, null);
+            Coupon coupon = Coupon.createAutomatic(COUPON_NAME, Money.from(ONE), ADMIN, null);
             Member member = Member.createGuest(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
             LocalDateTime now = LocalDateTime.now();
@@ -38,7 +37,7 @@ class IssuedCouponTest {
         @Test
         void 이미_사용한_쿠폰이면_실패한다() {
             // given
-            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE), ADMIN, AUTOMATIC, null);
+            Coupon coupon = Coupon.createAutomatic(COUPON_NAME, Money.from(ONE), ADMIN, null);
             Member member = Member.createGuest(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
             LocalDateTime now = LocalDateTime.now();
@@ -53,7 +52,7 @@ class IssuedCouponTest {
         @Test
         void 이미_회수한_쿠폰이면_실패한다() {
             // given
-            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE), ADMIN, AUTOMATIC, null);
+            Coupon coupon = Coupon.createAutomatic(COUPON_NAME, Money.from(ONE), ADMIN, null);
             Member member = Member.createGuest(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
             issuedCoupon.revoke();
@@ -72,7 +71,7 @@ class IssuedCouponTest {
         @Test
         void 성공하면_회수여부는_true이다() {
             // given
-            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE), ADMIN, AUTOMATIC, null);
+            Coupon coupon = Coupon.createAutomatic(COUPON_NAME, Money.from(ONE), ADMIN, null);
             Member member = Member.createGuest(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
 
@@ -86,7 +85,7 @@ class IssuedCouponTest {
         @Test
         void 이미_회수한_발급쿠폰이면_실패한다() {
             // given
-            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE), ADMIN, AUTOMATIC, null);
+            Coupon coupon = Coupon.createAutomatic(COUPON_NAME, Money.from(ONE), ADMIN, null);
             Member member = Member.createGuest(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
             issuedCoupon.revoke();
@@ -100,7 +99,7 @@ class IssuedCouponTest {
         @Test
         void 이미_사용한_발급쿠폰이면_실패한다() {
             // given
-            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE), ADMIN, AUTOMATIC, null);
+            Coupon coupon = Coupon.createAutomatic(COUPON_NAME, Money.from(ONE), ADMIN, null);
             Member member = Member.createGuest(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
             issuedCoupon.use(LocalDateTime.now());

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
@@ -1,5 +1,7 @@
 package com.gdschongik.gdsc.domain.coupon.domain;
 
+import static com.gdschongik.gdsc.domain.coupon.domain.CouponType.*;
+import static com.gdschongik.gdsc.domain.coupon.domain.IssuanceMethodType.*;
 import static com.gdschongik.gdsc.global.common.constant.CouponConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
@@ -21,7 +23,7 @@ class IssuedCouponTest {
         @Test
         void 성공하면_사용여부는_true이다() {
             // given
-            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE));
+            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE), ADMIN, AUTOMATIC, null);
             Member member = Member.createGuest(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
             LocalDateTime now = LocalDateTime.now();
@@ -36,7 +38,7 @@ class IssuedCouponTest {
         @Test
         void 이미_사용한_쿠폰이면_실패한다() {
             // given
-            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE));
+            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE), ADMIN, AUTOMATIC, null);
             Member member = Member.createGuest(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
             LocalDateTime now = LocalDateTime.now();
@@ -51,7 +53,7 @@ class IssuedCouponTest {
         @Test
         void 이미_회수한_쿠폰이면_실패한다() {
             // given
-            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE));
+            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE), ADMIN, AUTOMATIC, null);
             Member member = Member.createGuest(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
             issuedCoupon.revoke();
@@ -70,7 +72,7 @@ class IssuedCouponTest {
         @Test
         void 성공하면_회수여부는_true이다() {
             // given
-            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE));
+            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE), ADMIN, AUTOMATIC, null);
             Member member = Member.createGuest(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
 
@@ -84,7 +86,7 @@ class IssuedCouponTest {
         @Test
         void 이미_회수한_발급쿠폰이면_실패한다() {
             // given
-            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE));
+            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE), ADMIN, AUTOMATIC, null);
             Member member = Member.createGuest(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
             issuedCoupon.revoke();
@@ -98,7 +100,7 @@ class IssuedCouponTest {
         @Test
         void 이미_사용한_발급쿠폰이면_실패한다() {
             // given
-            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE));
+            Coupon coupon = Coupon.create(COUPON_NAME, Money.from(ONE), ADMIN, AUTOMATIC, null);
             Member member = Member.createGuest(OAUTH_ID);
             IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
             issuedCoupon.use(LocalDateTime.now());

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.domain.order.application;
 
+import static com.gdschongik.gdsc.domain.coupon.domain.CouponType.*;
 import static com.gdschongik.gdsc.global.common.constant.OrderConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
@@ -83,7 +84,7 @@ class OrderServiceTest extends IntegrationTest {
 
             Membership membership = createMembership(member, recruitmentRound);
 
-            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
+            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member, ADMIN, null);
 
             // when
             var request = new OrderCreateRequest(
@@ -118,7 +119,7 @@ class OrderServiceTest extends IntegrationTest {
                     MONEY_20000_WON);
 
             Membership membership = createMembership(member, recruitmentRound);
-            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
+            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member, ADMIN, null);
 
             orderService.createPendingOrder(new OrderCreateRequest(
                     ORDER_NANO_ID,
@@ -159,7 +160,7 @@ class OrderServiceTest extends IntegrationTest {
                     MONEY_20000_WON);
 
             Membership membership = createMembership(member, recruitmentRound);
-            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
+            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member, ADMIN, null);
 
             orderService.createPendingOrder(new OrderCreateRequest(
                     ORDER_NANO_ID,
@@ -195,7 +196,7 @@ class OrderServiceTest extends IntegrationTest {
                     MONEY_20000_WON);
 
             Membership membership = createMembership(member, recruitmentRound);
-            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
+            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member, ADMIN, null);
 
             orderService.createPendingOrder(new OrderCreateRequest(
                     ORDER_NANO_ID,
@@ -229,7 +230,7 @@ class OrderServiceTest extends IntegrationTest {
                     MONEY_20000_WON);
 
             Membership membership = createMembership(member, recruitmentRound);
-            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
+            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member, ADMIN, null);
 
             orderService.createPendingOrder(new OrderCreateRequest(
                     ORDER_NANO_ID,
@@ -284,7 +285,7 @@ class OrderServiceTest extends IntegrationTest {
                     MONEY_20000_WON);
 
             Membership membership = createMembership(member, recruitmentRound);
-            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
+            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member, ADMIN, null);
 
             orderService.createPendingOrder(new OrderCreateRequest(
                     ORDER_NANO_ID,
@@ -364,7 +365,7 @@ class OrderServiceTest extends IntegrationTest {
                     MONEY_20000_WON);
 
             Membership membership = createMembership(member, recruitmentRound);
-            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
+            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member, ADMIN, null);
 
             orderService.createPendingOrder(new OrderCreateRequest(
                     ORDER_NANO_ID,
@@ -406,7 +407,7 @@ class OrderServiceTest extends IntegrationTest {
                     MONEY_20000_WON);
 
             Membership membership = createMembership(member, recruitmentRound);
-            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
+            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member, ADMIN, null);
 
             orderService.createPendingOrder(new OrderCreateRequest(
                     ORDER_NANO_ID,
@@ -451,7 +452,7 @@ class OrderServiceTest extends IntegrationTest {
                     MONEY_20000_WON);
 
             Membership membership = createMembership(member, recruitmentRound);
-            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
+            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member, ADMIN, null);
 
             orderService.createPendingOrder(new OrderCreateRequest(
                     ORDER_NANO_ID,
@@ -499,7 +500,7 @@ class OrderServiceTest extends IntegrationTest {
                     MONEY_20000_WON);
 
             Membership membership = createMembership(member, recruitmentRound);
-            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member);
+            IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, member, ADMIN, null);
 
             orderService.createPendingOrder(new OrderCreateRequest(
                     ORDER_NANO_ID,
@@ -544,7 +545,7 @@ class OrderServiceTest extends IntegrationTest {
                     MONEY_20000_WON);
 
             Membership membership = createMembership(member, recruitmentRound);
-            IssuedCoupon issuedCoupon = createAndIssue(MONEY_20000_WON, member);
+            IssuedCoupon issuedCoupon = createAndIssue(MONEY_20000_WON, member, ADMIN, null);
 
             var request = new OrderCreateRequest(
                     ORDER_NANO_ID,
@@ -579,7 +580,7 @@ class OrderServiceTest extends IntegrationTest {
                     MONEY_20000_WON);
 
             Membership membership = createMembership(member, recruitmentRound);
-            IssuedCoupon issuedCoupon = createAndIssue(MONEY_20000_WON, member);
+            IssuedCoupon issuedCoupon = createAndIssue(MONEY_20000_WON, member, ADMIN, null);
 
             var request = new OrderCreateRequest(
                     ORDER_NANO_ID,
@@ -612,7 +613,7 @@ class OrderServiceTest extends IntegrationTest {
                     MONEY_20000_WON);
 
             Membership membership = createMembership(member, recruitmentRound);
-            IssuedCoupon issuedCoupon = createAndIssue(MONEY_20000_WON, member);
+            IssuedCoupon issuedCoupon = createAndIssue(MONEY_20000_WON, member, ADMIN, null);
 
             var request = new OrderCreateRequest(
                     ORDER_NANO_ID,

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
+import com.gdschongik.gdsc.domain.coupon.domain.CouponType;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
@@ -45,7 +46,7 @@ class OrderValidatorTest {
     }
 
     private IssuedCoupon createAndIssue(Money money, Member member) {
-        return fixtureHelper.createAndIssue(money, member);
+        return fixtureHelper.createAndIssue(money, member, CouponType.ADMIN, null);
     }
 
     @Nested

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -15,7 +15,6 @@ import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.coupon.domain.Coupon;
 import com.gdschongik.gdsc.domain.coupon.domain.CouponType;
-import com.gdschongik.gdsc.domain.coupon.domain.IssuanceType;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
@@ -85,7 +84,7 @@ public class FixtureHelper {
     }
 
     public IssuedCoupon createAndIssue(Money money, Member member, CouponType couponType, Study study) {
-        Coupon coupon = Coupon.create(COUPON_NAME, money, couponType, IssuanceType.AUTOMATIC, study);
+        Coupon coupon = Coupon.createAutomatic(COUPON_NAME, money, couponType, study);
         return IssuedCoupon.create(coupon, member);
     }
 

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -15,7 +15,7 @@ import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.coupon.domain.Coupon;
 import com.gdschongik.gdsc.domain.coupon.domain.CouponType;
-import com.gdschongik.gdsc.domain.coupon.domain.IssuanceMethodType;
+import com.gdschongik.gdsc.domain.coupon.domain.IssuanceType;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
@@ -85,7 +85,7 @@ public class FixtureHelper {
     }
 
     public IssuedCoupon createAndIssue(Money money, Member member, CouponType couponType, Study study) {
-        Coupon coupon = Coupon.create(COUPON_NAME, money, couponType, IssuanceMethodType.AUTOMATIC, study);
+        Coupon coupon = Coupon.create(COUPON_NAME, money, couponType, IssuanceType.AUTOMATIC, study);
         return IssuedCoupon.create(coupon, member);
     }
 

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -3,6 +3,7 @@ package com.gdschongik.gdsc.helper;
 import static com.gdschongik.gdsc.domain.member.domain.Department.*;
 import static com.gdschongik.gdsc.domain.member.domain.MemberManageRole.ADMIN;
 import static com.gdschongik.gdsc.domain.member.domain.MemberStudyRole.MENTOR;
+import static com.gdschongik.gdsc.global.common.constant.CouponConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
@@ -13,6 +14,8 @@ import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.coupon.domain.Coupon;
+import com.gdschongik.gdsc.domain.coupon.domain.CouponType;
+import com.gdschongik.gdsc.domain.coupon.domain.IssuanceMethodType;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
@@ -81,8 +84,8 @@ public class FixtureHelper {
         return Membership.create(member, recruitmentRound);
     }
 
-    public IssuedCoupon createAndIssue(Money money, Member member) {
-        Coupon coupon = Coupon.create("테스트쿠폰", money);
+    public IssuedCoupon createAndIssue(Money money, Member member, CouponType couponType, Study study) {
+        Coupon coupon = Coupon.create(COUPON_NAME, money, couponType, IssuanceMethodType.AUTOMATIC, study);
         return IssuedCoupon.create(coupon, member);
     }
 

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.helper;
 
 import static com.gdschongik.gdsc.domain.member.domain.Department.*;
+import static com.gdschongik.gdsc.global.common.constant.CouponConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
@@ -13,6 +14,8 @@ import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.coupon.dao.CouponRepository;
 import com.gdschongik.gdsc.domain.coupon.dao.IssuedCouponRepository;
 import com.gdschongik.gdsc.domain.coupon.domain.Coupon;
+import com.gdschongik.gdsc.domain.coupon.domain.CouponType;
+import com.gdschongik.gdsc.domain.coupon.domain.IssuanceMethodType;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.discord.application.handler.DelegateMemberDiscordEventHandler;
 import com.gdschongik.gdsc.domain.discord.application.handler.MemberDiscordRoleRevokeHandler;
@@ -219,8 +222,8 @@ public abstract class IntegrationTest {
         return membershipRepository.save(membership);
     }
 
-    protected IssuedCoupon createAndIssue(Money money, Member member) {
-        Coupon coupon = Coupon.create("테스트쿠폰", money);
+    protected IssuedCoupon createAndIssue(Money money, Member member, CouponType couponType, Study study) {
+        Coupon coupon = Coupon.create(COUPON_NAME, money, couponType, IssuanceMethodType.AUTOMATIC, study);
         couponRepository.save(coupon);
         IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
         return issuedCouponRepository.save(issuedCoupon);

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -15,7 +15,6 @@ import com.gdschongik.gdsc.domain.coupon.dao.CouponRepository;
 import com.gdschongik.gdsc.domain.coupon.dao.IssuedCouponRepository;
 import com.gdschongik.gdsc.domain.coupon.domain.Coupon;
 import com.gdschongik.gdsc.domain.coupon.domain.CouponType;
-import com.gdschongik.gdsc.domain.coupon.domain.IssuanceType;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.discord.application.handler.DelegateMemberDiscordEventHandler;
 import com.gdschongik.gdsc.domain.discord.application.handler.MemberDiscordRoleRevokeHandler;
@@ -223,7 +222,7 @@ public abstract class IntegrationTest {
     }
 
     protected IssuedCoupon createAndIssue(Money money, Member member, CouponType couponType, Study study) {
-        Coupon coupon = Coupon.create(COUPON_NAME, money, couponType, IssuanceType.AUTOMATIC, study);
+        Coupon coupon = Coupon.createAutomatic(COUPON_NAME, money, couponType, study);
         couponRepository.save(coupon);
         IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
         return issuedCouponRepository.save(issuedCoupon);

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -15,7 +15,7 @@ import com.gdschongik.gdsc.domain.coupon.dao.CouponRepository;
 import com.gdschongik.gdsc.domain.coupon.dao.IssuedCouponRepository;
 import com.gdschongik.gdsc.domain.coupon.domain.Coupon;
 import com.gdschongik.gdsc.domain.coupon.domain.CouponType;
-import com.gdschongik.gdsc.domain.coupon.domain.IssuanceMethodType;
+import com.gdschongik.gdsc.domain.coupon.domain.IssuanceType;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.discord.application.handler.DelegateMemberDiscordEventHandler;
 import com.gdschongik.gdsc.domain.discord.application.handler.MemberDiscordRoleRevokeHandler;
@@ -223,7 +223,7 @@ public abstract class IntegrationTest {
     }
 
     protected IssuedCoupon createAndIssue(Money money, Member member, CouponType couponType, Study study) {
-        Coupon coupon = Coupon.create(COUPON_NAME, money, couponType, IssuanceMethodType.AUTOMATIC, study);
+        Coupon coupon = Coupon.create(COUPON_NAME, money, couponType, IssuanceType.AUTOMATIC, study);
         couponRepository.save(coupon);
         IssuedCoupon issuedCoupon = IssuedCoupon.create(coupon, member);
         return issuedCouponRepository.save(issuedCoupon);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #839

## 📌 작업 내용 및 특이사항
- Coupon에 쿠폰 타입(CouponType), 발급 방식(IssuanceMethodType), 스터디 필드를 추가했습니다.
- `CouponType`과 `IssuanceMethodType`은 enum 처리했고  `CouponType` 종류는 기획팀과 논의하여 우선 `ADMIN`,  `STUDY_COMPLETION`만 만들어 뒀습니다.
- `CouponType`이 스터디 관련인 경우, 어떤 study에서 발급된건지 저장하기 위한 목적으로 study 필드도 있습니다. 
`ADMIN`인 경우에는 이 필드가 null로 채워져서 정규화의 필요성에 대해 코어타임에 논의했지만 쿠폰의 수가 많지 않아 단일테이블을 유지하기로 했습니다.

## 📝 참고사항
- 쿠폰 생성 시, 프론트에서 쿠폰 타입과 스터디를 선택하는 과정이 추가됩니다. 이에 따라 종류들을 조회하는 api들이 추가되어야 합니다. https://github.com/GDSC-Hongik/gdsc-server/issues/846 에서 처리할 예정입니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 쿠폰 생성 및 발급 로직 개선
	- 쿠폰 타입 및 발급 유형 추가 (관리자, 스터디 수료)
	- 스터디와 연계된 쿠폰 생성 지원
	- 쿠폰 생성 요청에 스터디 ID 및 쿠폰 타입 추가

- **버그 수정**
	- 쿠폰 생성 및 발급 시 유효성 검사 강화

- **리팩터링**
	- 쿠폰 도메인 모델 구조 개선
	- 쿠폰 관련 데이터 모델 확장

<!-- end of auto-generated comment: release notes by coderabbit.ai -->