### PR TITLE
refactor: 엔티티 필드 및 생성자 메서드 시그니처 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCoupon.java
@@ -32,6 +32,11 @@ public class IssuedCoupon extends BaseEntity {
     @Column(name = "issued_coupon_id")
     private Long id;
 
+    @Comment("회수 여부")
+    private Boolean hasRevoked;
+
+    private LocalDateTime usedAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "coupon_id")
     private Coupon coupon;
@@ -40,16 +45,11 @@ public class IssuedCoupon extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @Comment("회수 여부")
-    private Boolean hasRevoked;
-
-    private LocalDateTime usedAt;
-
     @Builder(access = AccessLevel.PRIVATE)
-    private IssuedCoupon(Coupon coupon, Member member, Boolean hasRevoked) {
+    private IssuedCoupon(Boolean hasRevoked, Coupon coupon, Member member) {
+        this.hasRevoked = hasRevoked;
         this.coupon = coupon;
         this.member = member;
-        this.hasRevoked = hasRevoked;
     }
 
     public static IssuedCoupon create(Coupon coupon, Member member) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -33,6 +33,18 @@ public class Member extends BaseEntity {
     @Column(name = "member_id")
     private Long id;
 
+    @Enumerated(EnumType.STRING)
+    private MemberStatus status;
+
+    @Enumerated(EnumType.STRING)
+    private MemberRole role;
+
+    @Enumerated(EnumType.STRING)
+    private MemberManageRole manageRole;
+
+    @Enumerated(EnumType.STRING)
+    private MemberStudyRole studyRole;
+
     private String name;
 
     private String studentId;
@@ -55,18 +67,6 @@ public class Member extends BaseEntity {
     private LocalDateTime lastLoginAt;
 
     @Enumerated(EnumType.STRING)
-    private MemberRole role;
-
-    @Enumerated(EnumType.STRING)
-    private MemberManageRole manageRole;
-
-    @Enumerated(EnumType.STRING)
-    private MemberStudyRole studyRole;
-
-    @Enumerated(EnumType.STRING)
-    private MemberStatus status;
-
-    @Enumerated(EnumType.STRING)
     private Department department;
 
     @Embedded
@@ -74,6 +74,10 @@ public class Member extends BaseEntity {
 
     @Builder(access = AccessLevel.PRIVATE)
     private Member(
+            MemberStatus status,
+            MemberRole role,
+            MemberManageRole manageRole,
+            MemberStudyRole studyRole,
             String name,
             String studentId,
             String email,
@@ -83,12 +87,12 @@ public class Member extends BaseEntity {
             String nickname,
             String oauthId,
             LocalDateTime lastLoginAt,
-            MemberRole role,
-            MemberManageRole manageRole,
-            MemberStudyRole studyRole,
-            MemberStatus status,
             Department department,
             AssociateRequirement associateRequirement) {
+        this.status = status;
+        this.role = role;
+        this.manageRole = manageRole;
+        this.studyRole = studyRole;
         this.name = name;
         this.studentId = studentId;
         this.email = email;
@@ -98,10 +102,6 @@ public class Member extends BaseEntity {
         this.nickname = nickname;
         this.oauthId = oauthId;
         this.lastLoginAt = lastLoginAt;
-        this.role = role;
-        this.manageRole = manageRole;
-        this.studyRole = studyRole;
-        this.status = status;
         this.department = department;
         this.associateRequirement = associateRequirement;
     }
@@ -109,11 +109,11 @@ public class Member extends BaseEntity {
     public static Member createGuest(String oauthId) {
         AssociateRequirement associateRequirement = AssociateRequirement.unsatisfied();
         return Member.builder()
-                .oauthId(oauthId)
+                .status(MemberStatus.NORMAL)
                 .role(GUEST)
                 .manageRole(NONE)
                 .studyRole(STUDENT)
-                .status(MemberStatus.NORMAL)
+                .oauthId(oauthId)
                 .associateRequirement(associateRequirement)
                 .build();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -33,6 +33,27 @@ public class Member extends BaseEntity {
     @Column(name = "member_id")
     private Long id;
 
+    private String name;
+
+    private String studentId;
+
+    private String email;
+
+    private String univEmail;
+
+    private String phone;
+
+    private String discordId;
+
+    private String discordUsername;
+
+    private String nickname;
+
+    @Column(nullable = false)
+    private String oauthId;
+
+    private LocalDateTime lastLoginAt;
+
     @Enumerated(EnumType.STRING)
     private MemberRole role;
 
@@ -45,64 +66,43 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private MemberStatus status;
 
-    private String name;
-
-    private String studentId;
-
     @Enumerated(EnumType.STRING)
     private Department department;
-
-    private String email;
-
-    private String phone;
-
-    private String discordUsername;
-
-    private String nickname;
-
-    private String discordId;
-
-    @Column(nullable = false)
-    private String oauthId;
-
-    private LocalDateTime lastLoginAt;
-
-    private String univEmail;
 
     @Embedded
     private AssociateRequirement associateRequirement;
 
     @Builder(access = AccessLevel.PRIVATE)
     private Member(
-            MemberRole role,
-            MemberManageRole manageRole,
-            MemberStudyRole studyRole,
-            MemberStatus status,
             String name,
             String studentId,
-            Department department,
             String email,
+            String univEmail,
             String phone,
             String discordUsername,
             String nickname,
             String oauthId,
             LocalDateTime lastLoginAt,
-            String univEmail,
+            MemberRole role,
+            MemberManageRole manageRole,
+            MemberStudyRole studyRole,
+            MemberStatus status,
+            Department department,
             AssociateRequirement associateRequirement) {
-        this.role = role;
-        this.manageRole = manageRole;
-        this.studyRole = studyRole;
-        this.status = status;
         this.name = name;
         this.studentId = studentId;
-        this.department = department;
         this.email = email;
+        this.univEmail = univEmail;
         this.phone = phone;
         this.discordUsername = discordUsername;
         this.nickname = nickname;
         this.oauthId = oauthId;
         this.lastLoginAt = lastLoginAt;
-        this.univEmail = univEmail;
+        this.role = role;
+        this.manageRole = manageRole;
+        this.studyRole = studyRole;
+        this.status = status;
+        this.department = department;
         this.associateRequirement = associateRequirement;
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -49,6 +49,9 @@ public class Member extends BaseEntity {
 
     private String studentId;
 
+    @Enumerated(EnumType.STRING)
+    private Department department;
+
     private String email;
 
     private String univEmail;
@@ -66,9 +69,6 @@ public class Member extends BaseEntity {
 
     private LocalDateTime lastLoginAt;
 
-    @Enumerated(EnumType.STRING)
-    private Department department;
-
     @Embedded
     private AssociateRequirement associateRequirement;
 
@@ -80,6 +80,7 @@ public class Member extends BaseEntity {
             MemberStudyRole studyRole,
             String name,
             String studentId,
+            Department department,
             String email,
             String univEmail,
             String phone,
@@ -87,7 +88,6 @@ public class Member extends BaseEntity {
             String nickname,
             String oauthId,
             LocalDateTime lastLoginAt,
-            Department department,
             AssociateRequirement associateRequirement) {
         this.status = status;
         this.role = role;
@@ -95,6 +95,7 @@ public class Member extends BaseEntity {
         this.studyRole = studyRole;
         this.name = name;
         this.studentId = studentId;
+        this.department = department;
         this.email = email;
         this.univEmail = univEmail;
         this.phone = phone;
@@ -102,7 +103,6 @@ public class Member extends BaseEntity {
         this.nickname = nickname;
         this.oauthId = oauthId;
         this.lastLoginAt = lastLoginAt;
-        this.department = department;
         this.associateRequirement = associateRequirement;
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/domain/Membership.java
@@ -34,6 +34,9 @@ public class Membership extends BaseEntity {
     @Column(name = "membership_id")
     private Long id;
 
+    @Embedded
+    private RegularRequirement regularRequirement;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -42,14 +45,11 @@ public class Membership extends BaseEntity {
     @JoinColumn(name = "recruitment_round_id")
     private RecruitmentRound recruitmentRound;
 
-    @Embedded
-    private RegularRequirement regularRequirement;
-
     @Builder(access = AccessLevel.PRIVATE)
-    private Membership(Member member, RecruitmentRound recruitmentRound, RegularRequirement regularRequirement) {
+    private Membership(RegularRequirement regularRequirement, Member member, RecruitmentRound recruitmentRound) {
+        this.regularRequirement = regularRequirement;
         this.member = member;
         this.recruitmentRound = recruitmentRound;
-        this.regularRequirement = regularRequirement;
     }
 
     public static Membership create(Member member, RecruitmentRound recruitmentRound) {

--- a/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
@@ -63,7 +63,8 @@ public class OrderService {
 
         orderValidator.validatePendingOrderCreate(membership, issuedCoupon, moneyInfo, currentMember);
 
-        Order order = Order.createPending(request.orderNanoId(), membership, issuedCoupon, moneyInfo);
+        Order order = Order.createPending(request.orderNanoId(), moneyInfo,
+                membership, issuedCoupon);
 
         orderRepository.save(order);
 
@@ -168,7 +169,7 @@ public class OrderService {
 
         LocalDateTime now = LocalDateTime.now();
 
-        Order order = Order.createFree(request.orderNanoId(), membership, optionalIssuedCoupon.orElse(null), moneyInfo);
+        Order order = Order.createFree(request.orderNanoId(), moneyInfo, membership, optionalIssuedCoupon.orElse(null));
         optionalIssuedCoupon.ifPresent(issuedCoupon -> issuedCoupon.use(now));
 
         orderRepository.save(order);

--- a/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/application/OrderService.java
@@ -63,8 +63,7 @@ public class OrderService {
 
         orderValidator.validatePendingOrderCreate(membership, issuedCoupon, moneyInfo, currentMember);
 
-        Order order = Order.createPending(request.orderNanoId(), moneyInfo,
-                membership, issuedCoupon);
+        Order order = Order.createPending(request.orderNanoId(), moneyInfo, membership, issuedCoupon);
 
         orderRepository.save(order);
 

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
@@ -34,6 +34,10 @@ public class Order extends BaseEntity {
     @Column(name = "orders_id")
     private Long id;
 
+    @Comment("주문상태")
+    @Enumerated(EnumType.STRING)
+    private OrderStatus status;
+
     @Comment("주문 nanoId")
     @Column(unique = true, length = 21)
     private String nanoId;
@@ -56,28 +60,24 @@ public class Order extends BaseEntity {
 
     private ZonedDateTime canceledAt;
 
-    @Comment("주문상태")
-    @Enumerated(EnumType.STRING)
-    private OrderStatus status;
-
     @Embedded
     private MoneyInfo moneyInfo;
 
     @Builder(access = AccessLevel.PRIVATE)
     private Order(
+            OrderStatus status,
             String nanoId,
             Long memberId,
             Long membershipId,
             Long recruitmentRoundId,
             Long issuedCouponId,
-            OrderStatus status,
             MoneyInfo moneyInfo) {
+        this.status = status;
         this.nanoId = nanoId;
         this.memberId = memberId;
         this.membershipId = membershipId;
         this.recruitmentRoundId = recruitmentRoundId;
         this.issuedCouponId = issuedCouponId;
-        this.status = status;
         this.moneyInfo = moneyInfo;
 
         registerEvent(new OrderCreatedEvent(nanoId, isFree()));
@@ -90,12 +90,12 @@ public class Order extends BaseEntity {
     public static Order createPending(
             String nanoId, MoneyInfo moneyInfo, Membership membership, @Nullable IssuedCoupon issuedCoupon) {
         return Order.builder()
+                .status(OrderStatus.PENDING)
                 .nanoId(nanoId)
                 .memberId(membership.getMember().getId())
                 .membershipId(membership.getId())
                 .recruitmentRoundId(membership.getRecruitmentRound().getId())
                 .issuedCouponId(issuedCoupon != null ? issuedCoupon.getId() : null)
-                .status(OrderStatus.PENDING)
                 .moneyInfo(moneyInfo)
                 .build();
     }
@@ -104,12 +104,12 @@ public class Order extends BaseEntity {
             String nanoId, MoneyInfo moneyInfo, Membership membership, @Nullable IssuedCoupon issuedCoupon) {
         validateFreeOrder(moneyInfo);
         return Order.builder()
+                .status(OrderStatus.COMPLETED)
                 .nanoId(nanoId)
                 .memberId(membership.getMember().getId())
                 .membershipId(membership.getId())
                 .recruitmentRoundId(membership.getRecruitmentRound().getId())
                 .issuedCouponId(issuedCoupon != null ? issuedCoupon.getId() : null)
-                .status(OrderStatus.COMPLETED)
                 .moneyInfo(moneyInfo)
                 .build();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
@@ -34,10 +34,6 @@ public class Order extends BaseEntity {
     @Column(name = "orders_id")
     private Long id;
 
-    @Comment("주문상태")
-    @Enumerated(EnumType.STRING)
-    private OrderStatus status;
-
     @Comment("주문 nanoId")
     @Column(unique = true, length = 21)
     private String nanoId;
@@ -54,30 +50,34 @@ public class Order extends BaseEntity {
     @Comment("사용하려는 발급쿠폰 ID")
     private Long issuedCouponId;
 
-    @Embedded
-    private MoneyInfo moneyInfo;
-
     private String paymentKey;
 
     private ZonedDateTime approvedAt;
 
     private ZonedDateTime canceledAt;
 
+    @Comment("주문상태")
+    @Enumerated(EnumType.STRING)
+    private OrderStatus status;
+
+    @Embedded
+    private MoneyInfo moneyInfo;
+
     @Builder(access = AccessLevel.PRIVATE)
     private Order(
-            OrderStatus status,
             String nanoId,
             Long memberId,
             Long membershipId,
             Long recruitmentRoundId,
             Long issuedCouponId,
+            OrderStatus status,
             MoneyInfo moneyInfo) {
-        this.status = status;
         this.nanoId = nanoId;
         this.memberId = memberId;
         this.membershipId = membershipId;
         this.recruitmentRoundId = recruitmentRoundId;
         this.issuedCouponId = issuedCouponId;
+        this.status = status;
         this.moneyInfo = moneyInfo;
 
         registerEvent(new OrderCreatedEvent(nanoId, isFree()));
@@ -90,12 +90,12 @@ public class Order extends BaseEntity {
     public static Order createPending(
             String nanoId, Membership membership, @Nullable IssuedCoupon issuedCoupon, MoneyInfo moneyInfo) {
         return Order.builder()
-                .status(OrderStatus.PENDING)
                 .nanoId(nanoId)
                 .memberId(membership.getMember().getId())
                 .membershipId(membership.getId())
                 .recruitmentRoundId(membership.getRecruitmentRound().getId())
                 .issuedCouponId(issuedCoupon != null ? issuedCoupon.getId() : null)
+                .status(OrderStatus.PENDING)
                 .moneyInfo(moneyInfo)
                 .build();
     }
@@ -104,12 +104,12 @@ public class Order extends BaseEntity {
             String nanoId, Membership membership, @Nullable IssuedCoupon issuedCoupon, MoneyInfo moneyInfo) {
         validateFreeOrder(moneyInfo);
         return Order.builder()
-                .status(OrderStatus.COMPLETED)
                 .nanoId(nanoId)
                 .memberId(membership.getMember().getId())
                 .membershipId(membership.getId())
                 .recruitmentRoundId(membership.getRecruitmentRound().getId())
                 .issuedCouponId(issuedCoupon != null ? issuedCoupon.getId() : null)
+                .status(OrderStatus.COMPLETED)
                 .moneyInfo(moneyInfo)
                 .build();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
@@ -88,7 +88,7 @@ public class Order extends BaseEntity {
      * 쿠폰의 경우 사용 여부를 선택할 수 있습니다.
      */
     public static Order createPending(
-            String nanoId, Membership membership, @Nullable IssuedCoupon issuedCoupon, MoneyInfo moneyInfo) {
+            String nanoId, MoneyInfo moneyInfo, Membership membership, @Nullable IssuedCoupon issuedCoupon) {
         return Order.builder()
                 .nanoId(nanoId)
                 .memberId(membership.getMember().getId())
@@ -101,7 +101,7 @@ public class Order extends BaseEntity {
     }
 
     public static Order createFree(
-            String nanoId, Membership membership, @Nullable IssuedCoupon issuedCoupon, MoneyInfo moneyInfo) {
+            String nanoId, MoneyInfo moneyInfo, Membership membership, @Nullable IssuedCoupon issuedCoupon) {
         validateFreeOrder(moneyInfo);
         return Order.builder()
                 .nanoId(nanoId)

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -42,11 +42,10 @@ public class AdminRecruitmentService {
         recruitmentValidator.validateRecruitmentCreate(isRecruitmentOverlap);
 
         Recruitment recruitment = Recruitment.create(
-                request.academicYear(),
-                request.semesterType(),
-                Money.from(request.fee()),
-                request.feeName(),
-                Period.of(request.semesterStartDate(), request.semesterEndDate()));
+                request.feeName(), Money.from(request.fee()),
+                Period.of(request.semesterStartDate(), request.semesterEndDate()), request.academicYear(),
+                request.semesterType()
+        );
         recruitmentRepository.save(recruitment);
 
         log.info("[AdminRecruitmentService] 리쿠르팅 생성: recruitmentId={}", recruitment.getId());
@@ -82,7 +81,7 @@ public class AdminRecruitmentService {
                 recruitmentRoundsInThisSemester);
 
         RecruitmentRound recruitmentRound = RecruitmentRound.create(
-                request.name(), Period.of(request.startDate(), request.endDate()), recruitment, request.roundType());
+                request.name(), request.roundType(), Period.of(request.startDate(), request.endDate()), recruitment);
         recruitmentRoundRepository.save(recruitmentRound);
 
         log.info("[AdminRecruitmentService] 모집회차 생성: recruitmentRoundId={}", recruitmentRound.getId());

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -42,10 +42,11 @@ public class AdminRecruitmentService {
         recruitmentValidator.validateRecruitmentCreate(isRecruitmentOverlap);
 
         Recruitment recruitment = Recruitment.create(
-                request.feeName(), Money.from(request.fee()),
-                Period.of(request.semesterStartDate(), request.semesterEndDate()), request.academicYear(),
-                request.semesterType()
-        );
+                request.feeName(),
+                Money.from(request.fee()),
+                Period.of(request.semesterStartDate(), request.semesterEndDate()),
+                request.academicYear(),
+                request.semesterType());
         recruitmentRepository.save(recruitment);
 
         log.info("[AdminRecruitmentService] 리쿠르팅 생성: recruitmentId={}", recruitment.getId());

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
@@ -20,31 +20,31 @@ public class Recruitment extends BaseSemesterEntity {
     @Column(name = "recruitment_id")
     private Long id;
 
+    private String feeName;
+
     @Embedded
     private Money fee;
-
-    private String feeName;
 
     @Embedded
     private Period semesterPeriod;
 
     @Builder(access = AccessLevel.PRIVATE)
     private Recruitment(
-            Integer academicYear, SemesterType semesterType, Money fee, String feeName, final Period semesterPeriod) {
+            String feeName, Money fee, final Period semesterPeriod, Integer academicYear, SemesterType semesterType) {
         super(academicYear, semesterType);
-        this.fee = fee;
         this.feeName = feeName;
+        this.fee = fee;
         this.semesterPeriod = semesterPeriod;
     }
 
     public static Recruitment create(
-            Integer academicYear, SemesterType semesterType, Money fee, String feeName, Period semesterPeriod) {
+            String feeName, Money fee, Period semesterPeriod, Integer academicYear, SemesterType semesterType) {
         return Recruitment.builder()
+                .feeName(feeName)
+                .fee(fee)
+                .semesterPeriod(semesterPeriod)
                 .academicYear(academicYear)
                 .semesterType(semesterType)
-                .fee(fee)
-                .feeName(feeName)
-                .semesterPeriod(semesterPeriod)
                 .build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
@@ -34,6 +34,9 @@ public class RecruitmentRound extends BaseSemesterEntity {
 
     private String name;
 
+    @Enumerated(EnumType.STRING)
+    private RoundType roundType;
+
     @Embedded
     private Period period;
 
@@ -41,32 +44,29 @@ public class RecruitmentRound extends BaseSemesterEntity {
     @JoinColumn(name = "recruitment_id")
     private Recruitment recruitment;
 
-    @Enumerated(EnumType.STRING)
-    private RoundType roundType;
-
     @Builder(access = AccessLevel.PRIVATE)
     private RecruitmentRound(
             String name,
+            RoundType roundType,
             final Period period,
-            Integer academicYear,
-            SemesterType semesterType,
             Recruitment recruitment,
-            RoundType roundType) {
+            Integer academicYear,
+            SemesterType semesterType) {
         super(academicYear, semesterType);
         this.name = name;
+        this.roundType = roundType;
         this.period = period;
         this.recruitment = recruitment;
-        this.roundType = roundType;
     }
 
-    public static RecruitmentRound create(String name, Period period, Recruitment recruitment, RoundType roundType) {
+    public static RecruitmentRound create(String name, RoundType roundType, Period period, Recruitment recruitment) {
         return RecruitmentRound.builder()
                 .name(name)
                 .period(period)
-                .academicYear(recruitment.getAcademicYear())
-                .semesterType(recruitment.getSemesterType())
                 .recruitment(recruitment)
                 .roundType(roundType)
+                .academicYear(recruitment.getAcademicYear())
+                .semesterType(recruitment.getSemesterType())
                 .build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
@@ -62,9 +62,9 @@ public class RecruitmentRound extends BaseSemesterEntity {
     public static RecruitmentRound create(String name, RoundType roundType, Period period, Recruitment recruitment) {
         return RecruitmentRound.builder()
                 .name(name)
+                .roundType(roundType)
                 .period(period)
                 .recruitment(recruitment)
-                .roundType(roundType)
                 .academicYear(recruitment.getAcademicYear())
                 .semesterType(recruitment.getSemesterType())
                 .build();

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
@@ -32,10 +32,10 @@ public class RecruitmentRound extends BaseSemesterEntity {
     @Column(name = "recruitment_round_id")
     private Long id;
 
-    private String name;
-
     @Enumerated(EnumType.STRING)
     private RoundType roundType;
+
+    private String name;
 
     @Embedded
     private Period period;
@@ -46,8 +46,8 @@ public class RecruitmentRound extends BaseSemesterEntity {
 
     @Builder(access = AccessLevel.PRIVATE)
     private RecruitmentRound(
-            String name,
             RoundType roundType,
+            String name,
             final Period period,
             Recruitment recruitment,
             Integer academicYear,
@@ -61,8 +61,8 @@ public class RecruitmentRound extends BaseSemesterEntity {
 
     public static RecruitmentRound create(String name, RoundType roundType, Period period, Recruitment recruitment) {
         return RecruitmentRound.builder()
-                .name(name)
                 .roundType(roundType)
+                .name(name)
                 .period(period)
                 .recruitment(recruitment)
                 .academicYear(recruitment.getAcademicYear())

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyAchievementService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyAchievementService.java
@@ -52,7 +52,7 @@ public class MentorStudyAchievementService {
 
         List<Member> outstandingStudents = memberRepository.findAllById(request.studentIds());
         List<StudyAchievement> studyAchievements = outstandingStudents.stream()
-                .map(member -> StudyAchievement.create(member, study, request.achievementType()))
+                .map(member -> StudyAchievement.create(request.achievementType(), member, study))
                 .toList();
         studyAchievementRepository.saveAll(studyAchievements);
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
@@ -123,7 +123,8 @@ public class MentorStudyService {
 
         studyValidator.validateStudyMentor(currentMember, study);
 
-        StudyAnnouncement studyAnnouncement = StudyAnnouncement.create(study, request.title(), request.link());
+        StudyAnnouncement studyAnnouncement = StudyAnnouncement.create(request.title(),
+                request.link(), study);
         studyAnnouncementRepository.save(studyAnnouncement);
 
         log.info("[MentorStudyService] 스터디 공지 생성: studyAnnouncementId={}", studyAnnouncement.getId());

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/MentorStudyService.java
@@ -123,8 +123,7 @@ public class MentorStudyService {
 
         studyValidator.validateStudyMentor(currentMember, study);
 
-        StudyAnnouncement studyAnnouncement = StudyAnnouncement.create(request.title(),
-                request.link(), study);
+        StudyAnnouncement studyAnnouncement = StudyAnnouncement.create(request.title(), request.link(), study);
         studyAnnouncementRepository.save(studyAnnouncement);
 
         log.info("[MentorStudyService] 스터디 공지 생성: studyAnnouncementId={}", studyAnnouncement.getId());

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
@@ -36,20 +36,20 @@ public class AssignmentHistory extends BaseEntity {
     @Column(name = "assignment_history_id")
     private Long id;
 
-    @Column(columnDefinition = "TEXT")
-    private String submissionLink;
-
-    private String commitHash;
-
-    private Integer contentLength;
-
-    private LocalDateTime committedAt;
-
     @Enumerated(EnumType.STRING)
     private AssignmentSubmissionStatus submissionStatus;
 
     @Enumerated(EnumType.STRING)
     private SubmissionFailureType submissionFailureType;
+
+    private Integer contentLength;
+
+    @Column(columnDefinition = "TEXT")
+    private String submissionLink;
+
+    private String commitHash;
+
+    private LocalDateTime committedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "study_detail_id")

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
@@ -36,14 +36,6 @@ public class AssignmentHistory extends BaseEntity {
     @Column(name = "assignment_history_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "study_detail_id")
-    private StudyDetail studyDetail;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
-
     @Column(columnDefinition = "TEXT")
     private String submissionLink;
 
@@ -59,24 +51,32 @@ public class AssignmentHistory extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private SubmissionFailureType submissionFailureType;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_detail_id")
+    private StudyDetail studyDetail;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
     @Builder(access = AccessLevel.PRIVATE)
     private AssignmentHistory(
-            StudyDetail studyDetail,
-            Member member,
             AssignmentSubmissionStatus submissionStatus,
-            SubmissionFailureType submissionFailureType) {
-        this.studyDetail = studyDetail;
-        this.member = member;
+            SubmissionFailureType submissionFailureType,
+            StudyDetail studyDetail,
+            Member member) {
         this.submissionStatus = submissionStatus;
         this.submissionFailureType = submissionFailureType;
+        this.studyDetail = studyDetail;
+        this.member = member;
     }
 
     public static AssignmentHistory create(StudyDetail studyDetail, Member member) {
         return AssignmentHistory.builder()
-                .studyDetail(studyDetail)
-                .member(member)
                 .submissionStatus(FAILURE)
                 .submissionFailureType(NOT_SUBMITTED)
+                .studyDetail(studyDetail)
+                .member(member)
                 .build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
@@ -42,18 +42,6 @@ public class Study extends BaseSemesterEntity {
 
     private String title;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member mentor;
-
-    @Embedded
-    private Period period;
-
-    @Embedded
-    @AttributeOverride(name = "startDate", column = @Column(name = "application_start_date"))
-    @AttributeOverride(name = "endDate", column = @Column(name = "application_end_date"))
-    private Period applicationPeriod;
-
     @Comment("총 주차수")
     private Long totalWeek;
 
@@ -64,6 +52,12 @@ public class Study extends BaseSemesterEntity {
     @Comment("스터디 한줄 소개")
     private String introduction;
 
+    @Comment("스터디 시작 시간")
+    private LocalTime startTime;
+
+    @Comment("스터디 종료 시간")
+    private LocalTime endTime;
+
     @Enumerated(EnumType.STRING)
     private StudyType studyType;
 
@@ -71,64 +65,70 @@ public class Study extends BaseSemesterEntity {
     @Enumerated(EnumType.STRING)
     private DayOfWeek dayOfWeek;
 
-    @Comment("스터디 시작 시간")
-    private LocalTime startTime;
+    @Embedded
+    private Period period;
 
-    @Comment("스터디 종료 시간")
-    private LocalTime endTime;
+    @Embedded
+    @AttributeOverride(name = "startDate", column = @Column(name = "application_start_date"))
+    @AttributeOverride(name = "endDate", column = @Column(name = "application_end_date"))
+    private Period applicationPeriod;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member mentor;
 
     @Builder(access = AccessLevel.PRIVATE)
     private Study(
-            Integer academicYear,
-            SemesterType semesterType,
             String title,
-            Member mentor,
-            Period period,
-            Period applicationPeriod,
             Long totalWeek,
+            LocalTime startTime,
+            LocalTime endTime,
             StudyType studyType,
             DayOfWeek dayOfWeek,
-            LocalTime startTime,
-            LocalTime endTime) {
+            Period period,
+            Period applicationPeriod,
+            Member mentor,
+            Integer academicYear,
+            SemesterType semesterType) {
         super(academicYear, semesterType);
         this.title = title;
-        this.mentor = mentor;
-        this.period = period;
-        this.applicationPeriod = applicationPeriod;
         this.totalWeek = totalWeek;
-        this.studyType = studyType;
-        this.dayOfWeek = dayOfWeek;
         this.startTime = startTime;
         this.endTime = endTime;
+        this.studyType = studyType;
+        this.dayOfWeek = dayOfWeek;
+        this.period = period;
+        this.applicationPeriod = applicationPeriod;
+        this.mentor = mentor;
     }
 
     public static Study create(
-            Integer academicYear,
-            SemesterType semesterType,
             String title,
-            Member mentor,
-            Period period,
-            Period applicationPeriod,
             Long totalWeek,
+            LocalTime startTime,
+            LocalTime endTime,
             StudyType studyType,
             DayOfWeek dayOfWeek,
-            LocalTime startTime,
-            LocalTime endTime) {
+            Period period,
+            Period applicationPeriod,
+            Member mentor,
+            Integer academicYear,
+            SemesterType semesterType) {
         validateApplicationStartDateBeforeCurriculumStartDate(applicationPeriod.getStartDate(), period.getStartDate());
         validateMentorRole(mentor);
         validateStudyTime(studyType, startTime, endTime);
         return Study.builder()
-                .academicYear(academicYear)
-                .semesterType(semesterType)
                 .title(title)
-                .mentor(mentor)
-                .period(period)
-                .applicationPeriod(applicationPeriod)
                 .totalWeek(totalWeek)
-                .studyType(studyType)
-                .dayOfWeek(dayOfWeek)
                 .startTime(startTime)
                 .endTime(endTime)
+                .studyType(studyType)
+                .dayOfWeek(dayOfWeek)
+                .period(period)
+                .applicationPeriod(applicationPeriod)
+                .mentor(mentor)
+                .academicYear(academicYear)
+                .semesterType(semesterType)
                 .build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
@@ -40,30 +40,30 @@ public class Study extends BaseSemesterEntity {
     @Column(name = "study_id")
     private Long id;
 
+    @Enumerated(EnumType.STRING)
+    private StudyType studyType;
+
     private String title;
 
-    @Comment("총 주차수")
-    private Long totalWeek;
+    @Comment("스터디 한줄 소개")
+    private String introduction;
 
     @Comment("스터디 상세 노션 링크(Text)")
     @Column(columnDefinition = "TEXT")
     private String notionLink;
 
-    @Comment("스터디 한줄 소개")
-    private String introduction;
+    @Comment("총 주차수")
+    private Long totalWeek;
+
+    @Comment("스터디 요일")
+    @Enumerated(EnumType.STRING)
+    private DayOfWeek dayOfWeek;
 
     @Comment("스터디 시작 시간")
     private LocalTime startTime;
 
     @Comment("스터디 종료 시간")
     private LocalTime endTime;
-
-    @Enumerated(EnumType.STRING)
-    private StudyType studyType;
-
-    @Comment("스터디 요일")
-    @Enumerated(EnumType.STRING)
-    private DayOfWeek dayOfWeek;
 
     @Embedded
     private Period period;
@@ -79,36 +79,36 @@ public class Study extends BaseSemesterEntity {
 
     @Builder(access = AccessLevel.PRIVATE)
     private Study(
+            StudyType studyType,
             String title,
             Long totalWeek,
+            DayOfWeek dayOfWeek,
             LocalTime startTime,
             LocalTime endTime,
-            StudyType studyType,
-            DayOfWeek dayOfWeek,
             Period period,
             Period applicationPeriod,
             Member mentor,
             Integer academicYear,
             SemesterType semesterType) {
         super(academicYear, semesterType);
+        this.studyType = studyType;
         this.title = title;
         this.totalWeek = totalWeek;
+        this.dayOfWeek = dayOfWeek;
         this.startTime = startTime;
         this.endTime = endTime;
-        this.studyType = studyType;
-        this.dayOfWeek = dayOfWeek;
         this.period = period;
         this.applicationPeriod = applicationPeriod;
         this.mentor = mentor;
     }
 
     public static Study create(
+            StudyType studyType,
             String title,
             Long totalWeek,
+            DayOfWeek dayOfWeek,
             LocalTime startTime,
             LocalTime endTime,
-            StudyType studyType,
-            DayOfWeek dayOfWeek,
             Period period,
             Period applicationPeriod,
             Member mentor,
@@ -118,12 +118,12 @@ public class Study extends BaseSemesterEntity {
         validateMentorRole(mentor);
         validateStudyTime(studyType, startTime, endTime);
         return Study.builder()
+                .studyType(studyType)
                 .title(title)
                 .totalWeek(totalWeek)
+                .dayOfWeek(dayOfWeek)
                 .startTime(startTime)
                 .endTime(endTime)
-                .studyType(studyType)
-                .dayOfWeek(dayOfWeek)
                 .period(period)
                 .applicationPeriod(applicationPeriod)
                 .mentor(mentor)

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAchievement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAchievement.java
@@ -30,6 +30,9 @@ public class StudyAchievement extends BaseEntity {
     @Column(name = "study_achievement_id")
     private Long id;
 
+    @Enumerated(EnumType.STRING)
+    private AchievementType achievementType;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member student;
@@ -38,21 +41,18 @@ public class StudyAchievement extends BaseEntity {
     @JoinColumn(name = "study_id")
     private Study study;
 
-    @Enumerated(EnumType.STRING)
-    private AchievementType achievementType;
-
     @Builder(access = AccessLevel.PRIVATE)
-    private StudyAchievement(Member student, Study study, AchievementType achievementType) {
+    private StudyAchievement(AchievementType achievementType, Member student, Study study) {
+        this.achievementType = achievementType;
         this.student = student;
         this.study = study;
-        this.achievementType = achievementType;
     }
 
-    public static StudyAchievement create(Member student, Study study, AchievementType achievementType) {
+    public static StudyAchievement create(AchievementType achievementType, Member student, Study study) {
         return StudyAchievement.builder()
+                .achievementType(achievementType)
                 .student(student)
                 .study(study)
-                .achievementType(achievementType)
                 .build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAnnouncement.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyAnnouncement.java
@@ -24,24 +24,24 @@ public class StudyAnnouncement extends BaseEntity {
     @Column(name = "study_announcement_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "study_id")
-    private Study study;
-
     private String title;
 
     @Column(columnDefinition = "TEXT")
     private String link;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_id")
+    private Study study;
+
     @Builder(access = AccessLevel.PRIVATE)
-    public StudyAnnouncement(Study study, String title, String link) {
-        this.study = study;
+    public StudyAnnouncement(String title, String link, Study study) {
         this.title = title;
         this.link = link;
+        this.study = study;
     }
 
-    public static StudyAnnouncement create(Study study, String title, String link) {
-        return StudyAnnouncement.builder().study(study).title(title).link(link).build();
+    public static StudyAnnouncement create(String title, String link, Study study) {
+        return StudyAnnouncement.builder().title(title).link(link).study(study).build();
     }
 
     public void update(String title, String link) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyDetail.java
@@ -28,10 +28,6 @@ public class StudyDetail extends BaseEntity {
     @Column(name = "study_detail_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "study_id")
-    private Study study;
-
     @Comment("현 주차수")
     private Long week; // TODO: Integer로 변경
 
@@ -55,31 +51,35 @@ public class StudyDetail extends BaseEntity {
     @AttributeOverride(name = "status", column = @Column(name = "assignment_status"))
     private Assignment assignment;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_id")
+    private Study study;
+
     @Builder(access = AccessLevel.PRIVATE)
     private StudyDetail(
-            Study study,
             Long week,
             String attendanceNumber,
             Period period,
             Curriculum curriculum,
-            Assignment assignment) {
-        this.study = study;
+            Assignment assignment,
+            Study study) {
         this.week = week;
         this.attendanceNumber = attendanceNumber;
         this.period = period;
         this.curriculum = curriculum;
         this.assignment = assignment;
+        this.study = study;
     }
 
-    public static StudyDetail create(Study study, Long week, String attendanceNumber, Period period) {
+    public static StudyDetail create(Long week, String attendanceNumber, Period period, Study study) {
         return StudyDetail.builder()
-                .study(study)
                 .week(week)
                 .period(period)
                 .attendanceNumber(attendanceNumber)
                 .period(period)
                 .curriculum(Curriculum.empty())
                 .assignment(Assignment.empty())
+                .study(study)
                 .build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -35,6 +35,12 @@ public class StudyHistory extends BaseEntity {
     @Column(name = "study_history_id")
     private Long id;
 
+    private String repositoryLink;
+
+    @Comment("수료 상태")
+    @Enumerated(EnumType.STRING)
+    private StudyHistoryStatus studyHistoryStatus;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member student;
@@ -43,17 +49,11 @@ public class StudyHistory extends BaseEntity {
     @JoinColumn(name = "study_id")
     private Study study;
 
-    private String repositoryLink;
-
-    @Comment("수료 상태")
-    @Enumerated(EnumType.STRING)
-    private StudyHistoryStatus studyHistoryStatus;
-
     @Builder(access = AccessLevel.PRIVATE)
     private StudyHistory(Member student, Study study) {
+        this.studyHistoryStatus = NONE;
         this.student = student;
         this.study = study;
-        this.studyHistoryStatus = NONE;
     }
 
     public static StudyHistory create(Member student, Study study) {

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/StudyHistory.java
@@ -35,11 +35,11 @@ public class StudyHistory extends BaseEntity {
     @Column(name = "study_history_id")
     private Long id;
 
-    private String repositoryLink;
-
     @Comment("수료 상태")
     @Enumerated(EnumType.STRING)
     private StudyHistoryStatus studyHistoryStatus;
+
+    private String repositoryLink;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/gdschongik/gdsc/domain/study/factory/StudyDomainFactory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/factory/StudyDomainFactory.java
@@ -18,9 +18,11 @@ public class StudyDomainFactory {
     public Study createNewStudy(StudyCreateRequest request, Member mentor) {
         LocalDate endDate = request.startDate().plusWeeks(request.totalWeek()).minusDays(1);
         return Study.create(
-                request.studyType(), request.title(),
+                request.studyType(),
+                request.title(),
                 request.totalWeek(),
-                request.dayOfWeek(), request.studyStartTime(),
+                request.dayOfWeek(),
+                request.studyStartTime(),
                 request.studyEndTime(),
                 Period.of(request.startDate().atStartOfDay(), endDate.atTime(LocalTime.MAX)),
                 Period.of(

--- a/src/main/java/com/gdschongik/gdsc/domain/study/factory/StudyDomainFactory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/factory/StudyDomainFactory.java
@@ -18,13 +18,19 @@ public class StudyDomainFactory {
     public Study createNewStudy(StudyCreateRequest request, Member mentor) {
         LocalDate endDate = request.startDate().plusWeeks(request.totalWeek()).minusDays(1);
         return Study.create(
-                request.title(), request.totalWeek(), request.studyStartTime(),
-                request.studyEndTime(), request.studyType(), request.dayOfWeek(),
-                Period.of(request.startDate().atStartOfDay(), endDate.atTime(LocalTime.MAX)), Period.of(
+                request.title(),
+                request.totalWeek(),
+                request.studyStartTime(),
+                request.studyEndTime(),
+                request.studyType(),
+                request.dayOfWeek(),
+                Period.of(request.startDate().atStartOfDay(), endDate.atTime(LocalTime.MAX)),
+                Period.of(
                         request.applicationStartDate().atStartOfDay(),
-                        request.applicationEndDate().atTime(LocalTime.MAX)), mentor, request.academicYear(),
-                request.semesterType()
-        );
+                        request.applicationEndDate().atTime(LocalTime.MAX)),
+                mentor,
+                request.academicYear(),
+                request.semesterType());
     }
 
     // 해당 주의 비어있는 스터디상세를 생성합니다.

--- a/src/main/java/com/gdschongik/gdsc/domain/study/factory/StudyDomainFactory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/factory/StudyDomainFactory.java
@@ -18,12 +18,10 @@ public class StudyDomainFactory {
     public Study createNewStudy(StudyCreateRequest request, Member mentor) {
         LocalDate endDate = request.startDate().plusWeeks(request.totalWeek()).minusDays(1);
         return Study.create(
-                request.title(),
+                request.studyType(), request.title(),
                 request.totalWeek(),
-                request.studyStartTime(),
+                request.dayOfWeek(), request.studyStartTime(),
                 request.studyEndTime(),
-                request.studyType(),
-                request.dayOfWeek(),
                 Period.of(request.startDate().atStartOfDay(), endDate.atTime(LocalTime.MAX)),
                 Period.of(
                         request.applicationStartDate().atStartOfDay(),

--- a/src/main/java/com/gdschongik/gdsc/domain/study/factory/StudyDomainFactory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/factory/StudyDomainFactory.java
@@ -18,19 +18,13 @@ public class StudyDomainFactory {
     public Study createNewStudy(StudyCreateRequest request, Member mentor) {
         LocalDate endDate = request.startDate().plusWeeks(request.totalWeek()).minusDays(1);
         return Study.create(
-                request.academicYear(),
-                request.semesterType(),
-                request.title(),
-                mentor,
-                Period.of(request.startDate().atStartOfDay(), endDate.atTime(LocalTime.MAX)),
-                Period.of(
+                request.title(), request.totalWeek(), request.studyStartTime(),
+                request.studyEndTime(), request.studyType(), request.dayOfWeek(),
+                Period.of(request.startDate().atStartOfDay(), endDate.atTime(LocalTime.MAX)), Period.of(
                         request.applicationStartDate().atStartOfDay(),
-                        request.applicationEndDate().atTime(LocalTime.MAX)),
-                request.totalWeek(),
-                request.studyType(),
-                request.dayOfWeek(),
-                request.studyStartTime(),
-                request.studyEndTime());
+                        request.applicationEndDate().atTime(LocalTime.MAX)), mentor, request.academicYear(),
+                request.semesterType()
+        );
     }
 
     // 해당 주의 비어있는 스터디상세를 생성합니다.
@@ -40,6 +34,6 @@ public class StudyDomainFactory {
 
         String attendanceNumber =
                 new Random().ints(4, 0, 10).mapToObj(String::valueOf).reduce("", String::concat);
-        return StudyDetail.create(study, week, attendanceNumber, Period.of(startDate, endDate));
+        return StudyDetail.create(week, attendanceNumber, Period.of(startDate, endDate), study);
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/util/CouponNameUtilTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/util/CouponNameUtilTest.java
@@ -21,12 +21,10 @@ class CouponNameUtilTest {
         // given
         Member mentor = fixtureHelper.createMentor(1L);
         Study study = Study.create(
-                "기초 백엔드 스터디",
+                ONLINE_STUDY, "기초 백엔드 스터디",
                 TOTAL_WEEK,
-                STUDY_START_TIME,
+                DAY_OF_WEEK, STUDY_START_TIME,
                 STUDY_END_TIME,
-                ONLINE_STUDY,
-                DAY_OF_WEEK,
                 STUDY_ONGOING_PERIOD,
                 Period.of(START_DATE.minusDays(10), START_DATE.minusDays(5)),
                 mentor,

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/util/CouponNameUtilTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/util/CouponNameUtilTest.java
@@ -21,9 +21,11 @@ class CouponNameUtilTest {
         // given
         Member mentor = fixtureHelper.createMentor(1L);
         Study study = Study.create(
-                ONLINE_STUDY, "기초 백엔드 스터디",
+                ONLINE_STUDY,
+                "기초 백엔드 스터디",
                 TOTAL_WEEK,
-                DAY_OF_WEEK, STUDY_START_TIME,
+                DAY_OF_WEEK,
+                STUDY_START_TIME,
                 STUDY_END_TIME,
                 STUDY_ONGOING_PERIOD,
                 Period.of(START_DATE.minusDays(10), START_DATE.minusDays(5)),

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/util/CouponNameUtilTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/util/CouponNameUtilTest.java
@@ -21,11 +21,17 @@ class CouponNameUtilTest {
         // given
         Member mentor = fixtureHelper.createMentor(1L);
         Study study = Study.create(
-                "기초 백엔드 스터디", TOTAL_WEEK, STUDY_START_TIME, STUDY_END_TIME, ONLINE_STUDY,
-                DAY_OF_WEEK, STUDY_ONGOING_PERIOD,
-                Period.of(START_DATE.minusDays(10), START_DATE.minusDays(5)), mentor, 2025,
-                SemesterType.FIRST
-        );
+                "기초 백엔드 스터디",
+                TOTAL_WEEK,
+                STUDY_START_TIME,
+                STUDY_END_TIME,
+                ONLINE_STUDY,
+                DAY_OF_WEEK,
+                STUDY_ONGOING_PERIOD,
+                Period.of(START_DATE.minusDays(10), START_DATE.minusDays(5)),
+                mentor,
+                2025,
+                SemesterType.FIRST);
 
         // when
         String couponName = couponNameUtil.generateStudyCompletionCouponName(study);

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/util/CouponNameUtilTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/util/CouponNameUtilTest.java
@@ -21,17 +21,11 @@ class CouponNameUtilTest {
         // given
         Member mentor = fixtureHelper.createMentor(1L);
         Study study = Study.create(
-                2025,
-                SemesterType.FIRST,
-                "기초 백엔드 스터디",
-                mentor,
-                STUDY_ONGOING_PERIOD,
-                Period.of(START_DATE.minusDays(10), START_DATE.minusDays(5)),
-                TOTAL_WEEK,
-                ONLINE_STUDY,
-                DAY_OF_WEEK,
-                STUDY_START_TIME,
-                STUDY_END_TIME);
+                "기초 백엔드 스터디", TOTAL_WEEK, STUDY_START_TIME, STUDY_END_TIME, ONLINE_STUDY,
+                DAY_OF_WEEK, STUDY_ONGOING_PERIOD,
+                Period.of(START_DATE.minusDays(10), START_DATE.minusDays(5)), mentor, 2025,
+                SemesterType.FIRST
+        );
 
         // when
         String couponName = couponNameUtil.generateStudyCompletionCouponName(study);

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
@@ -25,10 +25,10 @@ public class MemberValidatorTest {
         void 해당_학기에_이미_시작된_모집기간이_있다면_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
             LocalDateTime now = LocalDateTime.now();
             RecruitmentRound recruitmentRound = RecruitmentRound.create(
-                    RECRUITMENT_ROUND_NAME, Period.of(now.minusDays(1), now.plusDays(1)), recruitment, ROUND_TYPE);
+                    RECRUITMENT_ROUND_NAME, ROUND_TYPE, Period.of(now.minusDays(1), now.plusDays(1)), recruitment);
             List<RecruitmentRound> recruitmentRounds = List.of(recruitmentRound);
 
             // when & then

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
@@ -29,9 +29,9 @@ class MembershipTest {
             member.advanceToAssociate();
 
             Recruitment recruitment = Recruitment.create(
-                    ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE));
+                    FEE_NAME, FEE, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE), ACADEMIC_YEAR, SEMESTER_TYPE);
             RecruitmentRound recruitmentRound =
-                    RecruitmentRound.create(RECRUITMENT_ROUND_NAME, START_TO_END_PERIOD, recruitment, ROUND_TYPE);
+                    RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, START_TO_END_PERIOD, recruitment);
 
             // when
             Membership membership = Membership.create(member, recruitmentRound);

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
@@ -42,8 +42,7 @@ class MembershipValidatorTest {
             LocalDateTime endDate) {
         Recruitment recruitment = Recruitment.create(
                 FEE_NAME, fee, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE), academicYear, semesterType);
-        return RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE,
-                Period.of(startDate, endDate), recruitment);
+        return RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, Period.of(startDate, endDate), recruitment);
     }
 
     @Nested

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
@@ -41,8 +41,9 @@ class MembershipValidatorTest {
             LocalDateTime startDate,
             LocalDateTime endDate) {
         Recruitment recruitment = Recruitment.create(
-                academicYear, semesterType, fee, FEE_NAME, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE));
-        return RecruitmentRound.create(RECRUITMENT_ROUND_NAME, Period.of(startDate, endDate), recruitment, ROUND_TYPE);
+                FEE_NAME, fee, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE), academicYear, semesterType);
+        return RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE,
+                Period.of(startDate, endDate), recruitment);
     }
 
     @Nested

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderTest.java
@@ -58,7 +58,7 @@ class OrderTest {
             MoneyInfo freeMoneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_20000_WON, Money.ZERO);
 
             // when
-            Order order = Order.createFree("testNanoId", membership, null, freeMoneyInfo);
+            Order order = Order.createFree("testNanoId", freeMoneyInfo, membership, null);
 
             // then
             assertThat(order.getStatus()).isEqualTo(OrderStatus.COMPLETED);
@@ -78,7 +78,7 @@ class OrderTest {
             MoneyInfo freeMoneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_15000_WON, MONEY_5000_WON);
 
             // when & then
-            assertThatThrownBy(() -> Order.createFree("testNanoId", membership, null, freeMoneyInfo))
+            assertThatThrownBy(() -> Order.createFree("testNanoId", freeMoneyInfo, membership, null))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ORDER_FREE_FINAL_PAYMENT_NOT_ZERO.getMessage());
         }
@@ -100,7 +100,8 @@ class OrderTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             Order order = Order.createPending(
-                    "testNanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+                    "testNanoId", MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON),
+                    membership, null);
 
             ZonedDateTime canceledAt = ZonedDateTime.now();
 
@@ -123,7 +124,8 @@ class OrderTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             Order order = Order.createPending(
-                    "testNanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+                    "testNanoId", MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON),
+                    membership, null);
             order.complete("testPaymentKey", ZonedDateTime.now());
             order.cancel(ZonedDateTime.now());
 
@@ -148,7 +150,7 @@ class OrderTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
             MoneyInfo freeMoneyInfo = MoneyInfo.of(MONEY_20000_WON, MONEY_20000_WON, Money.ZERO);
 
-            Order order = Order.createFree("testNanoId", membership, null, freeMoneyInfo);
+            Order order = Order.createFree("testNanoId", freeMoneyInfo, membership, null);
 
             ZonedDateTime canceledAt = ZonedDateTime.now();
 
@@ -171,7 +173,8 @@ class OrderTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             Order order = Order.createPending(
-                    "testNanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+                    "testNanoId", MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON),
+                    membership, null);
             order.complete("testPaymentKey", ZonedDateTime.now());
 
             ZonedDateTime canceledAt = ZonedDateTime.now();

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderTest.java
@@ -100,8 +100,7 @@ class OrderTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             Order order = Order.createPending(
-                    "testNanoId", MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON),
-                    membership, null);
+                    "testNanoId", MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON), membership, null);
 
             ZonedDateTime canceledAt = ZonedDateTime.now();
 
@@ -124,8 +123,7 @@ class OrderTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             Order order = Order.createPending(
-                    "testNanoId", MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON),
-                    membership, null);
+                    "testNanoId", MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON), membership, null);
             order.complete("testPaymentKey", ZonedDateTime.now());
             order.cancel(ZonedDateTime.now());
 
@@ -173,8 +171,7 @@ class OrderTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             Order order = Order.createPending(
-                    "testNanoId", MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON),
-                    membership, null);
+                    "testNanoId", MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON), membership, null);
             order.complete("testPaymentKey", ZonedDateTime.now());
 
             ZonedDateTime canceledAt = ZonedDateTime.now();

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
@@ -322,8 +322,7 @@ class OrderValidatorTest {
             issuedCoupon.use(LocalDateTime.now()); // 쿠폰을 사용 불가능한 상태로 만듦
 
             Order order = Order.createPending(
-                    "nanoId", MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON),
-                    membership, issuedCoupon);
+                    "nanoId", MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON), membership, issuedCoupon);
 
             Optional<IssuedCoupon> optionalIssuedCoupon = Optional.of(issuedCoupon);
 
@@ -350,8 +349,7 @@ class OrderValidatorTest {
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, anotherMember);
 
             Order order = Order.createPending(
-                    "nanoId", MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON),
-                    membership, issuedCoupon);
+                    "nanoId", MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON), membership, issuedCoupon);
 
             Optional<IssuedCoupon> optionalIssuedCoupon = Optional.of(issuedCoupon);
 
@@ -425,8 +423,7 @@ class OrderValidatorTest {
 
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
             Order order = Order.createPending(
-                    "nanoId", MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON),
-                    membership, issuedCoupon);
+                    "nanoId", MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON), membership, issuedCoupon);
 
             Optional<IssuedCoupon> optionalIssuedCoupon = Optional.of(issuedCoupon);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/domain/OrderValidatorTest.java
@@ -294,7 +294,7 @@ class OrderValidatorTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             Order completedOrder = Order.createPending(
-                    "nanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, Money.ZERO, MONEY_20000_WON));
+                    "nanoId", MoneyInfo.of(MONEY_20000_WON, Money.ZERO, MONEY_20000_WON), membership, null);
             completedOrder.complete("paymentKey", ZonedDateTime.now());
 
             Optional<IssuedCoupon> emptyIssuedCoupon = Optional.empty();
@@ -322,7 +322,8 @@ class OrderValidatorTest {
             issuedCoupon.use(LocalDateTime.now()); // 쿠폰을 사용 불가능한 상태로 만듦
 
             Order order = Order.createPending(
-                    "nanoId", membership, issuedCoupon, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+                    "nanoId", MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON),
+                    membership, issuedCoupon);
 
             Optional<IssuedCoupon> optionalIssuedCoupon = Optional.of(issuedCoupon);
 
@@ -349,7 +350,8 @@ class OrderValidatorTest {
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, anotherMember);
 
             Order order = Order.createPending(
-                    "nanoId", membership, issuedCoupon, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+                    "nanoId", MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON),
+                    membership, issuedCoupon);
 
             Optional<IssuedCoupon> optionalIssuedCoupon = Optional.of(issuedCoupon);
 
@@ -374,7 +376,7 @@ class OrderValidatorTest {
             Membership membership = createMembership(anotherMember, recruitmentRound);
 
             Order order = Order.createPending(
-                    "nanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, Money.ZERO, MONEY_20000_WON));
+                    "nanoId", MoneyInfo.of(MONEY_20000_WON, Money.ZERO, MONEY_20000_WON), membership, null);
 
             Optional<IssuedCoupon> emptyIssuedCoupon = Optional.empty();
 
@@ -398,7 +400,7 @@ class OrderValidatorTest {
             Membership membership = createMembership(currentMember, recruitmentRound);
 
             Order order = Order.createPending(
-                    "nanoId", membership, null, MoneyInfo.of(MONEY_20000_WON, Money.ZERO, MONEY_20000_WON));
+                    "nanoId", MoneyInfo.of(MONEY_20000_WON, Money.ZERO, MONEY_20000_WON), membership, null);
 
             Optional<IssuedCoupon> emptyIssuedCoupon = Optional.empty();
 
@@ -423,7 +425,8 @@ class OrderValidatorTest {
 
             IssuedCoupon issuedCoupon = createAndIssue(MONEY_5000_WON, currentMember);
             Order order = Order.createPending(
-                    "nanoId", membership, issuedCoupon, MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON));
+                    "nanoId", MoneyInfo.of(MONEY_20000_WON, MONEY_5000_WON, MONEY_15000_WON),
+                    membership, issuedCoupon);
 
             Optional<IssuedCoupon> optionalIssuedCoupon = Optional.of(issuedCoupon);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -71,8 +71,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
             // given
             LocalDateTime now = LocalDateTime.now().withNano(0);
             Recruitment recruitment =
-                    Recruitment.create(FEE_NAME, FEE, Period.of(now, now.plusMonths(3)),
-                            ACADEMIC_YEAR, SEMESTER_TYPE);
+                    Recruitment.create(FEE_NAME, FEE, Period.of(now, now.plusMonths(3)), ACADEMIC_YEAR, SEMESTER_TYPE);
             recruitmentRepository.save(recruitment);
 
             RecruitmentRound recruitmentRound = RecruitmentRound.create(

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -71,11 +71,12 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
             // given
             LocalDateTime now = LocalDateTime.now().withNano(0);
             Recruitment recruitment =
-                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, Period.of(now, now.plusMonths(3)));
+                    Recruitment.create(FEE_NAME, FEE, Period.of(now, now.plusMonths(3)),
+                            ACADEMIC_YEAR, SEMESTER_TYPE);
             recruitmentRepository.save(recruitment);
 
             RecruitmentRound recruitmentRound = RecruitmentRound.create(
-                    RECRUITMENT_ROUND_NAME, Period.of(now.plusDays(1), now.plusDays(2)), recruitment, ROUND_TYPE);
+                    RECRUITMENT_ROUND_NAME, ROUND_TYPE, Period.of(now.plusDays(1), now.plusDays(2)), recruitment);
             recruitmentRoundRepository.save(recruitmentRound);
 
             RecruitmentRoundUpdateRequest request = new RecruitmentRoundUpdateRequest(

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
@@ -25,11 +25,11 @@ public class RecruitmentRoundValidatorTest {
         void 모집_시작일과_종료일의_연도가_입력된_학년도와_다르다면_실패한다() {
             // given
             Recruitment recruitment = Recruitment.create(
-                    FEE_NAME, FEE,
+                    FEE_NAME,
+                    FEE,
                     Period.of(LocalDateTime.of(2025, 3, 2, 0, 0), LocalDateTime.of(2025, 8, 31, 0, 0)),
                     2025,
-                    SEMESTER_TYPE
-            );
+                    SEMESTER_TYPE);
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundCreate(
@@ -42,11 +42,11 @@ public class RecruitmentRoundValidatorTest {
         void 학기_시작일과_종료일의_학기가_입력된_학기와_다르다면_실패한다() {
             // given
             Recruitment recruitment = Recruitment.create(
-                    FEE_NAME, FEE,
+                    FEE_NAME,
+                    FEE,
                     Period.of(LocalDateTime.of(2024, 9, 1, 0, 0), LocalDateTime.of(2025, 2, 28, 0, 0)),
                     ACADEMIC_YEAR,
-                    SemesterType.SECOND
-            );
+                    SemesterType.SECOND);
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundCreate(

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
@@ -25,11 +25,11 @@ public class RecruitmentRoundValidatorTest {
         void 모집_시작일과_종료일의_연도가_입력된_학년도와_다르다면_실패한다() {
             // given
             Recruitment recruitment = Recruitment.create(
+                    FEE_NAME, FEE,
+                    Period.of(LocalDateTime.of(2025, 3, 2, 0, 0), LocalDateTime.of(2025, 8, 31, 0, 0)),
                     2025,
-                    SEMESTER_TYPE,
-                    FEE,
-                    FEE_NAME,
-                    Period.of(LocalDateTime.of(2025, 3, 2, 0, 0), LocalDateTime.of(2025, 8, 31, 0, 0)));
+                    SEMESTER_TYPE
+            );
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundCreate(
@@ -42,11 +42,11 @@ public class RecruitmentRoundValidatorTest {
         void 학기_시작일과_종료일의_학기가_입력된_학기와_다르다면_실패한다() {
             // given
             Recruitment recruitment = Recruitment.create(
+                    FEE_NAME, FEE,
+                    Period.of(LocalDateTime.of(2024, 9, 1, 0, 0), LocalDateTime.of(2025, 2, 28, 0, 0)),
                     ACADEMIC_YEAR,
-                    SemesterType.SECOND,
-                    FEE,
-                    FEE_NAME,
-                    Period.of(LocalDateTime.of(2024, 9, 1, 0, 0), LocalDateTime.of(2025, 2, 28, 0, 0)));
+                    SemesterType.SECOND
+            );
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundCreate(
@@ -59,7 +59,7 @@ public class RecruitmentRoundValidatorTest {
         void 모집_시작일과_종료일이_학기_시작일로부터_2주_이내에_있지_않다면_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundCreate(
@@ -72,10 +72,10 @@ public class RecruitmentRoundValidatorTest {
         void 학년도_학기_차수가_모두_중복되면_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
 
             RecruitmentRound recruitmentRound =
-                    RecruitmentRound.create(RECRUITMENT_ROUND_NAME, START_TO_END_PERIOD, recruitment, ROUND_TYPE);
+                    RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, START_TO_END_PERIOD, recruitment);
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundCreate(
@@ -92,7 +92,7 @@ public class RecruitmentRoundValidatorTest {
         void RoundType_1차가_없을때_2차를_생성하려_하면_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundCreate(
@@ -105,10 +105,10 @@ public class RecruitmentRoundValidatorTest {
         void 기간이_중복되는_모집회차가_있다면_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
 
             RecruitmentRound recruitmentRound =
-                    RecruitmentRound.create(RECRUITMENT_ROUND_NAME, START_TO_END_PERIOD, recruitment, ROUND_TYPE);
+                    RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, START_TO_END_PERIOD, recruitment);
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundCreate(
@@ -125,14 +125,14 @@ public class RecruitmentRoundValidatorTest {
         void 기간이_중복되는_모집회차가_있다면_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
 
             RecruitmentRound firstRound =
-                    RecruitmentRound.create(RECRUITMENT_ROUND_NAME, START_TO_END_PERIOD, recruitment, ROUND_TYPE);
+                    RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, START_TO_END_PERIOD, recruitment);
             ReflectionTestUtils.setField(firstRound, "id", 1L);
 
             RecruitmentRound secondRound = RecruitmentRound.create(
-                    RECRUITMENT_ROUND_NAME, ROUND_TWO_START_TO_END_PERIOD, recruitment, RoundType.SECOND);
+                    RECRUITMENT_ROUND_NAME, RoundType.SECOND, ROUND_TWO_START_TO_END_PERIOD, recruitment);
             ReflectionTestUtils.setField(secondRound, "id", 2L);
 
             // when & then
@@ -151,14 +151,14 @@ public class RecruitmentRoundValidatorTest {
         void 차수가_중복되는_모집회차가_있다면_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
 
             RecruitmentRound firstRound =
-                    RecruitmentRound.create(RECRUITMENT_ROUND_NAME, START_TO_END_PERIOD, recruitment, ROUND_TYPE);
+                    RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, START_TO_END_PERIOD, recruitment);
             ReflectionTestUtils.setField(firstRound, "id", 1L);
 
             RecruitmentRound secondRound = RecruitmentRound.create(
-                    RECRUITMENT_ROUND_NAME, ROUND_TWO_START_TO_END_PERIOD, recruitment, RoundType.SECOND);
+                    RECRUITMENT_ROUND_NAME, RoundType.SECOND, ROUND_TWO_START_TO_END_PERIOD, recruitment);
             ReflectionTestUtils.setField(secondRound, "id", 2L);
 
             // when & then
@@ -177,10 +177,10 @@ public class RecruitmentRoundValidatorTest {
         void 모집_시작일과_종료일이_학기_시작일로부터_2주_이내에_있지_않다면_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
 
             RecruitmentRound firstRound =
-                    RecruitmentRound.create(RECRUITMENT_ROUND_NAME, START_TO_END_PERIOD, recruitment, ROUND_TYPE);
+                    RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, START_TO_END_PERIOD, recruitment);
             ReflectionTestUtils.setField(firstRound, "id", 1L);
 
             // when & then
@@ -199,10 +199,10 @@ public class RecruitmentRoundValidatorTest {
         void RoundType_1차를_2차로_수정하려_하면_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
 
             RecruitmentRound firstRound =
-                    RecruitmentRound.create(RECRUITMENT_ROUND_NAME, START_TO_END_PERIOD, recruitment, ROUND_TYPE);
+                    RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, START_TO_END_PERIOD, recruitment);
             ReflectionTestUtils.setField(firstRound, "id", 1L);
 
             // when & then
@@ -216,10 +216,10 @@ public class RecruitmentRoundValidatorTest {
         void 모집_시작일이_지났다면_수정_실패한다() {
             // given
             Recruitment recruitment =
-                    Recruitment.create(ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, START_TO_END_PERIOD);
+                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
 
             RecruitmentRound recruitmentRound =
-                    RecruitmentRound.create(RECRUITMENT_ROUND_NAME, START_TO_END_PERIOD, recruitment, ROUND_TYPE);
+                    RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, START_TO_END_PERIOD, recruitment);
             long recruitmentRoundId = 1L;
             ReflectionTestUtils.setField(recruitmentRound, "id", recruitmentRoundId);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
@@ -19,7 +19,7 @@ class RecruitmentTest {
 
             // when
             Recruitment recruitment = Recruitment.create(
-                    ACADEMIC_YEAR, SEMESTER_TYPE, FEE, FEE_NAME, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE));
+                    FEE_NAME, FEE, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE), ACADEMIC_YEAR, SEMESTER_TYPE);
 
             // then
             assertThat(recruitment.getSemesterPeriod().getStartDate()).isEqualTo(SEMESTER_START_DATE);

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyTest.java
@@ -40,11 +40,13 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                    ONLINE_STUDY, STUDY_TITLE,
+                            ONLINE_STUDY,
+                            STUDY_TITLE,
                             TOTAL_WEEK,
-                    DAY_OF_WEEK, STUDY_START_TIME,
+                            DAY_OF_WEEK,
+                            STUDY_START_TIME,
                             STUDY_END_TIME,
-                    START_TO_END_PERIOD,
+                            START_TO_END_PERIOD,
                             applicationPeriod,
                             guestMember,
                             ACADEMIC_YEAR,
@@ -62,11 +64,13 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                    ONLINE_STUDY, STUDY_TITLE,
+                            ONLINE_STUDY,
+                            STUDY_TITLE,
                             TOTAL_WEEK,
-                    DAY_OF_WEEK, STUDY_START_TIME,
+                            DAY_OF_WEEK,
+                            STUDY_START_TIME,
                             STUDY_END_TIME,
-                    period,
+                            period,
                             applicationPeriod,
                             member,
                             ACADEMIC_YEAR,
@@ -84,11 +88,13 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                    ONLINE_STUDY, STUDY_TITLE,
+                            ONLINE_STUDY,
+                            STUDY_TITLE,
                             TOTAL_WEEK,
-                    DAY_OF_WEEK, null,
+                            DAY_OF_WEEK,
                             null,
-                    period,
+                            null,
+                            period,
                             applicationPeriod,
                             member,
                             ACADEMIC_YEAR,
@@ -108,11 +114,13 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                    ONLINE_STUDY, STUDY_TITLE,
+                            ONLINE_STUDY,
+                            STUDY_TITLE,
                             TOTAL_WEEK,
-                    DAY_OF_WEEK, studyStartTime,
+                            DAY_OF_WEEK,
+                            studyStartTime,
                             studyEndTime,
-                    period,
+                            period,
                             applicationPeriod,
                             member,
                             ACADEMIC_YEAR,
@@ -132,11 +140,13 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                    ASSIGNMENT_STUDY, STUDY_TITLE,
+                            ASSIGNMENT_STUDY,
+                            STUDY_TITLE,
                             TOTAL_WEEK,
-                    DAY_OF_WEEK, studyStartTime,
+                            DAY_OF_WEEK,
+                            studyStartTime,
                             studyEndTime,
-                    period,
+                            period,
                             applicationPeriod,
                             member,
                             ACADEMIC_YEAR,

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyTest.java
@@ -40,13 +40,11 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                            STUDY_TITLE,
+                    ONLINE_STUDY, STUDY_TITLE,
                             TOTAL_WEEK,
-                            STUDY_START_TIME,
+                    DAY_OF_WEEK, STUDY_START_TIME,
                             STUDY_END_TIME,
-                            ONLINE_STUDY,
-                            DAY_OF_WEEK,
-                            START_TO_END_PERIOD,
+                    START_TO_END_PERIOD,
                             applicationPeriod,
                             guestMember,
                             ACADEMIC_YEAR,
@@ -64,13 +62,11 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                            STUDY_TITLE,
+                    ONLINE_STUDY, STUDY_TITLE,
                             TOTAL_WEEK,
-                            STUDY_START_TIME,
+                    DAY_OF_WEEK, STUDY_START_TIME,
                             STUDY_END_TIME,
-                            ONLINE_STUDY,
-                            DAY_OF_WEEK,
-                            period,
+                    period,
                             applicationPeriod,
                             member,
                             ACADEMIC_YEAR,
@@ -88,13 +84,11 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                            STUDY_TITLE,
+                    ONLINE_STUDY, STUDY_TITLE,
                             TOTAL_WEEK,
+                    DAY_OF_WEEK, null,
                             null,
-                            null,
-                            ONLINE_STUDY,
-                            DAY_OF_WEEK,
-                            period,
+                    period,
                             applicationPeriod,
                             member,
                             ACADEMIC_YEAR,
@@ -114,13 +108,11 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                            STUDY_TITLE,
+                    ONLINE_STUDY, STUDY_TITLE,
                             TOTAL_WEEK,
-                            studyStartTime,
+                    DAY_OF_WEEK, studyStartTime,
                             studyEndTime,
-                            ONLINE_STUDY,
-                            DAY_OF_WEEK,
-                            period,
+                    period,
                             applicationPeriod,
                             member,
                             ACADEMIC_YEAR,
@@ -140,13 +132,11 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                            STUDY_TITLE,
+                    ASSIGNMENT_STUDY, STUDY_TITLE,
                             TOTAL_WEEK,
-                            studyStartTime,
+                    DAY_OF_WEEK, studyStartTime,
                             studyEndTime,
-                            ASSIGNMENT_STUDY,
-                            DAY_OF_WEEK,
-                            period,
+                    period,
                             applicationPeriod,
                             member,
                             ACADEMIC_YEAR,

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyTest.java
@@ -40,17 +40,10 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                            ACADEMIC_YEAR,
-                            SEMESTER_TYPE,
-                            STUDY_TITLE,
-                            guestMember,
-                            START_TO_END_PERIOD,
-                            applicationPeriod,
-                            TOTAL_WEEK,
-                            ONLINE_STUDY,
-                            DAY_OF_WEEK,
-                            STUDY_START_TIME,
-                            STUDY_END_TIME))
+                    STUDY_TITLE, TOTAL_WEEK, STUDY_START_TIME, STUDY_END_TIME, ONLINE_STUDY,
+                    DAY_OF_WEEK, START_TO_END_PERIOD, applicationPeriod, guestMember, ACADEMIC_YEAR,
+                            SEMESTER_TYPE
+            ))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(STUDY_MENTOR_IS_UNAUTHORIZED.getMessage());
         }
@@ -64,17 +57,10 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                            ACADEMIC_YEAR,
-                            SEMESTER_TYPE,
-                            STUDY_TITLE,
-                            member,
-                            period,
-                            applicationPeriod,
-                            TOTAL_WEEK,
-                            ONLINE_STUDY,
-                            DAY_OF_WEEK,
-                            STUDY_START_TIME,
-                            STUDY_END_TIME))
+                    STUDY_TITLE, TOTAL_WEEK, STUDY_START_TIME, STUDY_END_TIME, ONLINE_STUDY,
+                    DAY_OF_WEEK, period, applicationPeriod, member, ACADEMIC_YEAR,
+                            SEMESTER_TYPE
+            ))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(STUDY_APPLICATION_START_DATE_INVALID.getMessage());
         }
@@ -88,17 +74,10 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                            ACADEMIC_YEAR,
-                            SEMESTER_TYPE,
-                            STUDY_TITLE,
-                            member,
-                            period,
-                            applicationPeriod,
-                            TOTAL_WEEK,
-                            ONLINE_STUDY,
-                            DAY_OF_WEEK,
-                            null,
-                            null))
+                    STUDY_TITLE, TOTAL_WEEK, null, null, ONLINE_STUDY, DAY_OF_WEEK, period,
+                    applicationPeriod, member, ACADEMIC_YEAR,
+                            SEMESTER_TYPE
+            ))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ON_OFF_LINE_STUDY_TIME_IS_ESSENTIAL.getMessage());
         }
@@ -114,17 +93,10 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                            ACADEMIC_YEAR,
-                            SEMESTER_TYPE,
-                            STUDY_TITLE,
-                            member,
-                            period,
-                            applicationPeriod,
-                            TOTAL_WEEK,
-                            ONLINE_STUDY,
-                            DAY_OF_WEEK,
-                            studyStartTime,
-                            studyEndTime))
+                    STUDY_TITLE, TOTAL_WEEK, studyStartTime, studyEndTime, ONLINE_STUDY,
+                    DAY_OF_WEEK, period, applicationPeriod, member, ACADEMIC_YEAR,
+                            SEMESTER_TYPE
+            ))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(STUDY_TIME_INVALID.getMessage());
         }
@@ -140,17 +112,10 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                            ACADEMIC_YEAR,
-                            SEMESTER_TYPE,
-                            STUDY_TITLE,
-                            member,
-                            period,
-                            applicationPeriod,
-                            TOTAL_WEEK,
-                            ASSIGNMENT_STUDY,
-                            DAY_OF_WEEK,
-                            studyStartTime,
-                            studyEndTime))
+                    STUDY_TITLE, TOTAL_WEEK, studyStartTime, studyEndTime, ASSIGNMENT_STUDY,
+                    DAY_OF_WEEK, period, applicationPeriod, member, ACADEMIC_YEAR,
+                            SEMESTER_TYPE
+            ))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ASSIGNMENT_STUDY_CAN_NOT_INPUT_STUDY_TIME.getMessage());
         }

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyTest.java
@@ -40,10 +40,17 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                    STUDY_TITLE, TOTAL_WEEK, STUDY_START_TIME, STUDY_END_TIME, ONLINE_STUDY,
-                    DAY_OF_WEEK, START_TO_END_PERIOD, applicationPeriod, guestMember, ACADEMIC_YEAR,
-                            SEMESTER_TYPE
-            ))
+                            STUDY_TITLE,
+                            TOTAL_WEEK,
+                            STUDY_START_TIME,
+                            STUDY_END_TIME,
+                            ONLINE_STUDY,
+                            DAY_OF_WEEK,
+                            START_TO_END_PERIOD,
+                            applicationPeriod,
+                            guestMember,
+                            ACADEMIC_YEAR,
+                            SEMESTER_TYPE))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(STUDY_MENTOR_IS_UNAUTHORIZED.getMessage());
         }
@@ -57,10 +64,17 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                    STUDY_TITLE, TOTAL_WEEK, STUDY_START_TIME, STUDY_END_TIME, ONLINE_STUDY,
-                    DAY_OF_WEEK, period, applicationPeriod, member, ACADEMIC_YEAR,
-                            SEMESTER_TYPE
-            ))
+                            STUDY_TITLE,
+                            TOTAL_WEEK,
+                            STUDY_START_TIME,
+                            STUDY_END_TIME,
+                            ONLINE_STUDY,
+                            DAY_OF_WEEK,
+                            period,
+                            applicationPeriod,
+                            member,
+                            ACADEMIC_YEAR,
+                            SEMESTER_TYPE))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(STUDY_APPLICATION_START_DATE_INVALID.getMessage());
         }
@@ -74,10 +88,17 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                    STUDY_TITLE, TOTAL_WEEK, null, null, ONLINE_STUDY, DAY_OF_WEEK, period,
-                    applicationPeriod, member, ACADEMIC_YEAR,
-                            SEMESTER_TYPE
-            ))
+                            STUDY_TITLE,
+                            TOTAL_WEEK,
+                            null,
+                            null,
+                            ONLINE_STUDY,
+                            DAY_OF_WEEK,
+                            period,
+                            applicationPeriod,
+                            member,
+                            ACADEMIC_YEAR,
+                            SEMESTER_TYPE))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ON_OFF_LINE_STUDY_TIME_IS_ESSENTIAL.getMessage());
         }
@@ -93,10 +114,17 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                    STUDY_TITLE, TOTAL_WEEK, studyStartTime, studyEndTime, ONLINE_STUDY,
-                    DAY_OF_WEEK, period, applicationPeriod, member, ACADEMIC_YEAR,
-                            SEMESTER_TYPE
-            ))
+                            STUDY_TITLE,
+                            TOTAL_WEEK,
+                            studyStartTime,
+                            studyEndTime,
+                            ONLINE_STUDY,
+                            DAY_OF_WEEK,
+                            period,
+                            applicationPeriod,
+                            member,
+                            ACADEMIC_YEAR,
+                            SEMESTER_TYPE))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(STUDY_TIME_INVALID.getMessage());
         }
@@ -112,10 +140,17 @@ public class StudyTest {
 
             // when & then
             assertThatThrownBy(() -> Study.create(
-                    STUDY_TITLE, TOTAL_WEEK, studyStartTime, studyEndTime, ASSIGNMENT_STUDY,
-                    DAY_OF_WEEK, period, applicationPeriod, member, ACADEMIC_YEAR,
-                            SEMESTER_TYPE
-            ))
+                            STUDY_TITLE,
+                            TOTAL_WEEK,
+                            studyStartTime,
+                            studyEndTime,
+                            ASSIGNMENT_STUDY,
+                            DAY_OF_WEEK,
+                            period,
+                            applicationPeriod,
+                            member,
+                            ACADEMIC_YEAR,
+                            SEMESTER_TYPE))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ASSIGNMENT_STUDY_CAN_NOT_INPUT_STUDY_TIME.getMessage());
         }

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -88,9 +88,11 @@ public class FixtureHelper {
 
     public Study createStudy(Member mentor, Period period, Period applicationPeriod) {
         return Study.create(
-                ONLINE_STUDY, STUDY_TITLE,
+                ONLINE_STUDY,
+                STUDY_TITLE,
                 TOTAL_WEEK,
-                DAY_OF_WEEK, STUDY_START_TIME,
+                DAY_OF_WEEK,
+                STUDY_START_TIME,
                 STUDY_END_TIME,
                 period,
                 applicationPeriod,

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -88,17 +88,10 @@ public class FixtureHelper {
 
     public Study createStudy(Member mentor, Period period, Period applicationPeriod) {
         return Study.create(
-                ACADEMIC_YEAR,
-                SEMESTER_TYPE,
-                STUDY_TITLE,
-                mentor,
-                period,
-                applicationPeriod,
-                TOTAL_WEEK,
-                ONLINE_STUDY,
-                DAY_OF_WEEK,
-                STUDY_START_TIME,
-                STUDY_END_TIME);
+                STUDY_TITLE, TOTAL_WEEK, STUDY_START_TIME, STUDY_END_TIME, ONLINE_STUDY,
+                DAY_OF_WEEK, period, applicationPeriod, mentor, ACADEMIC_YEAR,
+                SEMESTER_TYPE
+        );
     }
 
     public Study createStudyWithMentor(Long mentorId, Period period, Period applicationPeriod) {
@@ -107,12 +100,13 @@ public class FixtureHelper {
     }
 
     public StudyDetail createStudyDetail(Study study, LocalDateTime startDate, LocalDateTime endDate) {
-        return StudyDetail.create(study, 1L, ATTENDANCE_NUMBER, Period.of(startDate, endDate));
+        return StudyDetail.create(1L, ATTENDANCE_NUMBER, Period.of(startDate, endDate), study);
     }
 
     public StudyDetail createNewStudyDetail(
             Long id, Study study, Long week, LocalDateTime startDate, LocalDateTime endDate) {
-        StudyDetail studyDetail = StudyDetail.create(study, week, ATTENDANCE_NUMBER, Period.of(startDate, endDate));
+        StudyDetail studyDetail = StudyDetail.create(week, ATTENDANCE_NUMBER,
+                Period.of(startDate, endDate), study);
         ReflectionTestUtils.setField(studyDetail, "id", id);
         return studyDetail;
     }

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -71,10 +71,10 @@ public class FixtureHelper {
             SemesterType semesterType,
             Money fee) {
         Recruitment recruitment = Recruitment.create(
-                academicYear, semesterType, fee, FEE_NAME, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE));
+                FEE_NAME, fee, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE), academicYear, semesterType);
 
         return RecruitmentRound.create(
-                RECRUITMENT_ROUND_NAME, Period.of(startDate, endDate), recruitment, RoundType.FIRST);
+                RECRUITMENT_ROUND_NAME, RoundType.FIRST, Period.of(startDate, endDate), recruitment);
     }
 
     public Membership createMembership(Member member, RecruitmentRound recruitmentRound) {

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -88,12 +88,10 @@ public class FixtureHelper {
 
     public Study createStudy(Member mentor, Period period, Period applicationPeriod) {
         return Study.create(
-                STUDY_TITLE,
+                ONLINE_STUDY, STUDY_TITLE,
                 TOTAL_WEEK,
-                STUDY_START_TIME,
+                DAY_OF_WEEK, STUDY_START_TIME,
                 STUDY_END_TIME,
-                ONLINE_STUDY,
-                DAY_OF_WEEK,
                 period,
                 applicationPeriod,
                 mentor,

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -88,10 +88,17 @@ public class FixtureHelper {
 
     public Study createStudy(Member mentor, Period period, Period applicationPeriod) {
         return Study.create(
-                STUDY_TITLE, TOTAL_WEEK, STUDY_START_TIME, STUDY_END_TIME, ONLINE_STUDY,
-                DAY_OF_WEEK, period, applicationPeriod, mentor, ACADEMIC_YEAR,
-                SEMESTER_TYPE
-        );
+                STUDY_TITLE,
+                TOTAL_WEEK,
+                STUDY_START_TIME,
+                STUDY_END_TIME,
+                ONLINE_STUDY,
+                DAY_OF_WEEK,
+                period,
+                applicationPeriod,
+                mentor,
+                ACADEMIC_YEAR,
+                SEMESTER_TYPE);
     }
 
     public Study createStudyWithMentor(Long mentorId, Period period, Period applicationPeriod) {
@@ -105,8 +112,7 @@ public class FixtureHelper {
 
     public StudyDetail createNewStudyDetail(
             Long id, Study study, Long week, LocalDateTime startDate, LocalDateTime endDate) {
-        StudyDetail studyDetail = StudyDetail.create(week, ATTENDANCE_NUMBER,
-                Period.of(startDate, endDate), study);
+        StudyDetail studyDetail = StudyDetail.create(week, ATTENDANCE_NUMBER, Period.of(startDate, endDate), study);
         ReflectionTestUtils.setField(studyDetail, "id", id);
         return studyDetail;
     }

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -188,7 +188,7 @@ public abstract class IntegrationTest {
         Recruitment recruitment = createRecruitment(ACADEMIC_YEAR, SEMESTER_TYPE, FEE);
 
         RecruitmentRound recruitmentRound =
-                RecruitmentRound.create(RECRUITMENT_ROUND_NAME, START_TO_END_PERIOD, recruitment, ROUND_TYPE);
+                RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, START_TO_END_PERIOD, recruitment);
 
         return recruitmentRoundRepository.save(recruitmentRound);
     }
@@ -204,13 +204,13 @@ public abstract class IntegrationTest {
         Recruitment recruitment = createRecruitment(academicYear, semesterType, fee);
 
         RecruitmentRound recruitmentRound =
-                RecruitmentRound.create(name, Period.of(startDate, endDate), recruitment, roundType);
+                RecruitmentRound.create(name, roundType, Period.of(startDate, endDate), recruitment);
         return recruitmentRoundRepository.save(recruitmentRound);
     }
 
     protected Recruitment createRecruitment(Integer academicYear, SemesterType semesterType, Money fee) {
         Recruitment recruitment = Recruitment.create(
-                academicYear, semesterType, fee, FEE_NAME, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE));
+                FEE_NAME, fee, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE), academicYear, semesterType);
         return recruitmentRepository.save(recruitment);
     }
 

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -228,12 +228,10 @@ public abstract class IntegrationTest {
 
     protected Study createStudy(Member mentor, Period period, Period applicationPeriod) {
         Study study = Study.create(
-                STUDY_TITLE,
+                ONLINE_STUDY, STUDY_TITLE,
                 TOTAL_WEEK,
-                STUDY_START_TIME,
+                DAY_OF_WEEK, STUDY_START_TIME,
                 STUDY_END_TIME,
-                ONLINE_STUDY,
-                DAY_OF_WEEK,
                 period,
                 applicationPeriod,
                 mentor,
@@ -245,12 +243,10 @@ public abstract class IntegrationTest {
 
     protected Study createNewStudy(Member mentor, Long totalWeek, Period period, Period applicationPeriod) {
         Study study = Study.create(
-                STUDY_TITLE,
+                ONLINE_STUDY, STUDY_TITLE,
                 totalWeek,
-                STUDY_START_TIME,
+                DAY_OF_WEEK, STUDY_START_TIME,
                 STUDY_END_TIME,
-                ONLINE_STUDY,
-                DAY_OF_WEEK,
                 period,
                 applicationPeriod,
                 mentor,

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -228,9 +228,11 @@ public abstract class IntegrationTest {
 
     protected Study createStudy(Member mentor, Period period, Period applicationPeriod) {
         Study study = Study.create(
-                ONLINE_STUDY, STUDY_TITLE,
+                ONLINE_STUDY,
+                STUDY_TITLE,
                 TOTAL_WEEK,
-                DAY_OF_WEEK, STUDY_START_TIME,
+                DAY_OF_WEEK,
+                STUDY_START_TIME,
                 STUDY_END_TIME,
                 period,
                 applicationPeriod,
@@ -243,9 +245,11 @@ public abstract class IntegrationTest {
 
     protected Study createNewStudy(Member mentor, Long totalWeek, Period period, Period applicationPeriod) {
         Study study = Study.create(
-                ONLINE_STUDY, STUDY_TITLE,
+                ONLINE_STUDY,
+                STUDY_TITLE,
                 totalWeek,
-                DAY_OF_WEEK, STUDY_START_TIME,
+                DAY_OF_WEEK,
+                STUDY_START_TIME,
                 STUDY_END_TIME,
                 period,
                 applicationPeriod,

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -228,45 +228,33 @@ public abstract class IntegrationTest {
 
     protected Study createStudy(Member mentor, Period period, Period applicationPeriod) {
         Study study = Study.create(
-                ACADEMIC_YEAR,
-                SEMESTER_TYPE,
-                STUDY_TITLE,
-                mentor,
-                period,
-                applicationPeriod,
-                TOTAL_WEEK,
-                ONLINE_STUDY,
-                DAY_OF_WEEK,
-                STUDY_START_TIME,
-                STUDY_END_TIME);
+                STUDY_TITLE, TOTAL_WEEK, STUDY_START_TIME, STUDY_END_TIME, ONLINE_STUDY,
+                DAY_OF_WEEK, period, applicationPeriod, mentor, ACADEMIC_YEAR,
+                SEMESTER_TYPE
+        );
 
         return studyRepository.save(study);
     }
 
     protected Study createNewStudy(Member mentor, Long totalWeek, Period period, Period applicationPeriod) {
         Study study = Study.create(
-                ACADEMIC_YEAR,
-                SEMESTER_TYPE,
-                STUDY_TITLE,
-                mentor,
-                period,
-                applicationPeriod,
-                totalWeek,
-                ONLINE_STUDY,
-                DAY_OF_WEEK,
-                STUDY_START_TIME,
-                STUDY_END_TIME);
+                STUDY_TITLE, totalWeek, STUDY_START_TIME, STUDY_END_TIME, ONLINE_STUDY, DAY_OF_WEEK,
+                period, applicationPeriod, mentor, ACADEMIC_YEAR,
+                SEMESTER_TYPE
+        );
 
         return studyRepository.save(study);
     }
 
     protected StudyDetail createStudyDetail(Study study, LocalDateTime startDate, LocalDateTime endDate) {
-        StudyDetail studyDetail = StudyDetail.create(study, 1L, ATTENDANCE_NUMBER, Period.of(startDate, endDate));
+        StudyDetail studyDetail = StudyDetail.create(1L, ATTENDANCE_NUMBER,
+                Period.of(startDate, endDate), study);
         return studyDetailRepository.save(studyDetail);
     }
 
     protected StudyDetail createNewStudyDetail(Long week, Study study, LocalDateTime startDate, LocalDateTime endDate) {
-        StudyDetail studyDetail = StudyDetail.create(study, week, ATTENDANCE_NUMBER, Period.of(startDate, endDate));
+        StudyDetail studyDetail = StudyDetail.create(week, ATTENDANCE_NUMBER,
+                Period.of(startDate, endDate), study);
         return studyDetailRepository.save(studyDetail);
     }
 
@@ -276,7 +264,7 @@ public abstract class IntegrationTest {
     }
 
     protected StudyAchievement createStudyAchievement(Member member, Study study, AchievementType achievementType) {
-        StudyAchievement studyAchievement = StudyAchievement.create(member, study, achievementType);
+        StudyAchievement studyAchievement = StudyAchievement.create(achievementType, member, study);
         return studyAchievementRepository.save(studyAchievement);
     }
 

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -228,33 +228,45 @@ public abstract class IntegrationTest {
 
     protected Study createStudy(Member mentor, Period period, Period applicationPeriod) {
         Study study = Study.create(
-                STUDY_TITLE, TOTAL_WEEK, STUDY_START_TIME, STUDY_END_TIME, ONLINE_STUDY,
-                DAY_OF_WEEK, period, applicationPeriod, mentor, ACADEMIC_YEAR,
-                SEMESTER_TYPE
-        );
+                STUDY_TITLE,
+                TOTAL_WEEK,
+                STUDY_START_TIME,
+                STUDY_END_TIME,
+                ONLINE_STUDY,
+                DAY_OF_WEEK,
+                period,
+                applicationPeriod,
+                mentor,
+                ACADEMIC_YEAR,
+                SEMESTER_TYPE);
 
         return studyRepository.save(study);
     }
 
     protected Study createNewStudy(Member mentor, Long totalWeek, Period period, Period applicationPeriod) {
         Study study = Study.create(
-                STUDY_TITLE, totalWeek, STUDY_START_TIME, STUDY_END_TIME, ONLINE_STUDY, DAY_OF_WEEK,
-                period, applicationPeriod, mentor, ACADEMIC_YEAR,
-                SEMESTER_TYPE
-        );
+                STUDY_TITLE,
+                totalWeek,
+                STUDY_START_TIME,
+                STUDY_END_TIME,
+                ONLINE_STUDY,
+                DAY_OF_WEEK,
+                period,
+                applicationPeriod,
+                mentor,
+                ACADEMIC_YEAR,
+                SEMESTER_TYPE);
 
         return studyRepository.save(study);
     }
 
     protected StudyDetail createStudyDetail(Study study, LocalDateTime startDate, LocalDateTime endDate) {
-        StudyDetail studyDetail = StudyDetail.create(1L, ATTENDANCE_NUMBER,
-                Period.of(startDate, endDate), study);
+        StudyDetail studyDetail = StudyDetail.create(1L, ATTENDANCE_NUMBER, Period.of(startDate, endDate), study);
         return studyDetailRepository.save(studyDetail);
     }
 
     protected StudyDetail createNewStudyDetail(Long week, Study study, LocalDateTime startDate, LocalDateTime endDate) {
-        StudyDetail studyDetail = StudyDetail.create(week, ATTENDANCE_NUMBER,
-                Period.of(startDate, endDate), study);
+        StudyDetail studyDetail = StudyDetail.create(week, ATTENDANCE_NUMBER, Period.of(startDate, endDate), study);
         return studyDetailRepository.save(studyDetail);
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #848 

## 📌 작업 내용 및 특이사항
- 엔티티 필드 순서를 Id -> 일반 필드 -> enum -> vo -> 연관관계 순으로 정렬했습니다.

## 📝 참고사항
- BaseSemesterEntity 관련 필드는 뒷쪽으로 옮겼습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

- **도메인 변경**
	- 쿠폰, 회원, 멤버십, 주문, 모집, 스터디 관련 도메인 클래스의 필드 및 생성자 구조 재정비
	- 일부 클래스에 새로운 필드 추가 (예: 쿠폰의 사용 여부, 리포지토리 링크, 스터디 이력 상태 등)
	- 생성자 및 메서드 파라미터 순서 조정

- **기능 변경**
	- 도메인 클래스의 내부 로직 유지
	- 객체 생성 및 상태 관리 방식 개선

이번 업데이트는 시스템의 내부 구조를 최적화하고 코드의 일관성을 높이는 데 중점을 두었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->