### PR TITLE
feat: 멘토 내 담당 스터디 조회 V2 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/MentorStudyControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/MentorStudyControllerV2.java
@@ -22,7 +22,7 @@ public class MentorStudyControllerV2 {
     @Operation(summary = "내 스터디 조회", description = "내가 멘토로 있는 스터디를 조회합니다.")
     @GetMapping("/me")
     public ResponseEntity<List<StudyManagerResponse>> getStudiesInCharge() {
-        List<StudyManagerResponse> response = mentorStudyServiceV2.getStudiesInCharge();
+        var response = mentorStudyServiceV2.getStudiesInCharge();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/MentorStudyControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/MentorStudyControllerV2.java
@@ -1,0 +1,28 @@
+package com.gdschongik.gdsc.domain.studyv2.api;
+
+import com.gdschongik.gdsc.domain.studyv2.application.MentorStudyServiceV2;
+import com.gdschongik.gdsc.domain.studyv2.dto.response.StudyManagerResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Mentor Study V2", description = "스터디 V2 멘토 API입니다.")
+@RestController
+@RequestMapping("/v2/mentor/studies")
+@RequiredArgsConstructor
+public class MentorStudyControllerV2 {
+
+    private final MentorStudyServiceV2 mentorStudyServiceV2;
+
+    @Operation(summary = "내 스터디 조회", description = "내가 멘토로 있는 스터디를 조회합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<List<StudyManagerResponse>> getStudiesInCharge() {
+        List<StudyManagerResponse> response = mentorStudyServiceV2.getStudiesInCharge();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/MentorStudyServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/MentorStudyServiceV2.java
@@ -1,0 +1,28 @@
+package com.gdschongik.gdsc.domain.studyv2.application;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.studyv2.dao.StudyV2Repository;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyV2;
+import com.gdschongik.gdsc.domain.studyv2.dto.response.StudyManagerResponse;
+import com.gdschongik.gdsc.global.util.MemberUtil;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MentorStudyServiceV2 {
+
+    private final MemberUtil memberUtil;
+    private final StudyV2Repository studyV2Repository;
+
+    @Transactional(readOnly = true)
+    public List<StudyManagerResponse> getStudiesInCharge() {
+        Member mentor = memberUtil.getCurrentMember();
+        List<StudyV2> myStudies = studyV2Repository.findAllByMentor(mentor);
+        return myStudies.stream().map(StudyManagerResponse::from).toList();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dao/StudyV2Repository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dao/StudyV2Repository.java
@@ -1,6 +1,11 @@
 package com.gdschongik.gdsc.domain.studyv2.dao;
 
+import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyV2;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StudyV2Repository extends JpaRepository<StudyV2, Long>, StudyV2CustomRepository {}
+public interface StudyV2Repository extends JpaRepository<StudyV2, Long>, StudyV2CustomRepository {
+
+    List<StudyV2> findAllByMentor(Member mentor);
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #882

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
- 

## 📚 기타
- Repository들은 `V2Repository`로 네이밍 되고 있고 이외의 것들은 V2 끝에 붙고 있습니다. 둘 중 하나로 통일하는게 좋을 것 같습니다. 별도 논의 후에 이슈 파서 진행하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 멘토가 자신의 스터디 목록을 확인할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
	- 스터디 조회 기능이 개선되어, 멘토와 연관된 스터디를 보다 정확하게 확인할 수 있습니다.
	- 멘토와 관련된 스터디를 조회할 수 있는 서비스가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->