### PR TITLE
feat: 수료 철회시 쿠폰 회수 이벤트 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponEventHandler.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.coupon.application;
 
 import com.gdschongik.gdsc.domain.study.domain.StudyHistoriesCompletedEvent;
+import com.gdschongik.gdsc.domain.study.domain.StudyHistoryCompletionWithdrawnEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -19,5 +20,11 @@ public class CouponEventHandler {
     public void handleStudyHistoryCompletedEvent(StudyHistoriesCompletedEvent event) {
         log.info("[CouponEventHandler] 스터디 수료 이벤트 수신: studyHistoryIds={}", event.studyHistoryIds());
         couponService.createAndIssueCouponByStudyHistories(event.studyHistoryIds());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleStudyHistoryCompletionWithdrawnEvent(StudyHistoryCompletionWithdrawnEvent event) {
+        log.info("[CouponEventHandler] 스터디 수료 철회 이벤트 수신: studyHistoryId={}", event.studyHistoryId());
+        couponService.revokeStudyCompletionCouponByStudyHistoryId(event.studyHistoryId());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponService.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.domain.coupon.application;
 
+import static com.gdschongik.gdsc.domain.coupon.domain.CouponType.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.vo.Money;
@@ -109,7 +110,7 @@ public class CouponService {
         List<Member> students = memberRepository.findAllById(studentIds);
         Study study = studyHistories.get(0).getStudy();
 
-        Coupon coupon = findOrCreate(CouponType.STUDY_COMPLETION, study);
+        Coupon coupon = findOrCreate(STUDY_COMPLETION, study);
 
         List<IssuedCoupon> issuedCoupons = students.stream()
                 .map(student -> IssuedCoupon.create(coupon, student))
@@ -127,5 +128,22 @@ public class CouponService {
             Coupon coupon = Coupon.createAutomatic(couponName, Money.FIVE_THOUSAND, couponType, study);
             return couponRepository.save(coupon);
         });
+    }
+
+    @Transactional
+    public void revokeStudyCompletionCouponByStudyHistoryId(long studyHistoryId) {
+        StudyHistory studyHistory = studyHistoryRepository
+                .findById(studyHistoryId)
+                .orElseThrow(() -> new CustomException(STUDY_HISTORY_NOT_FOUND));
+
+        IssuedCoupon issuedCoupon = issuedCouponRepository
+                .findNonRevokedIssuedCouponByCouponTypeAndMemberAndStudy(
+                        STUDY_COMPLETION, studyHistory.getStudent(), studyHistory.getStudy())
+                .orElseThrow(() -> new CustomException(ISSUED_COUPON_NOT_FOUND));
+
+        issuedCoupon.revoke();
+        issuedCouponRepository.save(issuedCoupon);
+
+        log.info("[CouponService] 스터디 수료 쿠폰 회수: issuedCouponId={}", issuedCoupon.getId());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponService.java
@@ -137,8 +137,7 @@ public class CouponService {
                 .orElseThrow(() -> new CustomException(STUDY_HISTORY_NOT_FOUND));
 
         IssuedCoupon issuedCoupon = issuedCouponRepository
-                .findNonRevokedIssuedCouponByCouponTypeAndMemberAndStudy(
-                        STUDY_COMPLETION, studyHistory.getStudent(), studyHistory.getStudy())
+                .findUnrevokedIssuedStudyCoupon(STUDY_COMPLETION, studyHistory.getStudent(), studyHistory.getStudy())
                 .orElseThrow(() -> new CustomException(ISSUED_COUPON_NOT_FOUND));
 
         issuedCoupon.revoke();

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/dao/IssuedCouponCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/dao/IssuedCouponCustomRepository.java
@@ -13,6 +13,5 @@ public interface IssuedCouponCustomRepository {
 
     Page<IssuedCoupon> findAllIssuedCoupons(IssuedCouponQueryOption queryOption, Pageable pageable);
 
-    Optional<IssuedCoupon> findNonRevokedIssuedCouponByCouponTypeAndMemberAndStudy(
-            CouponType couponType, Member member, Study study);
+    Optional<IssuedCoupon> findUnrevokedIssuedStudyCoupon(CouponType couponType, Member member, Study study);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/dao/IssuedCouponCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/dao/IssuedCouponCustomRepository.java
@@ -1,11 +1,18 @@
 package com.gdschongik.gdsc.domain.coupon.dao;
 
+import com.gdschongik.gdsc.domain.coupon.domain.CouponType;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.coupon.dto.request.IssuedCouponQueryOption;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.study.domain.Study;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface IssuedCouponCustomRepository {
 
     Page<IssuedCoupon> findAllIssuedCoupons(IssuedCouponQueryOption queryOption, Pageable pageable);
+
+    Optional<IssuedCoupon> findNonRevokedIssuedCouponByCouponTypeAndMemberAndStudy(
+            CouponType couponType, Member member, Study study);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/dao/IssuedCouponCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/dao/IssuedCouponCustomRepositoryImpl.java
@@ -43,10 +43,10 @@ public class IssuedCouponCustomRepositoryImpl implements IssuedCouponCustomRepos
         return Optional.ofNullable(queryFactory
                 .selectFrom(issuedCoupon)
                 .leftJoin(issuedCoupon.coupon, coupon)
-                .where(hasRevoked(false)
-                        .and(coupon.couponType.eq(couponType))
-                        .and(eqMember(member))
-                        .and(coupon.study.eq(study)))
+                .where(eqMember(member)
+                        .and(coupon.study.eq(study))
+                        .and(hasRevoked(false))
+                        .and(coupon.couponType.eq(couponType)))
                 .fetchFirst());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/dao/IssuedCouponCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/dao/IssuedCouponCustomRepositoryImpl.java
@@ -1,12 +1,17 @@
 package com.gdschongik.gdsc.domain.coupon.dao;
 
+import static com.gdschongik.gdsc.domain.coupon.domain.QCoupon.*;
 import static com.gdschongik.gdsc.domain.coupon.domain.QIssuedCoupon.issuedCoupon;
 
+import com.gdschongik.gdsc.domain.coupon.domain.CouponType;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.coupon.dto.request.IssuedCouponQueryOption;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -31,5 +36,18 @@ public class IssuedCouponCustomRepositoryImpl implements IssuedCouponCustomRepos
                 queryFactory.select(issuedCoupon.count()).from(issuedCoupon).where(matchesQueryOption(queryOption));
 
         return PageableExecutionUtils.getPage(fetch, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Optional<IssuedCoupon> findNonRevokedIssuedCouponByCouponTypeAndMemberAndStudy(
+            CouponType couponType, Member member, Study study) {
+        return Optional.ofNullable(queryFactory
+                .selectFrom(issuedCoupon)
+                .leftJoin(issuedCoupon.coupon, coupon)
+                .where(hasRevoked(false)
+                        .and(coupon.couponType.eq(couponType))
+                        .and(eqMember(member))
+                        .and(coupon.study.eq(study)))
+                .fetchFirst());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/dao/IssuedCouponCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/dao/IssuedCouponCustomRepositoryImpl.java
@@ -39,8 +39,7 @@ public class IssuedCouponCustomRepositoryImpl implements IssuedCouponCustomRepos
     }
 
     @Override
-    public Optional<IssuedCoupon> findNonRevokedIssuedCouponByCouponTypeAndMemberAndStudy(
-            CouponType couponType, Member member, Study study) {
+    public Optional<IssuedCoupon> findUnrevokedIssuedStudyCoupon(CouponType couponType, Member member, Study study) {
         return Optional.ofNullable(queryFactory
                 .selectFrom(issuedCoupon)
                 .leftJoin(issuedCoupon.coupon, coupon)

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/dao/IssuedCouponQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/dao/IssuedCouponQueryMethod.java
@@ -3,6 +3,7 @@ package com.gdschongik.gdsc.domain.coupon.dao;
 import static com.gdschongik.gdsc.domain.coupon.domain.QIssuedCoupon.issuedCoupon;
 
 import com.gdschongik.gdsc.domain.coupon.dto.request.IssuedCouponQueryOption;
+import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
 
@@ -14,6 +15,10 @@ public interface IssuedCouponQueryMethod {
 
     default BooleanExpression eqMemberName(String memberName) {
         return memberName != null ? issuedCoupon.coupon.name.containsIgnoreCase(memberName) : null;
+    }
+
+    default BooleanExpression eqMember(Member member) {
+        return member != null ? issuedCoupon.member.eq(member) : null;
     }
 
     default BooleanExpression eqPhone(String phone) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #841

## 📌 작업 내용 및 특이사항
- 수료 처리하여 쿠폰이 발급되었지만 이를 철회했다가 다시 수료처리한다면 IssuedCoupon이 두 개 존재하게 됩니다. 하나는 revoke가 true고 하나는 false가 됩니다. 따라서 Revoke가 false인 발급 쿠폰을 가져오도록 해야합니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
  - 스터디 완료 쿠폰 취소 기능 추가
  - 스터디 이력에 따른 쿠폰 관리 기능 개선
  - 회원 객체를 기반으로 한 쿠폰 필터링 기능 추가

- **버그 수정**
  - 쿠폰 발급 및 취소 프로세스의 트랜잭션 안정성 강화

- **리팩토링**
  - 쿠폰 관련 이벤트 핸들러 및 서비스 로직 최적화
  - 쿠폰 조회 및 필터링 메서드 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->