### PR TITLE
feat: 스터디 수료 쿠폰을 스터디 당 하나만 가지도록 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/common/vo/Money.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/vo/Money.java
@@ -18,6 +18,7 @@ import lombok.NonNull;
 public final class Money {
 
     public static final Money ZERO = Money.from(BigDecimal.ZERO);
+    public static final Money FIVE_THOUSAND = Money.from(5000L);
 
     private BigDecimal amount;
 

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/dao/CouponRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/dao/CouponRepository.java
@@ -1,6 +1,11 @@
 package com.gdschongik.gdsc.domain.coupon.dao;
 
 import com.gdschongik.gdsc.domain.coupon.domain.Coupon;
+import com.gdschongik.gdsc.domain.coupon.domain.CouponType;
+import com.gdschongik.gdsc.domain.study.domain.Study;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CouponRepository extends JpaRepository<Coupon, Long> {}
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+    Optional<Coupon> findByCouponTypeAndStudy(CouponType couponType, Study study);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/domain/Coupon.java
@@ -17,6 +17,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,6 +26,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"coupon_type", "study_id"})})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Coupon extends BaseEntity {
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyHistoryService.java
@@ -133,6 +133,7 @@ public class StudentStudyHistoryService {
     }
 
     private AssignmentHistory findOrCreate(Member currentMember, StudyDetail studyDetail) {
+        // todo: create로 분기할 경우 내부에서 save 호출하도록 수정
         return assignmentHistoryRepository
                 .findByMemberAndStudyDetail(currentMember, studyDetail)
                 .orElseGet(() -> AssignmentHistory.create(studyDetail, currentMember));


### PR DESCRIPTION
## 🌱 관련 이슈
- close #840

## 📌 작업 내용 및 특이사항
- 스터디 당 하나의 수료 쿠폰만 가질 수 있도록 수정했습니다.
기존에는 바로 create하고 save했다면, findOrCreate해서 save 하도록 수정했습니다.
- 찬님께서 말씀해주신 하드코딩 관련 내용https://github.com/GDSC-Hongik/gdsc-server/pull/847#discussion_r1925226572 도 같이 처리했습니다.

## 📝 참고사항
- 테스트들은 https://github.com/GDSC-Hongik/gdsc-server/issues/842 에서 추가할 예정입니다~

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- 쿠폰 생성 및 발급 로직 개선
	- 중복 쿠폰 생성 방지 기능 추가
	- 스터디 완료 기반 쿠폰 관리 기능 강화
	- 쿠폰 리포지토리에 새로운 조회 메서드 추가

- **개선 사항**
	- 쿠폰 조회 및 생성 메서드 최적화
	- 데이터베이스에서 쿠폰의 고유성 보장

- **기타**
	- 금액 관련 상수 `FIVE_THOUSAND` 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->