### PR TITLE
feat: Study V2 도메인 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/common/vo/Semester.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/vo/Semester.java
@@ -1,0 +1,22 @@
+package com.gdschongik.gdsc.domain.common.vo;
+
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Semester {
+
+    private Integer academicYear;
+
+    @Enumerated(EnumType.STRING)
+    private SemesterType semesterType;
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidator.java
@@ -61,6 +61,7 @@ public class RecruitmentRoundValidator {
 
     private void validatePeriodOverlap(
             List<RecruitmentRound> recruitmentRounds, LocalDateTime startDate, LocalDateTime endDate) {
+        // TODO: recruitmentRound.getPeriod().validatePeriodOverlap(startDate, endDate)로 변경
         recruitmentRounds.forEach(recruitmentRound -> recruitmentRound.validatePeriodOverlap(startDate, endDate));
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +21,7 @@ import org.hibernate.annotations.Comment;
 
 @Getter
 @Entity
+@Table(name = "study_session_v2")
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class StudySessionV2 extends BaseEntity {
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
@@ -1,0 +1,118 @@
+package com.gdschongik.gdsc.domain.studyv2.domain;
+
+import com.gdschongik.gdsc.domain.common.model.BaseEntity;
+import com.gdschongik.gdsc.domain.common.vo.Period;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@Entity
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudySessionV2 extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_session_v2_id")
+    private Long id;
+
+    // 수업 관련 필드
+
+    @Comment("수업 상태")
+    private StudyStatusV2 lessonStatus;
+
+    @Comment("수업 제목")
+    private String lessonTitle;
+
+    @Comment("수업 설명")
+    private String lessonDescription;
+
+    @Comment("수업 출석 번호")
+    private Integer lessonAttendanceNumber;
+
+    @Embedded
+    @AttributeOverride(name = "startDate", column = @Column(name = "lesson_start_at"))
+    @AttributeOverride(name = "endDate", column = @Column(name = "lesson_end_at"))
+    private Period lessonPeriod;
+
+    // 과제 관련 필드
+
+    @Comment("과제 상태")
+    private StudyStatusV2 assignmentStatus;
+
+    @Comment("과제 제목")
+    private String assignmentTitle;
+
+    @Comment("과제 명세 링크")
+    private String assignmentDescriptionLink;
+
+    @Embedded
+    @AttributeOverride(name = "startDate", column = @Column(name = "assignment_start_at"))
+    @AttributeOverride(name = "endDate", column = @Column(name = "assignment_end_at"))
+    private Period assignmentPeriod;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_v2_id")
+    private StudyV2 studyV2;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private StudySessionV2(
+            StudyStatusV2 lessonStatus,
+            String lessonTitle,
+            String lessonDescription,
+            Integer lessonAttendanceNumber,
+            Period lessonPeriod,
+            StudyStatusV2 assignmentStatus,
+            String assignmentTitle,
+            String assignmentDescriptionLink,
+            Period assignmentPeriod,
+            StudyV2 studyV2) {
+        this.lessonStatus = lessonStatus;
+        this.lessonTitle = lessonTitle;
+        this.lessonDescription = lessonDescription;
+        this.lessonAttendanceNumber = lessonAttendanceNumber;
+        this.lessonPeriod = lessonPeriod;
+        this.assignmentStatus = assignmentStatus;
+        this.assignmentTitle = assignmentTitle;
+        this.assignmentDescriptionLink = assignmentDescriptionLink;
+        this.assignmentPeriod = assignmentPeriod;
+        this.studyV2 = studyV2;
+    }
+
+    public static StudySessionV2 create(
+            StudyStatusV2 lessonStatus,
+            String lessonTitle,
+            String lessonDescription,
+            Integer lessonAttendanceNumber,
+            Period lessonPeriod,
+            StudyStatusV2 assignmentStatus,
+            String assignmentTitle,
+            String assignmentDescriptionLink,
+            Period assignmentPeriod,
+            StudyV2 studyV2) {
+        return StudySessionV2.builder()
+                .lessonStatus(lessonStatus)
+                .lessonTitle(lessonTitle)
+                .lessonDescription(lessonDescription)
+                .lessonAttendanceNumber(lessonAttendanceNumber)
+                .lessonPeriod(lessonPeriod)
+                .assignmentStatus(assignmentStatus)
+                .assignmentTitle(assignmentTitle)
+                .assignmentDescriptionLink(assignmentDescriptionLink)
+                .assignmentPeriod(assignmentPeriod)
+                .studyV2(studyV2)
+                .build();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyStatusV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyStatusV2.java
@@ -1,0 +1,14 @@
+package com.gdschongik.gdsc.domain.studyv2.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StudyStatusV2 {
+    OPENED("개설"),
+    CANCELED("휴강"),
+    ;
+
+    private final String value;
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
@@ -17,6 +17,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 import lombok.AccessLevel;
@@ -27,6 +28,7 @@ import org.hibernate.annotations.Comment;
 
 @Getter
 @Entity
+@Table(name = "study_v2")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StudyV2 extends BaseEntity {
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
@@ -1,0 +1,95 @@
+package com.gdschongik.gdsc.domain.studyv2.domain;
+
+import com.gdschongik.gdsc.domain.common.model.BaseEntity;
+import com.gdschongik.gdsc.domain.common.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Semester;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.study.domain.StudyType;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyV2 extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_v2_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private StudyType type;
+
+    private String title;
+
+    @Comment("스터디 한 줄 소개")
+    private String introduction;
+
+    @Comment("스터디 상세 노션 링크(Text)")
+    @Column(columnDefinition = "TEXT")
+    private String notionLink;
+
+    @Enumerated(EnumType.STRING)
+    private Semester semester;
+
+    @Comment("스터디 요일")
+    @Enumerated(EnumType.STRING)
+    private DayOfWeek dayOfWeek;
+
+    @Comment("스터디 시작 시간")
+    private LocalTime startTime;
+
+    @Comment("스터디 종료 시간")
+    private LocalTime endTime;
+
+    @Embedded
+    @AttributeOverride(name = "startDate", column = @Column(name = "application_start_date"))
+    @AttributeOverride(name = "endDate", column = @Column(name = "application_end_date"))
+    private Period applicationPeriod;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member mentor;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private StudyV2(
+            StudyType type,
+            String title,
+            String introduction,
+            String notionLink,
+            Semester semester,
+            DayOfWeek dayOfWeek,
+            LocalTime startTime,
+            LocalTime endTime,
+            Period applicationPeriod,
+            Member mentor) {
+        this.type = type;
+        this.title = title;
+        this.introduction = introduction;
+        this.notionLink = notionLink;
+        this.semester = semester;
+        this.dayOfWeek = dayOfWeek;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.applicationPeriod = applicationPeriod;
+        this.mentor = mentor;
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #845

## 📌 작업 내용 및 특이사항
- 스터디 V2 도메인 리팩토링 배경은... 와클 초기 작업 당시 제가 러프하게 구조만 잡고, 구현은 새로 오신 다른 분들이 하셔서... DDD(-Lite) 관점에서 잘못 구현된 부분이나 기존 프로젝트 컨벤션에 맞지 않는 부분들이 많았습니다. 이 부분을 고치고 + 한 학기 간 와클 운영하면서 문제가 있었던 부분도 겸사겸사 개선해보려고 합니다.

- 더 작업하면 사이즈가 커질 것 같아서 여기서 커트하고 PR 올립니다
- 기존 스터디 도메인과의 차이점 위주로 봐주시면 좋을듯 합니다 (아래에 핵심 변경점 위주로 정리는 해두었습니다)

### 초기 PR 이후 기획 픽스로 인해 구현 상 변경점 안내
PR 생성 후 혁님과 추가 논의 진행했으며 이로 인해 변경된 점 정리했습니다. 자세한 내용은 노션 '2025 GDG 방향' 문서 확인하시면 됩니다. 논의된 내용은 이 PR에서 전부 작업하지는 않을 예정이고, 테이블 구조 변경사항만 작업할 예정입니다. 나머지는 별도 이슈로 분리
1. 스터디 관련 필드 변경
    - 제거 : 스터디 진행기간, 스터디 총 주차 (n주 코스)
    - 변경 : 스터디 요일, 스터디 시간 -> 메타성 필드로 변경. 즉 도메인 로직에 사용하지 않고 사용자가 참고용으로만 사용하도록
    - 추가 : 디스코드 스터디 채널 ID (디코 알림 기능 대응, 초기 입력 후 수정 불가), 디스코드 스터디 역할 ID (역할 자동 부여 기능 대응, 초기 입력 후 수정 불가)
2. 스터디가 사용자에게 보여지는 기간 수정
    - (기) 스터디 진행기간 -> (현) 학기 진행기간(Recruitment의 period)
3. 스터디회차 관련 변경사항
    - 스터디 생성 시 n주차 개념 유지 (단 ui 상에서는 n회차 '코스'에서 n'주차'로 변경)
    - 스터디 생성 시 자동으로 빈 스터디회차 생성하는 기능 유지 (단 NONE 상태는 없을듯)
    - 회차순서에 따른 수업기간 선후관계 검증 정책 유지 (단 과제기간은 검증 X)
4. '휴강' 개념 제거 (핵심)
    -  수업휴강, 과제휴강 둘 다 없음
    - 휴강 개념 없애기 위해 status 필드 삭제
    - 실제 휴강 발생 시 대응 위해 수업기간 / 과제기간 수정 기능 도입
    - 휴강 발생 시 휴강회차의 수업기간을 밀고 + 그 뒤 회차의 수업기간도 어드민이 직접 연기하는 방식
5. 스터디 커리큘럼 + 과제 상세 정보 통합
    - 기존에는 각 주차에 대한 수업 정보 / 과제 정보에 대해서 각각의 제목 / 설명(설명링크) 가 존재했음
    - 수업 정보 / 과제 정보를 통합하여 회차 정보로 변경. 회차 제목 / 회차 설명 / 과제 링크와 같이 지정
    - 화면 상에서도 커리큘럼 테이블 / 과제 테이블을 하나로 통합할 예정 (사용자 화면 / 어드민 수정 화면 둘 다)


### --- 아래는 요구사항 변경 전 소개 ---

### 1. `BaseSemesterEntity` -> `Semester` 리팩토링 선반영을 위한 VO 추가
- '상속보다 컴포지션을 선호하라' 원칙을 지키기 위한 리팩토링입니다 (#389)
- 기존에는 `BaseSemesterEntity` 를 추가하여 상속 방식을 통해 공통적으로 등장하는 학기 관련 필드를 다루었습니다.
- 상속 구조를 통해서 얻을 수 있는 이점이 없고, 오히려 `SemesterFormatter` 로직에서 포맷팅을 수행할 때 이러한 상속 관계가 단점인 경우가 많았습니다.
```java
public static String format(BaseSemesterEntity semesterEntity) {
    return format(semesterEntity.getAcademicYear(), semesterEntity.getSemesterType());
}
```
- 위 메서드는 부모 클래스를 인자로 받아서 포매팅된 학기 문자열 (ex: `2024-1`) 을 반환합니다. 하지만 DTO Projection 등을 사용하는 등 엔티티를 인자로 넘길 수 없는 경우에는 별도의 메서드가 필요합니다.
- 이때 `Semester` VO를 사용했다면 항상 `Semester` VO를 받도록 해서, `Semester` 내부 필드를 풀어헤쳐서 인자로 받게 하는 일은 없겠죠...
- 그리고 `BaseEntity` 가 있는 상황에서 `BaseSemesterEntity` 를 중간에 한번 더 거쳐가는 게 마음에 안 들기도 했고요...

### 2. `StudyDetail` -> `StudySession` 변경
- 직역하면 `스터디-스터디상세` 구조인데, '상세'가 둘의 관계성을 명확하게 드러내지 못한다고 봤습니다.
- `스터디-스터디회차`가 두 엔티티의 관계성을 더 잘 드러냅니다. 기존 주차 개념이 유지되었다면 `Study-StudyWeek` 도 좋은 선택이었지만... 주차 개념 없어지고 회차 개념으로 변경되기 때문에, 회차 네이밍을 채택했습니다.
- `Session` 과 `Round` 중에서 고민했는데 GPT 픽으로 `Session` 을 선택했습니다.

### 3. `Curriculum`, `Assignment` VO 제거
- VO의 경우 서로 관련있는 필드들을 하나의 객체로 묶어서 다룰 수 있다는 장점이 있습니다.
- VO를 사용하는 케이스를 정리해보면 1) 내부 상태들의 불변성 보장 2) 중복되는 일련의 필드 등장 3) 이러한 일련의 필드들 간의 (+ 엔티티의 관심사와는 약간 독립적으로 존재할 수 있는) 도메인 규칙 보장 필요성 등이 있습니다.
- 특히 불변객체여야 한다는 제약조건이 가장 큰 문제인데요, 아무 값이나 막 VO로 구성하게 되면 참 어려운 상황에 마주하게 됩니다. 만약 10개의 필드 중에서 9개는 그대로 있는데, 1개의 필드만 내부 상태를 변경해야 하면, (불변 객체이기에)`update` 를 호출하는 건 불가능하고, 기존 값을 복사해온 뒤 새로운 객체를 생성하는 방식으로 구현해야 합니다.
- 이러한 이유로 `서로 생명주기가 다른 필드들은 VO로 묶이지 말아야 한다` 라는 생각이 들었습니다.
- 수업 VO와 과제 VO는 각각 `status` 필드를 가집니다. 그리고 개강 / 휴강 상태로 변경될 때, 다른 필드는 변경되지 않지만, 이 상태 필드만 변경되는 라이프사이클을 가집니다. 따라서 VO로 적절하지 않습니다.
- 또, `서로 관련있는 일련의 필드들` 이라는 조건만 충족시키는 것을 제외하면, `내부 상태에 대한 도메인 규칙 보장` 이나 `다른 엔티티에서의 중복된 등장` 조건 모두 충족시키지 못합니다. 
- 이러한 이유로 `StudySession` 에서 두 VO를 제거했습니다.

### 4. `StudyStatusV2`
- 기존에는 스터디를 만들면서 빈 스터디상세를 주차 수만큼 미리 만들어두었습니다.
- 이제는 스터디회차를 자유롭게 추가하고 수정할 수 있습니다. 회차 시작일 이전이라면 제거하는 기능도 추가 고려 중입니다.
- 따라서 자동으로 생성되는 케이스가 없으므로 미지정 상태, 즉 `NONE` 을 둘 필요가 없습니다. 따라서 제거했습니다.
- 추가로 `OPEN` -> `OPENED` 로 변경하여 `CANCELED` 와 시제를 맞췄습니다. 

### 5. `lessonPeriod` 와 `assignmentPeriod` 를 추가
- 기존에는 `deadline` 같은 것들이 있었는데요, 둘의 period를 완전히 독립적으로 존재할 수 있게 했습니다. 대신에 멘토가 여러 회차 생성할 때, 수업시간 동일하면 매번 번거롭게 지정해줘야겠지만... 이건 프론트에서 개선할 수 있는 부분이니깐요
- 아무튼 이제 수업 시작시간 ~ 종료시간과 과제 시작시간 ~ 종료시간은 서로 어떠한 종속적인 validation이 없습니다. 3주 있다가 과제를 내주는 것도 가능합니다. 과거로 수정하는 것도 가능합니다. 그러면 이후 과제 제출이력이 막히고 + 기존 제출이력과 과제제출기간이 일치하지 않는 경우도 있겠지만...
- 이번 학기에 운영해보셨으니 알겠지만, '현재 시점' 기준으로 validation 로직을 덕지덕지 붙이는 게 운영 효율성 측면에서 많이 좋지 못합니다. 테스트도 어렵고요. 정말 핵심 로직의 논리적 일관성을 위해서 필요한 게 아니라면 불필요한 validation은 (필요해지기 전까지는) 추가하지 않을 예정입니다.

그 외...
- 출석번호 Integer로 바꿨습니다.
- `curriculum` 을 `lesson` 으로 바꿨습니다.
- `week` , `totalWeek`, `dayOfWeek` 를 삭제했습니다. 이건 기획쪽과 추가 논의 필요
- 실제 로직 상에서는 `StudySession` 값을 쓰고 (출결 같은 것들), 스터디 시간/요일은 그냥 메타데이터 느낌으로 남겨도 되지 않을까... 싶은데, 이것 역시 기획쪽과 이야기 필요

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 새로운 학기(Semester) 값 객체 추가
	- 스터디 V2 관련 도메인 모델 도입
		- 스터디 세션 V2
		- 스터디 상태 V2
		- 스터디 V2 엔티티 생성

- **개선 사항**
	- 모집 라운드 검증 로직에 대한 주석 추가

이번 릴리즈는 스터디 관리 시스템의 새로운 버전을 준비하는 기반 작업을 포함하고 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->