### PR TITLE
feat: 스터디 과제 상세 조회 V2 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/MentorStudyControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/MentorStudyControllerV2.java
@@ -1,6 +1,8 @@
 package com.gdschongik.gdsc.domain.studyv2.api;
 
+import com.gdschongik.gdsc.domain.studyv2.application.CommonStudyServiceV2;
 import com.gdschongik.gdsc.domain.studyv2.application.MentorStudyServiceV2;
+import com.gdschongik.gdsc.domain.studyv2.dto.response.AssignmentResponse;
 import com.gdschongik.gdsc.domain.studyv2.dto.response.StudyManagerResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -8,6 +10,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,11 +21,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class MentorStudyControllerV2 {
 
     private final MentorStudyServiceV2 mentorStudyServiceV2;
+    private final CommonStudyServiceV2 commonStudyServiceV2;
 
     @Operation(summary = "내 스터디 조회", description = "내가 멘토로 있는 스터디를 조회합니다.")
     @GetMapping("/me")
     public ResponseEntity<List<StudyManagerResponse>> getStudiesInCharge() {
         var response = mentorStudyServiceV2.getStudiesInCharge();
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "스터디 과제 상세 조회", description = "멘토가 자신의 스터디 과제를 상세 조회합니다.")
+    @GetMapping("/{studyId}/sessions/{studySessionId}/assignment")
+    public ResponseEntity<AssignmentResponse> getStudyAssignment(
+            @PathVariable Long studyId, @PathVariable Long studySessionId) {
+        var response = commonStudyServiceV2.getAssignment(studySessionId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/CommonStudyServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/CommonStudyServiceV2.java
@@ -1,0 +1,24 @@
+package com.gdschongik.gdsc.domain.studyv2.application;
+
+import com.gdschongik.gdsc.domain.studyv2.dao.StudySessionV2Repository;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudySessionV2;
+import com.gdschongik.gdsc.domain.studyv2.dto.response.AssignmentResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommonStudyServiceV2 {
+
+    private final StudySessionV2Repository studySessionV2Repository;
+
+    @Transactional(readOnly = true)
+    public AssignmentResponse getAssignment(Long studySessionId) {
+        StudySessionV2 studySessionV2 =
+                studySessionV2Repository.findById(studySessionId).orElseThrow();
+        return AssignmentResponse.from(studySessionV2);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/CommonStudyServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/CommonStudyServiceV2.java
@@ -3,6 +3,8 @@ package com.gdschongik.gdsc.domain.studyv2.application;
 import com.gdschongik.gdsc.domain.studyv2.dao.StudySessionV2Repository;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudySessionV2;
 import com.gdschongik.gdsc.domain.studyv2.dto.response.AssignmentResponse;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,8 +19,9 @@ public class CommonStudyServiceV2 {
 
     @Transactional(readOnly = true)
     public AssignmentResponse getAssignment(Long studySessionId) {
-        StudySessionV2 studySessionV2 =
-                studySessionV2Repository.findById(studySessionId).orElseThrow();
+        StudySessionV2 studySessionV2 = studySessionV2Repository
+                .findById(studySessionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STUDY_SESSION_NOT_FOUND));
         return AssignmentResponse.from(studySessionV2);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dao/StudySessionV2Repository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dao/StudySessionV2Repository.java
@@ -1,0 +1,6 @@
+package com.gdschongik.gdsc.domain.studyv2.dao;
+
+import com.gdschongik.gdsc.domain.studyv2.domain.StudySessionV2;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudySessionV2Repository extends JpaRepository<StudySessionV2, Long> {}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/AssignmentResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/AssignmentResponse.java
@@ -1,0 +1,25 @@
+package com.gdschongik.gdsc.domain.studyv2.dto.response;
+
+import com.gdschongik.gdsc.domain.studyv2.domain.StudySessionV2;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record AssignmentResponse(
+        Long studySessionId,
+        @Schema(description = "스터디 이름") String studyTitle,
+        @Schema(description = "과제 제목") String title,
+        @Schema(description = "회차") Integer position,
+        @Schema(description = "과제 명세 링크") String descriptionLink,
+        @Schema(description = "과제 시작일") LocalDateTime assignmentStartDate,
+        @Schema(description = "과제 종료일") LocalDateTime assignmentEndDate) {
+    public static AssignmentResponse from(StudySessionV2 studySession) {
+        return new AssignmentResponse(
+                studySession.getId(),
+                studySession.getStudy().getTitle(),
+                studySession.getTitle(),
+                studySession.getPosition(),
+                studySession.getAssignmentDescriptionLink(),
+                studySession.getAssignmentPeriod().getStartDate(),
+                studySession.getAssignmentPeriod().getEndDate());
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -109,6 +109,9 @@ public enum ErrorCode {
     STUDY_NOT_CANCELABLE_APPLICATION_PERIOD(HttpStatus.CONFLICT, "스터디 신청기간이 아니라면 취소할 수 없습니다."),
     STUDY_NOT_CREATABLE_NOT_LIVE(HttpStatus.INTERNAL_SERVER_ERROR, "온라인 및 오프라인 타입만 라이브 스터디로 생성할 수 있습니다."),
 
+    // StudySession
+    STUDY_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 세션입니다."),
+
     // StudyDetail
     STUDY_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 상세 정보입니다."),
     STUDY_DETAIL_UPDATE_RESTRICTED_TO_MENTOR(HttpStatus.CONFLICT, "해당 스터디의 멘토만 수정할 수 있습니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #886

## 📌 작업 내용 및 특이사항
- 과제 상세 조회는 멘토말고 일반 멤버도 조회할 일이 있을 것 같아서 `CommonStudyServiceV2`를 만들어서 사용했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- 멘토 스터디에서 특정 스터디 세션에 연결된 과제의 세부 정보를 확인할 수 있는 기능을 추가했습니다.
	- 이제 스터디 과제에 대해 제목, 위치, 설명 링크, 시작일 및 종료일 등의 상세 정보를 제공합니다.
	- 스터디 세션이 존재하지 않을 경우에 대한 오류 처리를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->