### PR TITLE
feat: 멘토 스터디 정보 작성 V2 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/MentorStudyControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/MentorStudyControllerV2.java
@@ -1,0 +1,29 @@
+package com.gdschongik.gdsc.domain.studyv2.api;
+
+import com.gdschongik.gdsc.domain.studyv2.application.MentorStudyServiceV2;
+import com.gdschongik.gdsc.domain.studyv2.dto.request.StudyUpdateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Mentor Study V2 ", description = "스터디 V2 멘토 API입니다.")
+@RestController
+@RequestMapping("/v2/mentor/studies")
+@RequiredArgsConstructor
+public class MentorStudyControllerV2 {
+
+    private final MentorStudyServiceV2 mentorStudyServiceV2;
+
+    @Operation(summary = "스터디 정보 작성", description = "스터디 정보를 작성합니다.")
+    @PutMapping("/{studyId}")
+    public ResponseEntity<Void> updateStudy(@PathVariable Long studyId, @RequestBody StudyUpdateRequest request) {
+        mentorStudyServiceV2.updateStudy(studyId, request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/MentorStudyControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/MentorStudyControllerV2.java
@@ -1,15 +1,17 @@
 package com.gdschongik.gdsc.domain.studyv2.api;
 
-import java.util.List;
-
 import com.gdschongik.gdsc.domain.studyv2.application.MentorStudyServiceV2;
+import com.gdschongik.gdsc.domain.studyv2.dto.request.StudyUpdateRequest;
 import com.gdschongik.gdsc.domain.studyv2.dto.response.StudyManagerResponse;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,5 +28,12 @@ public class MentorStudyControllerV2 {
     public ResponseEntity<List<StudyManagerResponse>> getStudiesInCharge() {
         var response = mentorStudyServiceV2.getStudiesInCharge();
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "스터디 정보 변경", description = "스터디 정보를 변경합니다.")
+    @PutMapping("/{studyId}")
+    public ResponseEntity<Void> updateStudy(@PathVariable Long studyId, @RequestBody StudyUpdateRequest request) {
+        mentorStudyServiceV2.updateStudy(studyId, request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/MentorStudyServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/MentorStudyServiceV2.java
@@ -1,0 +1,16 @@
+package com.gdschongik.gdsc.domain.studyv2.application;
+
+import com.gdschongik.gdsc.domain.studyv2.dto.request.StudyUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MentorStudyServiceV2 {
+
+    @Transactional
+    public void updateStudy(Long studyId, StudyUpdateRequest request) {}
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/MentorStudyServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/MentorStudyServiceV2.java
@@ -1,9 +1,15 @@
 package com.gdschongik.gdsc.domain.studyv2.application;
 
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.studyv2.dao.StudyV2Repository;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyUpdateCommand;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyV2;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyValidatorV2;
+import com.gdschongik.gdsc.domain.studyv2.dto.request.StudyUpdateRequest;
 import com.gdschongik.gdsc.domain.studyv2.dto.response.StudyManagerResponse;
+import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -18,11 +24,28 @@ public class MentorStudyServiceV2 {
 
     private final MemberUtil memberUtil;
     private final StudyV2Repository studyV2Repository;
+    private final StudyValidatorV2 studyValidatorV2;
 
     @Transactional(readOnly = true)
     public List<StudyManagerResponse> getStudiesInCharge() {
         Member mentor = memberUtil.getCurrentMember();
         List<StudyV2> myStudies = studyV2Repository.findAllByMentor(mentor);
         return myStudies.stream().map(StudyManagerResponse::from).toList();
+    }
+
+    @Transactional
+    public void updateStudy(Long studyId, StudyUpdateRequest request) {
+        Member currentMember = memberUtil.getCurrentMember();
+        StudyV2 study =
+                studyV2Repository.findFetchById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
+
+        studyValidatorV2.validateStudyMentor(currentMember, study);
+
+        StudyUpdateCommand command = request.toCommand();
+
+        study.update(command);
+        studyV2Repository.save(study);
+
+        log.info("[MentoryStudyServiceV2] 스터디 정보 수정 완료: studyId={}", studyId);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
@@ -1,7 +1,10 @@
 package com.gdschongik.gdsc.domain.studyv2.domain;
 
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
 import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.common.vo.Period;
+import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -102,5 +105,26 @@ public class StudySessionV2 extends BaseEntity {
 
     public static void createEmptyForAssignment(Integer position, StudyV2 study) {
         StudySessionV2.builder().position(position).study(study).build();
+    }
+
+    // 데이터 변경 로직
+
+    public void update(StudyUpdateCommand.Session command) {
+        validateLessonFieldNullWhenAssignmentStudy(lessonPeriod);
+        this.title = command.title();
+        this.description = command.description();
+        this.lessonPeriod = command.lessonPeriod();
+        this.assignmentDescriptionLink = command.assignmentDescriptionLink();
+        this.assignmentPeriod = command.assignmentPeriod();
+    }
+
+    private void validateLessonFieldNullWhenAssignmentStudy(Period lessonPeriodToUpdate) {
+        if (study.getType().isLive()) {
+            return;
+        }
+
+        if (lessonPeriodToUpdate != null) {
+            throw new CustomException(STUDY_NOT_UPDATABLE_LESSON_FIELD_NOT_NULL);
+        }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
@@ -110,7 +110,7 @@ public class StudySessionV2 extends BaseEntity {
     // 데이터 변경 로직
 
     public void update(StudyUpdateCommand.Session command) {
-        validateLessonFieldNullWhenAssignmentStudy(lessonPeriod);
+        validateLessonFieldNullWhenAssignmentStudy(command.lessonPeriod());
         this.title = command.title();
         this.description = command.description();
         this.lessonPeriod = command.lessonPeriod();

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyUpdateCommand.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyUpdateCommand.java
@@ -1,0 +1,25 @@
+package com.gdschongik.gdsc.domain.studyv2.domain;
+
+import com.gdschongik.gdsc.domain.common.vo.Period;
+import jakarta.annotation.Nullable;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+
+public record StudyUpdateCommand(
+        String title,
+        String description,
+        String descriptionNotionLink,
+        DayOfWeek dayOfWeek,
+        LocalTime startTime,
+        LocalTime endTime,
+        List<Session> studySessions) {
+
+    public record Session(
+            Long studySessionId,
+            String title,
+            String description,
+            Period lessonPeriod,
+            @Nullable String assignmentDescriptionLink,
+            @Nullable Period assignmentPeriod) {}
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
@@ -209,7 +209,7 @@ public class StudyV2 extends BaseEntity {
             getStudySession(sessionCommand.studySessionId()).update(sessionCommand);
         });
 
-        validateLessonSuccession();
+        validateLessonTimeOrderMatchesPosition();
     }
 
     private StudySessionV2 getStudySession(Long studySessionId) {
@@ -222,7 +222,7 @@ public class StudyV2 extends BaseEntity {
     /**
      * 위치에 따라 정렬된 스터디회차의 수업 진행일들의 순차성을 검증합니다.
      */
-    private void validateLessonSuccession() {
+    private void validateLessonTimeOrderMatchesPosition() {
         List<Long> sessionIdsByPosition = studySessions.stream()
                 .sorted(Comparator.comparing(StudySessionV2::getPosition))
                 .map(StudySessionV2::getId)

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
@@ -1,12 +1,13 @@
 package com.gdschongik.gdsc.domain.studyv2.domain;
 
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
 import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.common.vo.Semester;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.StudyType;
 import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.global.exception.ErrorCode;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -25,6 +26,7 @@ import jakarta.persistence.Table;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -162,7 +164,7 @@ public class StudyV2 extends BaseEntity {
 
     private static void validateLiveStudy(StudyType type) {
         if (!type.isLive()) {
-            throw new CustomException(ErrorCode.STUDY_NOT_CREATABLE_NOT_LIVE);
+            throw new CustomException(STUDY_NOT_CREATABLE_NOT_LIVE);
         }
     }
 
@@ -191,5 +193,49 @@ public class StudyV2 extends BaseEntity {
                 .discordRoleId(discordRoleId)
                 .mentor(mentor)
                 .build();
+    }
+
+    // 데이터 변경 로직
+
+    public void update(StudyUpdateCommand command) {
+        this.title = command.title();
+        this.description = command.description();
+        this.descriptionNotionLink = command.descriptionNotionLink();
+        this.dayOfWeek = command.dayOfWeek();
+        this.startTime = command.startTime();
+        this.endTime = command.endTime();
+
+        command.studySessions().forEach(sessionCommand -> {
+            getStudySession(sessionCommand.studySessionId()).update(sessionCommand);
+        });
+
+        validateLessonSuccession();
+    }
+
+    private StudySessionV2 getStudySession(Long studySessionId) {
+        return studySessions.stream()
+                .filter(session -> session.getId().equals(studySessionId))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(STUDY_NOT_UPDATABLE_SESSION_NOT_FOUND));
+    }
+
+    /**
+     * 위치에 따라 정렬된 스터디회차의 수업 진행일들의 순차성을 검증합니다.
+     */
+    private void validateLessonSuccession() {
+        List<Long> sessionIdsByPosition = studySessions.stream()
+                .sorted(Comparator.comparing(StudySessionV2::getPosition))
+                .map(StudySessionV2::getId)
+                .toList();
+
+        List<Long> sessionIdsByLessonStart = studySessions.stream()
+                .sorted(Comparator.comparing(
+                        session -> session.getLessonPeriod().getStartDate()))
+                .map(StudySessionV2::getId)
+                .toList();
+
+        if (!sessionIdsByPosition.equals(sessionIdsByLessonStart)) {
+            throw new CustomException(STUDY_NOT_UPDATABLE_LESSON_PERIOD_NOT_SEQUENTIAL);
+        }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyValidatorV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyValidatorV2.java
@@ -1,0 +1,27 @@
+package com.gdschongik.gdsc.domain.studyv2.domain;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.global.annotation.DomainService;
+import com.gdschongik.gdsc.global.exception.CustomException;
+
+@DomainService
+public class StudyValidatorV2 {
+    public void validateStudyMentor(Member currentMember, StudyV2 study) {
+        // 어드민인 경우 검증 통과
+        if (currentMember.isAdmin()) {
+            return;
+        }
+
+        // 멘토인지 검증
+        if (!currentMember.isMentor()) {
+            throw new CustomException(STUDY_ACCESS_NOT_ALLOWED);
+        }
+
+        // 해당 스터디의 담당 멘토인지 검증
+        if (!currentMember.getId().equals(study.getMentor().getId())) {
+            throw new CustomException(STUDY_MENTOR_INVALID);
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyUpdateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyUpdateRequest.java
@@ -23,8 +23,8 @@ public record StudyUpdateRequest(
             @Nullable String assignmentDescriptionLink,
             @Nullable Period assignmentPeriod) {}
 
-    public static StudyUpdateCommand toCommand(StudyUpdateRequest request) {
-        var sessionCommands = request.studySessions().stream()
+    public StudyUpdateCommand toCommand() {
+        var sessionCommands = studySessions().stream()
                 .map(studySession -> new StudyUpdateCommand.Session(
                         studySession.studySessionId(),
                         studySession.title(),
@@ -35,12 +35,6 @@ public record StudyUpdateRequest(
                 .toList();
 
         return new StudyUpdateCommand(
-                request.title(),
-                request.description(),
-                request.descriptionNotionLink(),
-                request.dayOfWeek(),
-                request.startTime(),
-                request.endTime(),
-                sessionCommands);
+                title, description, descriptionNotionLink, dayOfWeek, startTime, endTime, sessionCommands);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyUpdateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyUpdateRequest.java
@@ -1,0 +1,24 @@
+package com.gdschongik.gdsc.domain.studyv2.dto.request;
+
+import com.gdschongik.gdsc.domain.common.vo.Period;
+import jakarta.annotation.Nullable;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+
+public record StudyUpdateRequest(
+        String title,
+        String description,
+        String descriptionNotionLink,
+        DayOfWeek dayOfWeek,
+        LocalTime startTime,
+        LocalTime endTime,
+        List<StudySessionUpdateDto> studySessions) {
+    public record StudySessionUpdateDto(
+            Long studySessionId,
+            String title,
+            String description,
+            Period lessonPeriod,
+            @Nullable String assignmentDescriptionLink,
+            @Nullable Period assignmentPeriod) {}
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyUpdateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.studyv2.dto.request;
 
 import com.gdschongik.gdsc.domain.common.vo.Period;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyUpdateCommand;
 import jakarta.annotation.Nullable;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
@@ -21,4 +22,25 @@ public record StudyUpdateRequest(
             Period lessonPeriod,
             @Nullable String assignmentDescriptionLink,
             @Nullable Period assignmentPeriod) {}
+
+    public static StudyUpdateCommand toCommand(StudyUpdateRequest request) {
+        var sessionCommands = request.studySessions().stream()
+                .map(studySession -> new StudyUpdateCommand.Session(
+                        studySession.studySessionId(),
+                        studySession.title(),
+                        studySession.description(),
+                        studySession.lessonPeriod(),
+                        studySession.assignmentDescriptionLink(),
+                        studySession.assignmentPeriod()))
+                .toList();
+
+        return new StudyUpdateCommand(
+                request.title(),
+                request.description(),
+                request.descriptionNotionLink(),
+                request.dayOfWeek(),
+                request.startTime(),
+                request.endTime(),
+                sessionCommands);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -108,6 +108,9 @@ public enum ErrorCode {
     STUDY_NOT_APPLICABLE(HttpStatus.CONFLICT, "스터디 신청기간이 아닙니다."),
     STUDY_NOT_CANCELABLE_APPLICATION_PERIOD(HttpStatus.CONFLICT, "스터디 신청기간이 아니라면 취소할 수 없습니다."),
     STUDY_NOT_CREATABLE_NOT_LIVE(HttpStatus.INTERNAL_SERVER_ERROR, "온라인 및 오프라인 타입만 라이브 스터디로 생성할 수 있습니다."),
+    STUDY_NOT_UPDATABLE_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 스터디에 수정하려는 스터디 회차 ID가 존재하지 않습니다."),
+    STUDY_NOT_UPDATABLE_LESSON_FIELD_NOT_NULL(HttpStatus.CONFLICT, "과제 스터디는 수업 관련 필드를 null로 설정할 수 없습니다."),
+    STUDY_NOT_UPDATABLE_LESSON_PERIOD_NOT_SEQUENTIAL(HttpStatus.CONFLICT, "뒷 수업의 시작시간은 앞 수업의 시작시간보다 빠를 수 없습니다."),
 
     // StudyDetail
     STUDY_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 상세 정보입니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #879

## 📌 작업 내용 및 특이사항
(테스트 추가 전 미리 리뷰하시라고 올려둡니다)

### 요약
- 전반적으로 DDD 전술적 설계를 더 명확하게 반영했습니다. 
- 특히 애그리거트의 정의에 더 부합하는 방향으로 스터디V2를 개선했습니다.

### 수정용 커맨드 객체
- 기존에는 스터디 / 스터디상세 따로 수정했었습니다.
- 지금은 애그리거트 루트 엔티티인 스터디가 자식 엔티티인 스터디회차 컬렉션에 대한 생명주기를 관리합니다.
- 스터디 회차에 직접 접근하여 수정하지 않고, 스터디로 스터디 회차에 대한 수정을 요청하도록 합니다.
- 이때 스터디 자체 메타정보를 수정할 수도 있고 + 여러 건의 스터디 회차들을 수행해야 하는 일이 update 하나에서 모두 일어납니다.
- 특히 여러 건의 스터디 회차를 수정하기 위해서는 List<StudySessionUpdateDto> 같은 필드를 받을 수 있게 도메인 단에 Dto 하나를 더 추가해야 하는 상황입니다.
- request를 그대로 받으면 응용 계층 관심사가 도메인 계층으로 침투하는 것이므로 도메인 모델 전용 필드 묶음이 필요합니다 -> `StudyUpdateCommand`를 만들었습니다. 그리고 이 커맨드 객체로 변환하는 `toCommand()` 를 request dto에 추가했습니다. 이러면 계층 의존성 방향이 위를 향하므로 괜찮습니다. 
- 편의성 측면에서 그냥 request dto를 응용 계층과 도메인 계층 둘 다에서 알도록 만들 수도 있겠지만... 차후 일관성 측면에서 처음에 표준을 잘 만드는 게 좋다고 판단했습니다.

### 스터디회차 숨기기
- 애그리거트 당 하나의 레포지터리만 존재해야 합니다. 스터디회차의 생명주기는 스터디에 의해 관리되어야 합니다. 만약 스터디 하나로 관리하기 너무 크다 하면 StudyValidator나 StudyDomainService로 추출해서 다루면 됩니다.
- 더 이상 `StudyDetailRepository`, `StudyDetailValidator` 같이 스터디회차(상세)가 단독으로 존재할 수 있게 하는 로직들을 만들지 않습니다.
- 마찬가지로 기존에 StudyDetailValidator에서 수행하던 로직들이 Study으로 들어갔습니다.
    1. 이번에 과제 스터디가 추가되면서 과제 스터디인 경우 스터디회차에서 수업 관련 필드가 null이어야 한다는 제약조건이 생겼습니다. `validateLessonFieldNullWhenAssignmentStudy` 참고 바람
    2. 과제 마감기한 관련 검증 정책은 완전히 제거되었습니다.
    3. 다만 수업 진행기한 정책은 여전히 존재해야 합니다. 복잡하게 가기보다는 StudySession을 position 기준으로 정렬했을 때, '수업 시작일시가 순차성을 띄어야 한다' 정도만 검증합니다. `validateLessonTimeOrderMatchesPosition` 참고. 단 이 경우에 시작일시 동일한 경우 검증 메서드에서 문제가 생길 수도 있을 듯 한데 이건 테스트로 좀 더 검증해야봐야 합니다.
 
### 테스트
테스트 추가해야 합니다. 검증해야 할 부분들 메모
1. 시작일시가 같은 경우 순차성 검증 로직에 문제 없는지, 엣지 케이스 없는지 체크
2. Study만 save 시 영속성 전이 옵션에 의해 변경된 StudySession도 같이 변경되어 저장되는지 통합 테스트 필요


## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- 멘토가 스터디 정보를 수정할 수 있는 업데이트 기능이 추가되었습니다.
	- 스터디 세션의 세부 정보와 시간 순서를 자동 검증하여 업데이트 과정의 일관성을 보장합니다.
	- 업데이트 요청 시 개선된 오류 메시지를 통해 문제 발생 시 명확한 피드백을 제공합니다.
	- 새로운 요청 형식인 `StudyUpdateRequest`가 추가되어 업데이트 데이터의 캡슐화를 지원합니다.
	- 스터디 업데이트를 위한 새로운 커맨드 객체인 `StudyUpdateCommand`가 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->