### PR TITLE
feat: 어드민 스터디 삭제 V2 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/AdminStudyControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/AdminStudyControllerV2.java
@@ -9,7 +9,9 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,5 +37,12 @@ public class AdminStudyControllerV2 {
     public ResponseEntity<List<StudyManagerResponse>> getStudies() {
         var response = adminStudyServiceV2.getAllStudies();
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "스터디 삭제", description = "스터디를 삭제합니다. 스터디의 세션도 함께 삭제됩니다.")
+    @DeleteMapping("/{studyId}")
+    public ResponseEntity<Void> deleteStudy(@PathVariable Long studyId) {
+        adminStudyServiceV2.deleteStudy(studyId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/AdminStudyServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/AdminStudyServiceV2.java
@@ -53,7 +53,7 @@ public class AdminStudyServiceV2 {
         memberRepository.save(mentor);
         studyV2Repository.save(study);
 
-        log.info("[AdminStudyService] 스터디 생성 완료: studyId = {}", study.getId());
+        log.info("[AdminStudyServiceV2] 스터디 생성 완료: studyId = {}", study.getId());
     }
 
     @Transactional(readOnly = true)
@@ -61,5 +61,12 @@ public class AdminStudyServiceV2 {
         return studyV2Repository.findFetchAll().stream()
                 .map(StudyManagerResponse::from)
                 .toList();
+    }
+
+    @Transactional
+    public void deleteStudy(Long studyId) {
+        studyV2Repository.deleteById(studyId);
+
+        log.info("[AdminStudyServiceV2] 스터디 삭제 완료: studyId = {}", studyId);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #883

## 📌 작업 내용 및 특이사항
- 어드민 스터디 삭제 v2 api 구현했습니다.

## 📝 참고사항
- 이전에 구현된 스터디 개설 로직의 로그에서 V2로 명시되지 않은 부분 있어서 같이 수정했습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 관리자 인터페이스에 study 삭제 기능이 추가되었습니다. 이제 관리자는 특정 study와 관련 세션을 함께 제거할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->