### PR TITLE
feat: 스터디 수강이력 레포지터리 입력 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyHistoryControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyHistoryControllerV2.java
@@ -1,0 +1,31 @@
+package com.gdschongik.gdsc.domain.studyv2.api;
+
+import com.gdschongik.gdsc.domain.studyv2.application.StudentStudyHistoryServiceV2;
+import com.gdschongik.gdsc.domain.studyv2.dto.request.StudyHistoryRepositoryUpdateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Student Study History V2", description = "학생 스터디 수강이력 API입니다.")
+@RestController
+@RequestMapping("/v2/study-history")
+@RequiredArgsConstructor
+public class StudentStudyHistoryControllerV2 {
+
+    private final StudentStudyHistoryServiceV2 studentStudyHistoryServiceV2;
+
+    @Operation(summary = "레포지토리 입력", description = "과제 제출 레포지토리를 입력합니다.")
+    @PutMapping("/{studyId}/repository")
+    public ResponseEntity<Void> updateRepository(
+            @PathVariable Long studyId, @Valid @RequestBody StudyHistoryRepositoryUpdateRequest request) {
+        studentStudyHistoryServiceV2.updateRepository(studyId, request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyHistoryControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyHistoryControllerV2.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,17 +14,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Student Study History V2", description = "학생 스터디 수강이력 API입니다.")
 @RestController
-@RequestMapping("/v2/study-history")
+@RequestMapping("/v2/study-histories")
 @RequiredArgsConstructor
 public class StudentStudyHistoryControllerV2 {
 
     private final StudentStudyHistoryServiceV2 studentStudyHistoryServiceV2;
 
-    @Operation(summary = "레포지토리 입력", description = "과제 제출 레포지토리를 입력합니다.")
-    @PutMapping("/{studyId}/repository")
-    public ResponseEntity<Void> updateRepository(
-            @PathVariable Long studyId, @Valid @RequestBody StudyHistoryRepositoryUpdateRequest request) {
-        studentStudyHistoryServiceV2.updateRepository(studyId, request);
+    @Operation(summary = "내 레포지토리 입력", description = "나의 과제 제출 레포지토리를 입력합니다.")
+    @PutMapping("/repositories/me")
+    public ResponseEntity<Void> updateRepository(@Valid @RequestBody StudyHistoryRepositoryUpdateRequest request) {
+        studentStudyHistoryServiceV2.updateRepository(request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyHistoryControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyHistoryControllerV2.java
@@ -22,8 +22,8 @@ public class StudentStudyHistoryControllerV2 {
 
     @Operation(summary = "내 레포지토리 입력", description = "나의 과제 제출 레포지토리를 입력합니다.")
     @PutMapping("/repositories/me")
-    public ResponseEntity<Void> updateRepository(@Valid @RequestBody StudyHistoryRepositoryUpdateRequest request) {
-        studentStudyHistoryServiceV2.updateRepository(request);
+    public ResponseEntity<Void> updateMyRepository(@Valid @RequestBody StudyHistoryRepositoryUpdateRequest request) {
+        studentStudyHistoryServiceV2.updateMyRepository(request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyHistoryServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyHistoryServiceV2.java
@@ -44,7 +44,7 @@ public class StudentStudyHistoryServiceV2 {
         studyHistoryV2Repository.save(studyHistory);
 
         log.info(
-                "[료StudentStudyHistoryServiceV2] 레포지토리 입력 완료: studyHistoryId={}, repositoryLink={}",
+                "[StudentStudyHistoryServiceV2] 레포지토리 입력 완료: studyHistoryId={}, repositoryLink={}",
                 studyHistory.getId(),
                 request.repositoryLink());
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyHistoryServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyHistoryServiceV2.java
@@ -44,7 +44,7 @@ public class StudentStudyHistoryServiceV2 {
         studyHistoryV2Repository.save(studyHistory);
 
         log.info(
-                "[StudentStudyHistoryServiceV2] 레포지토리 입력 완료: studyHistoryId={}, repositoryLink={}",
+                "[StudentStudyHistoryServiceV2] 내 레포지토리 입력 완료: studyHistoryId={}, repositoryLink={}",
                 studyHistory.getId(),
                 request.repositoryLink());
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyHistoryServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyHistoryServiceV2.java
@@ -1,0 +1,50 @@
+package com.gdschongik.gdsc.domain.studyv2.application;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.studyv2.dao.StudyHistoryV2Repository;
+import com.gdschongik.gdsc.domain.studyv2.dao.StudyV2Repository;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyHistoryV2;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyHistoryValidatorV2;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyV2;
+import com.gdschongik.gdsc.domain.studyv2.dto.request.StudyHistoryRepositoryUpdateRequest;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.util.MemberUtil;
+import com.gdschongik.gdsc.infra.github.client.GithubClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StudentStudyHistoryServiceV2 {
+
+    private final GithubClient githubClient;
+    private final MemberUtil memberUtil;
+    private final StudyV2Repository studyV2Repository;
+    private final StudyHistoryV2Repository studyHistoryV2Repository;
+    private final StudyHistoryValidatorV2 studyHistoryValidatorV2;
+
+    @Transactional
+    public void updateRepository(Long studyId, StudyHistoryRepositoryUpdateRequest request) {
+        Member currentMember = memberUtil.getCurrentMember();
+        StudyV2 study = studyV2Repository.findById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
+        StudyHistoryV2 studyHistory = studyHistoryV2Repository
+                .findByStudentAndStudy(currentMember, study)
+                .orElseThrow(() -> new CustomException(STUDY_HISTORY_NOT_FOUND));
+        String repositoryOwnerId = githubClient.getOwnerId(request.repositoryLink());
+
+        studyHistoryValidatorV2.validateUpdateRepository(repositoryOwnerId, currentMember);
+
+        studyHistory.updateRepositoryLink(request.repositoryLink());
+        studyHistoryV2Repository.save(studyHistory);
+
+        log.info(
+                "[료StudentStudyHistoryServiceV2] 레포지토리 입력 완료: studyHistoryId={}, repositoryLink={}",
+                studyHistory.getId(),
+                request.repositoryLink());
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyHistoryServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyHistoryServiceV2.java
@@ -29,7 +29,7 @@ public class StudentStudyHistoryServiceV2 {
     private final StudyHistoryValidatorV2 studyHistoryValidatorV2;
 
     @Transactional
-    public void updateRepository(StudyHistoryRepositoryUpdateRequest request) {
+    public void updateMyRepository(StudyHistoryRepositoryUpdateRequest request) {
         Member currentMember = memberUtil.getCurrentMember();
         StudyV2 study =
                 studyV2Repository.findById(request.studyId()).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyHistoryServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyHistoryServiceV2.java
@@ -29,9 +29,10 @@ public class StudentStudyHistoryServiceV2 {
     private final StudyHistoryValidatorV2 studyHistoryValidatorV2;
 
     @Transactional
-    public void updateRepository(Long studyId, StudyHistoryRepositoryUpdateRequest request) {
+    public void updateRepository(StudyHistoryRepositoryUpdateRequest request) {
         Member currentMember = memberUtil.getCurrentMember();
-        StudyV2 study = studyV2Repository.findById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
+        StudyV2 study =
+                studyV2Repository.findById(request.studyId()).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
         StudyHistoryV2 studyHistory = studyHistoryV2Repository
                 .findByStudentAndStudy(currentMember, study)
                 .orElseThrow(() -> new CustomException(STUDY_HISTORY_NOT_FOUND));

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dao/StudyHistoryV2Repository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dao/StudyHistoryV2Repository.java
@@ -1,6 +1,11 @@
 package com.gdschongik.gdsc.domain.studyv2.dao;
 
+import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyHistoryV2;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyV2;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StudyHistoryV2Repository extends JpaRepository<StudyHistoryV2, Long>, StudyHistoryV2CustomRepository {}
+public interface StudyHistoryV2Repository extends JpaRepository<StudyHistoryV2, Long>, StudyHistoryV2CustomRepository {
+    Optional<StudyHistoryV2> findByStudentAndStudy(Member student, StudyV2 study);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyHistoryValidatorV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyHistoryValidatorV2.java
@@ -5,6 +5,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import java.util.Objects;
 
 @DomainService
 public class StudyHistoryValidatorV2 {
@@ -19,7 +20,7 @@ public class StudyHistoryValidatorV2 {
         // 레포지토리 소유자가 현 멤버가 아닌 경우
         String currentMemberGithubId = currentMember.getOauthId();
 
-        if (!repositoryOwnerGithubId.equals(currentMemberGithubId)) {
+        if (!Objects.equals(repositoryOwnerGithubId, currentMemberGithubId)) {
             throw new CustomException(STUDY_HISTORY_REPOSITORY_NOT_UPDATABLE_OWNER_MISMATCH);
         }
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyHistoryValidatorV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyHistoryValidatorV2.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.domain.studyv2.domain;
 
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
+import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
 
@@ -11,6 +12,15 @@ public class StudyHistoryValidatorV2 {
     public void validateAppliedToStudy(long countStudyHistory, int studentCount) {
         if (countStudyHistory != studentCount) {
             throw new CustomException(STUDY_HISTORY_NOT_APPLIED_STUDENT_EXISTS);
+        }
+    }
+
+    public void validateUpdateRepository(String repositoryOwnerGithubId, Member currentMember) {
+        // 레포지토리 소유자가 현 멤버가 아닌 경우
+        String currentMemberGithubId = currentMember.getOauthId();
+
+        if (!repositoryOwnerGithubId.equals(currentMemberGithubId)) {
+            throw new CustomException(STUDY_HISTORY_REPOSITORY_NOT_UPDATABLE_OWNER_MISMATCH);
         }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyHistoryRepositoryUpdateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyHistoryRepositoryUpdateRequest.java
@@ -2,7 +2,10 @@ package com.gdschongik.gdsc.domain.studyv2.dto.request;
 
 import com.gdschongik.gdsc.global.common.constant.RegexConstant;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
 
 public record StudyHistoryRepositoryUpdateRequest(
+        @NotNull @Positive Long studyId,
         @NotBlank @Pattern(regexp = RegexConstant.GITHUB_REPOSITORY) String repositoryLink) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyHistoryRepositoryUpdateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyHistoryRepositoryUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.gdschongik.gdsc.domain.studyv2.dto.request;
+
+import com.gdschongik.gdsc.global.common.constant.RegexConstant;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record StudyHistoryRepositoryUpdateRequest(
+        @NotBlank @Pattern(regexp = RegexConstant.GITHUB_REPOSITORY) String repositoryLink) {}

--- a/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
@@ -39,6 +39,14 @@ public class GithubClient {
         }
     }
 
+    public String getOwnerId(String repo) {
+        try {
+            return String.valueOf(getRepository(repo).getOwner().getId());
+        } catch (IOException e) {
+            throw new CustomException(GITHUB_REPOSITORY_NOT_FOUND);
+        }
+    }
+
     public String getGithubHandle(String oauthId) {
         try (GitHubConnectorResponse response = gitHubConnector.send(new GithubUserRequest(oauthId));
                 InputStream inputStream = response.bodyStream(); ) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #910

## 📌 작업 내용 및 특이사항
기존과 동일하긴 한데, 사소한 변경사항이 있습니다.

- 인프라 계층을 서비스 계층에서 알지 못하게 `GithubClient`로부터 `GHRepository` 를 직접 가져오는 대신 레포지터리 오우너 정보만 가져오도록 개선했습니다.
- 도메인 서비스 검증 로직에서 현재 로그인한 유저의 oauthId와 레포지터리 오우너의 github ID 검증하는 로직에서 인자를 멤버 엔티티로 받도록 개선했습니다.
- 문자열 비교 시 NPE 방지 위해 `Objects.equals()` 사용하도록 변경했습니다.

### 0223 20:11 업데이트 사항
- API 엔드포인트 정보 및 요청 방식을 변경했습니다.
- 기존에는 `/study-histories/{studyId}` 와 같은 식이었는데요, 스터디 수강이력은 스터디 수강이력 ID로 식별해야 하며 studyId로 검색하고 싶은 경우 `/study-histories?studyId={studyId}` 와 같은 식으로 설계되어야 합니다.
- 단 get 요청이 아니므로 요청 파라미터를 사용하지 않고, 요청 바디 안에 studyId를 같이 담아서 전달해줘야 합니다.
- 또한, 현재 로그인한 유저 정보를 사용하여 데이터의 유형이 결정되는 my 계열 API의 경우, `/me` suffix를 붙여주는 것이 적절합니다.
- 따라서 `PUT /study-histories/repositories/me` 가 적절하다고 판단했습니다.
- 또한 컨벤션에 맞게 메서드명을 `updateRepository()` 를 `updateMyRepository()` 로 변경했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 학생 스터디 기록의 저장소 링크를 업데이트할 수 있는 API 엔드포인트가 추가되었습니다.
	- 업데이트 과정에서 GitHub 저장소 소유자 검증 및 입력 값 유효성 검사가 강화되어, 보다 안전한 변경이 가능합니다.
	- 사용자에게 안정적인 기록 관리를 제공하여 업데이트 시 발생할 수 있는 오류를 사전에 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->