### PR TITLE
test: `MemberIntegrationTest`에서 `@Slf4j` 제거

### DIFF
--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/MemberIntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/MemberIntegrationTest.java
@@ -8,11 +8,9 @@ import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberAssociateRequirementUpdatedEvent;
 import com.gdschongik.gdsc.helper.IntegrationTest;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@Slf4j
 public class MemberIntegrationTest extends IntegrationTest {
     @Autowired
     private MemberAssociateRequirementUpdatedEventHandler memberAssociateRequirementUpdatedEventHandler;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #861

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩토링**
	- 테스트 클래스에서 로깅 어노테이션(`@Slf4j`) 제거
	- 테스트 클래스의 로깅 기능 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->