### PR TITLE
feat: 내 스터디 수강이력 목록 조회 V2 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyHistoryControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyHistoryControllerV2.java
@@ -2,11 +2,14 @@ package com.gdschongik.gdsc.domain.studyv2.api;
 
 import com.gdschongik.gdsc.domain.studyv2.application.StudentStudyHistoryServiceV2;
 import com.gdschongik.gdsc.domain.studyv2.dto.request.StudyHistoryRepositoryUpdateRequest;
+import com.gdschongik.gdsc.domain.studyv2.dto.response.StudyHistoryMyResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,5 +28,12 @@ public class StudentStudyHistoryControllerV2 {
     public ResponseEntity<Void> updateMyRepository(@Valid @RequestBody StudyHistoryRepositoryUpdateRequest request) {
         studentStudyHistoryServiceV2.updateMyRepository(request);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "내 스터디 수강이력 목록 조회", description = "나의 스터디 수강이력 목록을 조회합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<List<StudyHistoryMyResponse>> getMyStudyHistories() {
+        var response = studentStudyHistoryServiceV2.getMyStudyHistories();
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyHistoryServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyHistoryServiceV2.java
@@ -1,17 +1,23 @@
 package com.gdschongik.gdsc.domain.studyv2.application;
 
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static java.util.stream.Collectors.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.studyv2.dao.StudyAchievementV2Repository;
 import com.gdschongik.gdsc.domain.studyv2.dao.StudyHistoryV2Repository;
 import com.gdschongik.gdsc.domain.studyv2.dao.StudyV2Repository;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyAchievementV2;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyHistoryV2;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyHistoryValidatorV2;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyV2;
 import com.gdschongik.gdsc.domain.studyv2.dto.request.StudyHistoryRepositoryUpdateRequest;
+import com.gdschongik.gdsc.domain.studyv2.dto.response.StudyHistoryMyResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import com.gdschongik.gdsc.infra.github.client.GithubClient;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,6 +32,7 @@ public class StudentStudyHistoryServiceV2 {
     private final MemberUtil memberUtil;
     private final StudyV2Repository studyV2Repository;
     private final StudyHistoryV2Repository studyHistoryV2Repository;
+    private final StudyAchievementV2Repository studyAchievementV2Repository;
     private final StudyHistoryValidatorV2 studyHistoryValidatorV2;
 
     @Transactional
@@ -47,5 +54,20 @@ public class StudentStudyHistoryServiceV2 {
                 "[StudentStudyHistoryServiceV2] 내 레포지토리 입력 완료: studyHistoryId={}, repositoryLink={}",
                 studyHistory.getId(),
                 request.repositoryLink());
+    }
+
+    @Transactional(readOnly = true)
+    public List<StudyHistoryMyResponse> getMyStudyHistories() {
+        Member currentMember = memberUtil.getCurrentMember();
+        List<StudyHistoryV2> studyHistories = studyHistoryV2Repository.findAllByStudent(currentMember);
+        List<StudyAchievementV2> studyAchievements = studyAchievementV2Repository.findAllByStudent(currentMember);
+
+        Map<StudyV2, List<StudyAchievementV2>> achievementsByStudy =
+                studyAchievements.stream().collect(groupingBy(StudyAchievementV2::getStudy));
+
+        return studyHistories.stream()
+                .map(history -> StudyHistoryMyResponse.of(
+                        history, history.getStudy(), achievementsByStudy.getOrDefault(history.getStudy(), List.of())))
+                .toList();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dao/StudyAchievementV2Repository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dao/StudyAchievementV2Repository.java
@@ -1,7 +1,11 @@
 package com.gdschongik.gdsc.domain.studyv2.dao;
 
+import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyAchievementV2;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudyAchievementV2Repository
-        extends JpaRepository<StudyAchievementV2, Long>, StudyAchievementV2CustomRepository {}
+        extends JpaRepository<StudyAchievementV2, Long>, StudyAchievementV2CustomRepository {
+    List<StudyAchievementV2> findAllByStudent(Member student);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dao/StudyHistoryV2Repository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dao/StudyHistoryV2Repository.java
@@ -3,9 +3,12 @@ package com.gdschongik.gdsc.domain.studyv2.dao;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyHistoryV2;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyV2;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudyHistoryV2Repository extends JpaRepository<StudyHistoryV2, Long>, StudyHistoryV2CustomRepository {
     Optional<StudyHistoryV2> findByStudentAndStudy(Member student, StudyV2 study);
+
+    List<StudyHistoryV2> findAllByStudent(Member student);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyAchievementDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyAchievementDto.java
@@ -1,0 +1,14 @@
+package com.gdschongik.gdsc.domain.studyv2.dto.dto;
+
+import com.gdschongik.gdsc.domain.study.domain.AchievementType;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyAchievementV2;
+
+public record StudyAchievementDto(Long studyAchievementId, AchievementType type, Long studentId, Long studyId) {
+    public static StudyAchievementDto from(StudyAchievementV2 studyAchievement) {
+        return new StudyAchievementDto(
+                studyAchievement.getId(),
+                studyAchievement.getType(),
+                studyAchievement.getStudent().getId(),
+                studyAchievement.getStudy().getId());
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyHistoryDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyHistoryDto.java
@@ -1,0 +1,14 @@
+package com.gdschongik.gdsc.domain.studyv2.dto.dto;
+
+import com.gdschongik.gdsc.domain.study.domain.StudyHistoryStatus;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyHistoryV2;
+
+public record StudyHistoryDto(Long studyHistoryId, StudyHistoryStatus status, Long memberId, Long studyId) {
+    public static StudyHistoryDto from(StudyHistoryV2 studyHistory) {
+        return new StudyHistoryDto(
+                studyHistory.getId(),
+                studyHistory.getStatus(),
+                studyHistory.getStudent().getId(),
+                studyHistory.getStudy().getId());
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyStudentDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyStudentDto.java
@@ -3,6 +3,7 @@ package com.gdschongik.gdsc.domain.studyv2.dto.dto;
 import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.common.vo.Semester;
 import com.gdschongik.gdsc.domain.study.domain.StudyType;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyV2;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 
@@ -22,4 +23,21 @@ public record StudyStudentDto(
         LocalTime endTime,
         Period applicationPeriod,
         Long mentorId,
-        String mentorName) {}
+        String mentorName) {
+    public static StudyStudentDto from(StudyV2 study) {
+        return new StudyStudentDto(
+                study.getId(),
+                study.getType(),
+                study.getTitle(),
+                study.getDescription(),
+                study.getDescriptionNotionLink(),
+                study.getSemester(),
+                study.getTotalRound(),
+                study.getDayOfWeek(),
+                study.getStartTime(),
+                study.getEndTime(),
+                study.getApplicationPeriod(),
+                study.getMentor().getId(),
+                study.getMentor().getName());
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyHistoryMyResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyHistoryMyResponse.java
@@ -1,0 +1,20 @@
+package com.gdschongik.gdsc.domain.studyv2.dto.response;
+
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyAchievementV2;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyHistoryV2;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyV2;
+import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyAchievementDto;
+import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyHistoryDto;
+import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyStudentDto;
+import java.util.List;
+
+public record StudyHistoryMyResponse(
+        StudyHistoryDto studyHistory, StudyStudentDto study, List<StudyAchievementDto> achievements) {
+    public static StudyHistoryMyResponse of(
+            StudyHistoryV2 studyHistory, StudyV2 study, List<StudyAchievementV2> achievements) {
+        return new StudyHistoryMyResponse(
+                StudyHistoryDto.from(studyHistory),
+                StudyStudentDto.from(study),
+                achievements.stream().map(StudyAchievementDto::from).toList());
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #914

## 📌 작업 내용 및 특이사항
- 기존 V1 API의 경우 '수료내역' 조회로 되어있고 메서드명도 `geMyCompletedStudyHistories` 로 되어있는데요, 실제 피그마 디자인을 보면 전체 수강이력을 가져와야 하고, 실제 조회 로직도 status가 COMPLETED된 것만 필터링하는 로직이 없습니다.
- 따라서 수료내역이 아닌 '수강이력 목록' 조회로 네이밍을 변경하고 관련 DTO도 네이밍 맞춰주었습니다.

++ DTO 사용하는 방식 한번씩 체크해주세요. 앞으로 DTO 코딩 컨벤션은 이렇게 진행할 예정입니다
대시보드 API나 수강이력 API처럼, 다른 엔티티를 같이 묶어서 반환하는 API의 경우,
모든 필드를 flatten하여 처리하지 않고, 각 엔티티와 1대1 대응되는 DTO를 조합하여 리턴합니다. (StudyHistoryMyResponse = StudyStudentDto + StudyHistoryDto + StudyAchievementDto)

## 📝 참고사항
-

## 📚 기타
-
