### PR TITLE
feat: 쿠폰 종류 조회 API 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/api/AdminCouponController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/api/AdminCouponController.java
@@ -5,6 +5,7 @@ import com.gdschongik.gdsc.domain.coupon.dto.request.CouponCreateRequest;
 import com.gdschongik.gdsc.domain.coupon.dto.request.CouponIssueRequest;
 import com.gdschongik.gdsc.domain.coupon.dto.request.IssuedCouponQueryOption;
 import com.gdschongik.gdsc.domain.coupon.dto.response.CouponResponse;
+import com.gdschongik.gdsc.domain.coupon.dto.response.CouponTypeResponse;
 import com.gdschongik.gdsc.domain.coupon.dto.response.IssuedCouponResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -41,6 +42,13 @@ public class AdminCouponController {
     @GetMapping
     public ResponseEntity<List<CouponResponse>> getCoupons() {
         List<CouponResponse> response = couponService.findAllCoupons();
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(summary = "쿠폰 종류 조회", description = "발급 가능한 모든 쿠폰 종류를 조회합니다.")
+    @GetMapping
+    public ResponseEntity<List<CouponTypeResponse>> getCouponTypes() {
+        List<CouponTypeResponse> response = couponService.getCouponTypes();
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/api/AdminCouponController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/api/AdminCouponController.java
@@ -46,7 +46,7 @@ public class AdminCouponController {
     }
 
     @Operation(summary = "쿠폰 종류 조회", description = "발급 가능한 모든 쿠폰 종류를 조회합니다.")
-    @GetMapping
+    @GetMapping("/types")
     public ResponseEntity<List<CouponTypeResponse>> getCouponTypes() {
         List<CouponTypeResponse> response = couponService.getCouponTypes();
         return ResponseEntity.ok().body(response);

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/api/AdminCouponController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/api/AdminCouponController.java
@@ -45,7 +45,7 @@ public class AdminCouponController {
         return ResponseEntity.ok().body(response);
     }
 
-    @Operation(summary = "쿠폰 종류 조회", description = "발급 가능한 모든 쿠폰 종류를 조회합니다.")
+    @Operation(summary = "쿠폰 종류 목록 조회", description = "발급 가능한 모든 쿠폰 종류 목록을 조회합니다.")
     @GetMapping("/types")
     public ResponseEntity<List<CouponTypeResponse>> getCouponTypes() {
         List<CouponTypeResponse> response = couponService.getCouponTypes();

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/application/CouponService.java
@@ -13,6 +13,7 @@ import com.gdschongik.gdsc.domain.coupon.dto.request.CouponCreateRequest;
 import com.gdschongik.gdsc.domain.coupon.dto.request.CouponIssueRequest;
 import com.gdschongik.gdsc.domain.coupon.dto.request.IssuedCouponQueryOption;
 import com.gdschongik.gdsc.domain.coupon.dto.response.CouponResponse;
+import com.gdschongik.gdsc.domain.coupon.dto.response.CouponTypeResponse;
 import com.gdschongik.gdsc.domain.coupon.dto.response.IssuedCouponResponse;
 import com.gdschongik.gdsc.domain.coupon.util.CouponNameUtil;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
@@ -23,6 +24,7 @@ import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -144,5 +146,9 @@ public class CouponService {
         issuedCouponRepository.save(issuedCoupon);
 
         log.info("[CouponService] 스터디 수료 쿠폰 회수: issuedCouponId={}", issuedCoupon.getId());
+    }
+
+    public List<CouponTypeResponse> getCouponTypes() {
+        return Arrays.stream(CouponType.values()).map(CouponTypeResponse::from).toList();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/dto/response/CouponTypeResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/dto/response/CouponTypeResponse.java
@@ -1,0 +1,9 @@
+package com.gdschongik.gdsc.domain.coupon.dto.response;
+
+import com.gdschongik.gdsc.domain.coupon.domain.CouponType;
+
+public record CouponTypeResponse(CouponType couponType, String name) {
+    public static CouponTypeResponse from(CouponType couponType) {
+        return new CouponTypeResponse(couponType, couponType.getValue());
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #846

## 📌 작업 내용 및 특이사항
- 쿠폰 생성시 쿠폰 종류와 스터디 이름을 지정해야 합니다.
- 각각의 조회 api가 필요한 상황인데, 후자는 /admin/studies로 대체 가능해서 쿠폰 종류 조회 api만 구현했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 쿠폰 관리 시스템에 쿠폰 타입 조회 기능이 추가되었습니다. 이를 통해 관리자는 등록된 다양한 쿠폰 유형 정보를 손쉽게 확인할 수 있게 되어, 쿠폰 운영 및 관리 효율성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->