### PR TITLE
feat: 수강중인 모든 스터디의 공지 조회 V2 API 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudyAnnouncementControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudyAnnouncementControllerV2.java
@@ -20,11 +20,17 @@ public class StudyAnnouncementControllerV2 {
 
     private final StudyAnnouncementServiceV2 studyAnnouncementServiceV2;
 
-    @Operation(summary = "스터디 공지 목록 조회", description = "스터디 공지 목록을 조회합니다. studyId가 없다면 수강중인 모든 스터디의 공지를 조회합니다.")
-    @GetMapping("/{studyId}")
-    public ResponseEntity<List<StudyAnnouncementResponse>> getStudyAnnouncements(
-            @PathVariable(required = false) Long studyId) {
+    @Operation(summary = "스터디 공지 목록 조회", description = "스터디 공지 목록을 조회합니다.")
+    @GetMapping("/{studyId}/me")
+    public ResponseEntity<List<StudyAnnouncementResponse>> getStudyAnnouncements(@PathVariable Long studyId) {
         var response = studyAnnouncementServiceV2.getStudyAnnouncements(studyId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "수강중인 모든 스터디의 공지 목록 조회", description = "수강중인 전체 스터디의 공지 목록을 조회합니다")
+    @GetMapping("/me")
+    public ResponseEntity<List<StudyAnnouncementResponse>> getStudiesAnnouncements() {
+        var response = studyAnnouncementServiceV2.getStudiesAnnouncements();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudyAnnouncementControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudyAnnouncementControllerV2.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.studyv2.api;
 
 import com.gdschongik.gdsc.domain.studyv2.application.StudyAnnouncementServiceV2;
-import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyAnnouncementDto;
+import com.gdschongik.gdsc.domain.studyv2.dto.response.StudyAnnouncementResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -22,7 +22,7 @@ public class StudyAnnouncementControllerV2 {
 
     @Operation(summary = "스터디 공지 목록 조회", description = "스터디 공지 목록을 조회합니다. studyId가 없다면 수강중인 모든 스터디의 공지를 조회합니다.")
     @GetMapping("/{studyId}")
-    public ResponseEntity<List<StudyAnnouncementDto>> getStudyAnnouncements(
+    public ResponseEntity<List<StudyAnnouncementResponse>> getStudyAnnouncements(
             @PathVariable(required = false) Long studyId) {
         var response = studyAnnouncementServiceV2.getStudyAnnouncements(studyId);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudyAnnouncementControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudyAnnouncementControllerV2.java
@@ -20,14 +20,14 @@ public class StudyAnnouncementControllerV2 {
 
     private final StudyAnnouncementServiceV2 studyAnnouncementServiceV2;
 
-    @Operation(summary = "스터디 공지 목록 조회", description = "스터디 공지 목록을 조회합니다.")
+    @Operation(summary = "수강중인 특정 스터디의 공지 목록 조회", description = "나의 수강중인 특정 스터디의 공지 목록을 조회합니다.")
     @GetMapping("/{studyId}/me")
     public ResponseEntity<List<StudyAnnouncementResponse>> getStudyAnnouncements(@PathVariable Long studyId) {
         var response = studyAnnouncementServiceV2.getStudyAnnouncements(studyId);
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "수강중인 모든 스터디의 공지 목록 조회", description = "수강중인 전체 스터디의 공지 목록을 조회합니다")
+    @Operation(summary = "수강중인 모든 스터디의 공지 목록 조회", description = "나의 수강중인 모든 스터디의 공지 목록을 조회합니다")
     @GetMapping("/me")
     public ResponseEntity<List<StudyAnnouncementResponse>> getStudiesAnnouncements() {
         var response = studyAnnouncementServiceV2.getStudiesAnnouncements();

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudyAnnouncementControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudyAnnouncementControllerV2.java
@@ -20,9 +20,10 @@ public class StudyAnnouncementControllerV2 {
 
     private final StudyAnnouncementServiceV2 studyAnnouncementServiceV2;
 
-    @Operation(summary = "스터디 공지 목록 조회", description = "스터디 공지 목록을 조회합니다.")
+    @Operation(summary = "스터디 공지 목록 조회", description = "스터디 공지 목록을 조회합니다. studyId가 없다면 수강중인 모든 스터디의 공지를 조회합니다.")
     @GetMapping("/{studyId}")
-    public ResponseEntity<List<StudyAnnouncementDto>> getStudyAnnouncements(@PathVariable Long studyId) {
+    public ResponseEntity<List<StudyAnnouncementDto>> getStudyAnnouncements(
+            @PathVariable(required = false) Long studyId) {
         var response = studyAnnouncementServiceV2.getStudyAnnouncements(studyId);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudyAnnouncementServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudyAnnouncementServiceV2.java
@@ -30,16 +30,14 @@ public class StudyAnnouncementServiceV2 {
 
     @Transactional(readOnly = true)
     public List<StudyAnnouncementResponse> getStudyAnnouncements(@Nullable Long studyId) {
-        if (studyId != null) {
+        List<StudyAnnouncementV2> studyAnnouncements =
+                studyAnnouncementV2Repository.findAllByStudyIdOrderByCreatedAtDesc(studyId);
 
-            List<StudyAnnouncementV2> studyAnnouncements =
-                    studyAnnouncementV2Repository.findAllByStudyIdOrderByCreatedAtDesc(studyId);
+        return studyAnnouncements.stream().map(StudyAnnouncementResponse::from).toList();
+    }
 
-            return studyAnnouncements.stream()
-                    .map(StudyAnnouncementResponse::from)
-                    .toList();
-        }
-
+    @Transactional(readOnly = true)
+    public List<StudyAnnouncementResponse> getStudiesAnnouncements() {
         Member currentMember = memberUtil.getCurrentMember();
         LocalDateTime now = LocalDateTime.now();
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudyAnnouncementServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudyAnnouncementServiceV2.java
@@ -9,7 +9,7 @@ import com.gdschongik.gdsc.domain.studyv2.dao.StudyAnnouncementV2Repository;
 import com.gdschongik.gdsc.domain.studyv2.dao.StudyHistoryV2Repository;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyAnnouncementV2;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyHistoryV2;
-import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyAnnouncementDto;
+import com.gdschongik.gdsc.domain.studyv2.dto.response.StudyAnnouncementResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import jakarta.annotation.Nullable;
@@ -29,13 +29,15 @@ public class StudyAnnouncementServiceV2 {
     private final StudyHistoryV2Repository studyHistoryV2Repository;
 
     @Transactional(readOnly = true)
-    public List<StudyAnnouncementDto> getStudyAnnouncements(@Nullable Long studyId) {
+    public List<StudyAnnouncementResponse> getStudyAnnouncements(@Nullable Long studyId) {
         if (studyId != null) {
 
             List<StudyAnnouncementV2> studyAnnouncements =
                     studyAnnouncementV2Repository.findAllByStudyIdOrderByCreatedAtDesc(studyId);
 
-            return studyAnnouncements.stream().map(StudyAnnouncementDto::from).toList();
+            return studyAnnouncements.stream()
+                    .map(StudyAnnouncementResponse::from)
+                    .toList();
         }
 
         Member currentMember = memberUtil.getCurrentMember();
@@ -53,6 +55,6 @@ public class StudyAnnouncementServiceV2 {
         List<StudyAnnouncementV2> studyAnnouncements =
                 studyAnnouncementV2Repository.findAllByStudyIdsOrderByCreatedAtDesc(currentStudyHistories);
 
-        return studyAnnouncements.stream().map(StudyAnnouncementDto::from).toList();
+        return studyAnnouncements.stream().map(StudyAnnouncementResponse::from).toList();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudyAnnouncementServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudyAnnouncementServiceV2.java
@@ -1,8 +1,19 @@
 package com.gdschongik.gdsc.domain.studyv2.application;
 
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
+import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.studyv2.dao.StudyAnnouncementV2Repository;
+import com.gdschongik.gdsc.domain.studyv2.dao.StudyHistoryV2Repository;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyAnnouncementV2;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyHistoryV2;
 import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyAnnouncementDto;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.util.MemberUtil;
+import jakarta.annotation.Nullable;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,12 +23,35 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class StudyAnnouncementServiceV2 {
 
+    private final MemberUtil memberUtil;
+    private final RecruitmentRepository recruitmentRepository;
     private final StudyAnnouncementV2Repository studyAnnouncementV2Repository;
+    private final StudyHistoryV2Repository studyHistoryV2Repository;
 
     @Transactional(readOnly = true)
-    public List<StudyAnnouncementDto> getStudyAnnouncements(Long studyId) {
+    public List<StudyAnnouncementDto> getStudyAnnouncements(@Nullable Long studyId) {
+        if (studyId != null) {
+
+            List<StudyAnnouncementV2> studyAnnouncements =
+                    studyAnnouncementV2Repository.findAllByStudyIdOrderByCreatedAtDesc(studyId);
+
+            return studyAnnouncements.stream().map(StudyAnnouncementDto::from).toList();
+        }
+
+        Member currentMember = memberUtil.getCurrentMember();
+        LocalDateTime now = LocalDateTime.now();
+
+        Recruitment recruitment = recruitmentRepository
+                .findCurrentRecruitment(now)
+                .orElseThrow(() -> new CustomException(RECRUITMENT_NOT_FOUND));
+
+        List<Long> currentStudyHistories = studyHistoryV2Repository.findAllByStudent(currentMember).stream()
+                .filter(studyHistory -> studyHistory.getStudy().getSemester().equals(recruitment.getSemester()))
+                .map(StudyHistoryV2::getId)
+                .toList();
+
         List<StudyAnnouncementV2> studyAnnouncements =
-                studyAnnouncementV2Repository.findAllByStudyIdOrderByCreatedAtDesc(studyId);
+                studyAnnouncementV2Repository.findAllByStudyIdsOrderByCreatedAtDesc(currentStudyHistories);
 
         return studyAnnouncements.stream().map(StudyAnnouncementDto::from).toList();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dao/StudyAnnouncementV2CustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dao/StudyAnnouncementV2CustomRepository.java
@@ -1,0 +1,9 @@
+package com.gdschongik.gdsc.domain.studyv2.dao;
+
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyAnnouncementV2;
+import java.util.List;
+
+public interface StudyAnnouncementV2CustomRepository {
+
+    List<StudyAnnouncementV2> findAllByStudyIdsOrderByCreatedAtDesc(List<Long> studyIds);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dao/StudyAnnouncementV2CustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dao/StudyAnnouncementV2CustomRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.gdschongik.gdsc.domain.studyv2.dao;
+
+import static com.gdschongik.gdsc.domain.studyv2.domain.QStudyAnnouncementV2.*;
+
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyAnnouncementV2;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class StudyAnnouncementV2CustomRepositoryImpl implements StudyAnnouncementV2CustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<StudyAnnouncementV2> findAllByStudyIdsOrderByCreatedAtDesc(List<Long> studyIds) {
+        return queryFactory
+                .selectFrom(studyAnnouncementV2)
+                .where(studyAnnouncementV2.study.id.in(studyIds))
+                .orderBy(studyAnnouncementV2.createdAt.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dao/StudyAnnouncementV2Repository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dao/StudyAnnouncementV2Repository.java
@@ -4,7 +4,8 @@ import com.gdschongik.gdsc.domain.studyv2.domain.StudyAnnouncementV2;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StudyAnnouncementV2Repository extends JpaRepository<StudyAnnouncementV2, Long> {
+public interface StudyAnnouncementV2Repository
+        extends JpaRepository<StudyAnnouncementV2, Long>, StudyAnnouncementV2CustomRepository {
 
     List<StudyAnnouncementV2> findAllByStudyIdOrderByCreatedAtDesc(Long studyId);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyAnnouncementResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyAnnouncementResponse.java
@@ -1,0 +1,12 @@
+package com.gdschongik.gdsc.domain.studyv2.dto.response;
+
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyAnnouncementV2;
+import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyAnnouncementDto;
+import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyStudentDto;
+
+public record StudyAnnouncementResponse(StudyStudentDto study, StudyAnnouncementDto studyAnnouncement) {
+    public static StudyAnnouncementResponse from(StudyAnnouncementV2 studyAnnouncement) {
+        return new StudyAnnouncementResponse(
+                StudyStudentDto.from(studyAnnouncement.getStudy()), StudyAnnouncementDto.from(studyAnnouncement));
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #968

## 📌 작업 내용 및 특이사항
- 기존 `스터디 공지 목록 조회`에서 PathVariable을 required=false로 하여 수강중인 스터디들의 모든 공지를 조회할 수 있도록 수정했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 스터디 공지 조회 기능이 확장되어, 스터디 ID 없이도 수강 중인 모든 스터디의 공지를 확인할 수 있습니다.
	- 공지 목록이 최신 등록일 순으로 정렬되어, 항상 최신 정보를 빠르게 확인할 수 있습니다.
	- 새로운 응답 형식인 `StudyAnnouncementResponse`가 도입되어, 공지 정보를 보다 체계적으로 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->