### PR TITLE
feat: 나의 할 일 조회 V2 API

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyControllerV2.java
@@ -7,14 +7,13 @@ import com.gdschongik.gdsc.domain.studyv2.dto.response.StudyDashboardResponse;
 import com.gdschongik.gdsc.domain.studyv2.dto.response.StudyTodoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @Tag(name = "Student Study V2", description = "학생 스터디 API입니다.")
 @RestController

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyControllerV2.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.domain.studyv2.api;
 
 import com.gdschongik.gdsc.domain.studyv2.application.StudentStudyServiceV2;
 import com.gdschongik.gdsc.domain.studyv2.dto.response.StudyDashboardResponse;
+import com.gdschongik.gdsc.domain.studyv2.dto.response.StudyTodoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Tag(name = "Student Study V2", description = "학생 스터디 API입니다.")
 @RestController
@@ -23,6 +26,13 @@ public class StudentStudyControllerV2 {
     @GetMapping("/{studyId}/me/dashboard")
     public ResponseEntity<StudyDashboardResponse> getMyStudyDashboard(@PathVariable Long studyId) {
         var response = studentStudyServiceV2.getMyStudyDashboard(studyId);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(summary = "수강중인 특정 스터디의 할 일 리스트 조회", description = "나의 수강중인 특정 스터디의 할 일 리스트를 조회합니다.")
+    @GetMapping("/{studyId}/me/todo")
+    public ResponseEntity<List<StudyTodoResponse>> getStudyTodoList(@PathVariable Long studyId) {
+        var response = studentStudyServiceV2.getMyStudyTodos(studyId);
         return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyControllerV2.java
@@ -45,14 +45,14 @@ public class StudentStudyControllerV2 {
     }
 
     @Operation(summary = "수강중인 특정 스터디의 할 일 리스트 조회", description = "나의 수강중인 특정 스터디의 할 일 리스트를 조회합니다.")
-    @GetMapping("/{studyId}/me/todo")
+    @GetMapping("/{studyId}/me/todos")
     public ResponseEntity<List<StudyTodoResponse>> getStudyTodoList(@PathVariable Long studyId) {
         var response = studentStudyServiceV2.getMyStudyTodos(studyId);
         return ResponseEntity.ok().body(response);
     }
 
     @Operation(summary = "수강중인 모든 스터디의 할 일 리스트 조회", description = "나의 수강중인 모든 스터디의 할 일 리스트를 조회합니다.")
-    @GetMapping("/me/todo")
+    @GetMapping("/me/todos")
     public ResponseEntity<List<StudyTodoResponse>> getStudiesTodoList() {
         var response = studentStudyServiceV2.getMyStudiesTodos();
         return ResponseEntity.ok().body(response);

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyControllerV2.java
@@ -50,4 +50,11 @@ public class StudentStudyControllerV2 {
         var response = studentStudyServiceV2.getMyStudyTodos(studyId);
         return ResponseEntity.ok().body(response);
     }
+
+    @Operation(summary = "수강중인 모든 스터디의 할 일 리스트 조회", description = "나의 수강중인 모든 스터디의 할 일 리스트를 조회합니다.")
+    @GetMapping("/me/todo")
+    public ResponseEntity<List<StudyTodoResponse>> getStudiesTodoList() {
+        var response = studentStudyServiceV2.getMyStudiesTodos();
+        return ResponseEntity.ok().body(response);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyServiceV2.java
@@ -84,9 +84,11 @@ public class StudentStudyServiceV2 {
     @Transactional(readOnly = true)
     public List<StudyTodoResponse> getMyStudyTodos(Long studyId) {
         Member member = memberUtil.getCurrentMember();
-        StudyV2 study = studyV2Repository.findFetchById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
+        StudyV2 study =
+                studyV2Repository.findFetchById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
         List<AttendanceV2> attendances = attendanceV2Repository.findFetchByMemberAndStudy(member, study);
-        List<AssignmentHistoryV2> assignmentHistories = assignmentHistoryV2Repository.findByMemberAndStudy(member, study);
+        List<AssignmentHistoryV2> assignmentHistories =
+                assignmentHistoryV2Repository.findByMemberAndStudy(member, study);
 
         LocalDateTime now = LocalDateTime.now();
         List<StudyTodoResponse> response = new ArrayList<>();
@@ -94,12 +96,14 @@ public class StudentStudyServiceV2 {
         // 출석체크
         study.getStudySessions().stream()
                 .filter(studySession -> studySession.getLessonPeriod().isWithin(now))
-                .forEach(studySession -> response.add(StudyTodoResponse.attendanceType(studySession, study.getType(), attendances, now)));
+                .forEach(studySession -> response.add(
+                        StudyTodoResponse.attendanceType(studySession, study.getType(), attendances, now)));
 
         // 과제
         study.getStudySessions().stream()
                 .filter(studySession -> studySession.getAssignmentPeriod().isWithin(now))
-                .forEach(studySession -> response.add(StudyTodoResponse.assignmentType(studySession, assignmentHistories, now)));
+                .forEach(studySession ->
+                        response.add(StudyTodoResponse.assignmentType(studySession, assignmentHistories, now)));
 
         return response;
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyServiceV2.java
@@ -9,10 +9,7 @@ import com.gdschongik.gdsc.domain.studyv2.dao.AssignmentHistoryV2Repository;
 import com.gdschongik.gdsc.domain.studyv2.dao.AttendanceV2Repository;
 import com.gdschongik.gdsc.domain.studyv2.dao.StudyHistoryV2Repository;
 import com.gdschongik.gdsc.domain.studyv2.dao.StudyV2Repository;
-import com.gdschongik.gdsc.domain.studyv2.domain.AssignmentHistoryV2;
-import com.gdschongik.gdsc.domain.studyv2.domain.AttendanceV2;
-import com.gdschongik.gdsc.domain.studyv2.domain.StudyHistoryV2;
-import com.gdschongik.gdsc.domain.studyv2.domain.StudyV2;
+import com.gdschongik.gdsc.domain.studyv2.domain.*;
 import com.gdschongik.gdsc.domain.studyv2.dto.response.StudentStudyMyCurrentResponse;
 import com.gdschongik.gdsc.domain.studyv2.dto.response.StudyApplicableResponse;
 import com.gdschongik.gdsc.domain.studyv2.dto.response.StudyDashboardResponse;
@@ -100,9 +97,9 @@ public class StudentStudyServiceV2 {
                 .forEach(studySession -> response.add(StudyTodoResponse.attendanceType(studySession, study.getType(), attendances, now)));
 
         // 과제
-        assignmentHistories.stream()
-                .filter(assignmentHistory -> assignmentHistory.getStudySession().getAssignmentPeriod().isWithin(now))
-                .forEach(assignmentHistory -> response.add(StudyTodoResponse.assignmentType(assignmentHistory, now)));
+        study.getStudySessions().stream()
+                .filter(studySession -> studySession.getAssignmentPeriod().isWithin(now))
+                .forEach(studySession -> response.add(StudyTodoResponse.assignmentType(studySession, assignmentHistories, now)));
 
         return response;
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyServiceV2.java
@@ -126,14 +126,16 @@ public class StudentStudyServiceV2 {
         return response;
     }
 
-    private List<StudyTodoResponse> getAttendanceTodos(StudyV2 study, List<AttendanceV2> attendances, LocalDateTime now) {
+    private List<StudyTodoResponse> getAttendanceTodos(
+            StudyV2 study, List<AttendanceV2> attendances, LocalDateTime now) {
         return study.getStudySessions().stream()
                 .filter(studySession -> studySession.isAttendable(now))
                 .map(studySession -> StudyTodoResponse.attendanceType(studySession, study.getType(), attendances, now))
                 .toList();
     }
 
-    private List<StudyTodoResponse> getAssignmentTodos(StudyV2 study, List<AssignmentHistoryV2> assignmentHistories, LocalDateTime now) {
+    private List<StudyTodoResponse> getAssignmentTodos(
+            StudyV2 study, List<AssignmentHistoryV2> assignmentHistories, LocalDateTime now) {
         return study.getStudySessions().stream()
                 .filter(studySession -> studySession.isAssignmentSubmittable(now))
                 .map(studySession -> StudyTodoResponse.assignmentType(studySession, assignmentHistories, now))

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyServiceV2.java
@@ -101,7 +101,7 @@ public class StudentStudyServiceV2 {
 
         // 과제
         study.getStudySessions().stream()
-                .filter(studySession -> studySession.getAssignmentPeriod().isWithin(now))
+                .filter(studySession -> studySession.isAssignmentSubmittable(now))
                 .forEach(studySession ->
                         response.add(StudyTodoResponse.assignmentType(studySession, assignmentHistories, now)));
 
@@ -137,7 +137,7 @@ public class StudentStudyServiceV2 {
 
             // 과제
             study.getStudySessions().stream()
-                    .filter(studySession -> studySession.getAssignmentPeriod().isWithin(now))
+                    .filter(studySession -> studySession.isAssignmentSubmittable(now))
                     .forEach(studySession ->
                             response.add(StudyTodoResponse.assignmentType(studySession, assignmentHistories, now)));
         });

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
@@ -132,6 +132,10 @@ public class StudySessionV2 extends BaseEntity {
         return assignmentPeriod.isWithin(now);
     }
 
+    public boolean isAttendable(LocalDateTime now) {
+        return lessonPeriod.isWithin(now);
+    }
+
     // 데이터 변경 로직
 
     public void update(StudyUpdateCommand.Session command) {

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
@@ -136,6 +136,7 @@ public class StudySessionV2 extends BaseEntity {
         if (lessonPeriod == null) {
             return false;
         }
+
         return lessonPeriod.isWithin(now);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
@@ -124,6 +124,14 @@ public class StudySessionV2 extends BaseEntity {
         }
     }
 
+    public boolean isAssignmentSubmittable(LocalDateTime now) {
+        if (assignmentPeriod == null) {
+            return false;
+        }
+
+        return assignmentPeriod.isWithin(now);
+    }
+
     // 데이터 변경 로직
 
     public void update(StudyUpdateCommand.Session command) {

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
@@ -133,6 +133,9 @@ public class StudySessionV2 extends BaseEntity {
     }
 
     public boolean isAttendable(LocalDateTime now) {
+        if (lessonPeriod == null) {
+            return false;
+        }
         return lessonPeriod.isWithin(now);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyTodoResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyTodoResponse.java
@@ -1,0 +1,64 @@
+package com.gdschongik.gdsc.domain.studyv2.dto.response;
+
+import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionStatus;
+import com.gdschongik.gdsc.domain.study.domain.StudyType;
+import com.gdschongik.gdsc.domain.study.dto.response.AssignmentSubmissionStatusResponse;
+import com.gdschongik.gdsc.domain.study.dto.response.AttendanceStatusResponse;
+import com.gdschongik.gdsc.domain.studyv2.domain.*;
+import com.gdschongik.gdsc.domain.studyv2.dto.dto.AssignmentHistoryDto;
+import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudySessionStudentDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static com.gdschongik.gdsc.domain.studyv2.dto.response.StudyTodoResponse.StudyTodoType.ASSIGNMENT;
+import static com.gdschongik.gdsc.domain.studyv2.dto.response.StudyTodoResponse.StudyTodoType.ATTENDANCE;
+
+public record StudyTodoResponse(
+        @Schema(description = "스터디 세션 정보") StudySessionStudentDto studySession,
+        @Schema(description = "할 일 타입") StudyTodoResponse.StudyTodoType todoType,
+        @Schema(description = "마감 시각") LocalDateTime deadLine,
+        @Schema(description = "출석 상태 (출석타입일 때만 사용)") AttendanceStatus attendanceStatus,
+        @Schema(description = "과제 정보 (과제타입일 때만 사용)") AssignmentHistoryDto assignmentHistory,
+        @Schema(description = "과제 제출 상태 (과제타입일 때만 사용)") AssignmentHistoryStatus assignmentHistoryStatus
+) {
+    public static StudyTodoResponse attendanceType(StudySessionV2 studySession, StudyType studyType, List<AttendanceV2> attendances, LocalDateTime now) {
+        return new StudyTodoResponse(
+                StudySessionStudentDto.of(studySession),
+                ATTENDANCE,
+                studySession.getLessonPeriod().getEndDate(),
+                AttendanceStatus.of(studySession, studyType, isAttended(studySession, attendances), now),
+                null,
+                null
+        );
+    }
+
+    public static StudyTodoResponse assignmentType(AssignmentHistoryV2 assignmentHistory, LocalDateTime now) {
+        StudySessionV2 studySession = assignmentHistory.getStudySession();
+        return new StudyTodoResponse(
+                StudySessionStudentDto.of(studySession),
+                ASSIGNMENT,
+                studySession.getAssignmentPeriod().getEndDate(),
+                null,
+                AssignmentHistoryDto.from(assignmentHistory),
+                AssignmentHistoryStatus.of(assignmentHistory, studySession, now)
+        );
+    }
+
+    private static boolean isAttended(StudySessionV2 studySession, List<AttendanceV2> attendances) {
+        return attendances.stream()
+                .anyMatch(attendance -> attendance.getStudySession().getId().equals(studySession.getId()));
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum StudyTodoType {
+        ATTENDANCE("출석"), ASSIGNMENT("과제");
+
+        private final String value;
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyTodoResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyTodoResponse.java
@@ -1,44 +1,40 @@
 package com.gdschongik.gdsc.domain.studyv2.dto.response;
 
-import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionStatus;
+import static com.gdschongik.gdsc.domain.studyv2.dto.response.StudyTodoResponse.StudyTodoType.ASSIGNMENT;
+import static com.gdschongik.gdsc.domain.studyv2.dto.response.StudyTodoResponse.StudyTodoType.ATTENDANCE;
+
 import com.gdschongik.gdsc.domain.study.domain.StudyType;
-import com.gdschongik.gdsc.domain.study.dto.response.AssignmentSubmissionStatusResponse;
-import com.gdschongik.gdsc.domain.study.dto.response.AttendanceStatusResponse;
 import com.gdschongik.gdsc.domain.studyv2.domain.*;
 import com.gdschongik.gdsc.domain.studyv2.dto.dto.AssignmentHistoryDto;
 import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudySessionStudentDto;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Nullable;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
-
-import static com.gdschongik.gdsc.domain.studyv2.dto.response.StudyTodoResponse.StudyTodoType.ASSIGNMENT;
-import static com.gdschongik.gdsc.domain.studyv2.dto.response.StudyTodoResponse.StudyTodoType.ATTENDANCE;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 public record StudyTodoResponse(
         @Schema(description = "스터디 세션 정보") StudySessionStudentDto studySession,
         @Schema(description = "할 일 타입") StudyTodoResponse.StudyTodoType todoType,
-        @Schema(description = "마감 시각") LocalDateTime deadLine, // 마감 시각이 lesson 의 end 인지, assignment end 인지 판단은 프론트보다 백이 하는 것이 맞다고 생각해서 놔둠. (PR에 명시)
+        @Schema(description = "마감 시각")
+                LocalDateTime
+                        deadLine, // 마감 시각이 lesson 의 end 인지, assignment end 인지 판단은 프론트보다 백이 하는 것이 맞다고 생각해서 놔둠. (PR에 명시)
         @Schema(description = "출석 상태 (출석타입일 때만 사용)") AttendanceStatus attendanceStatus,
         @Schema(description = "과제 정보 (과제타입일 때만 사용)") AssignmentHistoryDto assignmentHistory,
-        @Schema(description = "과제 제출 상태 (과제타입일 때만 사용)") AssignmentHistoryStatus assignmentHistoryStatus
-) {
-    public static StudyTodoResponse attendanceType(StudySessionV2 studySession, StudyType studyType, List<AttendanceV2> attendances, LocalDateTime now) {
+        @Schema(description = "과제 제출 상태 (과제타입일 때만 사용)") AssignmentHistoryStatus assignmentHistoryStatus) {
+    public static StudyTodoResponse attendanceType(
+            StudySessionV2 studySession, StudyType studyType, List<AttendanceV2> attendances, LocalDateTime now) {
         return new StudyTodoResponse(
                 StudySessionStudentDto.of(studySession),
                 ATTENDANCE,
                 studySession.getLessonPeriod().getEndDate(),
                 AttendanceStatus.of(studySession, studyType, isAttended(studySession, attendances), now),
                 null,
-                null
-        );
+                null);
     }
 
-    public static StudyTodoResponse assignmentType(StudySessionV2 studySession, List<AssignmentHistoryV2> assignmentHistories, LocalDateTime now) {
+    public static StudyTodoResponse assignmentType(
+            StudySessionV2 studySession, List<AssignmentHistoryV2> assignmentHistories, LocalDateTime now) {
         AssignmentHistoryV2 assignmentHistory = getSubmittedAssignment(assignmentHistories, studySession);
         return new StudyTodoResponse(
                 StudySessionStudentDto.of(studySession),
@@ -46,8 +42,7 @@ public record StudyTodoResponse(
                 studySession.getAssignmentPeriod().getEndDate(),
                 null,
                 assignmentHistory != null ? AssignmentHistoryDto.from(assignmentHistory) : null,
-                AssignmentHistoryStatus.of(assignmentHistory, studySession, now)
-        );
+                AssignmentHistoryStatus.of(assignmentHistory, studySession, now));
     }
 
     private static boolean isAttended(StudySessionV2 studySession, List<AttendanceV2> attendances) {
@@ -55,9 +50,11 @@ public record StudyTodoResponse(
                 .anyMatch(attendance -> attendance.getStudySession().getId().equals(studySession.getId()));
     }
 
-    private static AssignmentHistoryV2 getSubmittedAssignment(List<AssignmentHistoryV2> assignmentHistories, StudySessionV2 studySession) {
+    private static AssignmentHistoryV2 getSubmittedAssignment(
+            List<AssignmentHistoryV2> assignmentHistories, StudySessionV2 studySession) {
         return assignmentHistories.stream()
-                .filter(assignmentHistory -> assignmentHistory.getStudySession().getId().equals(studySession.getId()))
+                .filter(assignmentHistory ->
+                        assignmentHistory.getStudySession().getId().equals(studySession.getId()))
                 .findFirst()
                 .orElse(null);
     }
@@ -65,7 +62,8 @@ public record StudyTodoResponse(
     @Getter
     @RequiredArgsConstructor
     public enum StudyTodoType {
-        ATTENDANCE("출석"), ASSIGNMENT("과제");
+        ATTENDANCE("출석"),
+        ASSIGNMENT("과제");
 
         private final String value;
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyTodoResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyTodoResponse.java
@@ -16,9 +16,7 @@ import lombok.RequiredArgsConstructor;
 public record StudyTodoResponse(
         @Schema(description = "스터디 세션 정보") StudySessionStudentDto studySession,
         @Schema(description = "할 일 타입") StudyTodoResponse.StudyTodoType todoType,
-        @Schema(description = "마감 시각")
-                LocalDateTime
-                        deadLine, // 마감 시각이 lesson 의 end 인지, assignment end 인지 판단은 프론트보다 백이 하는 것이 맞다고 생각해서 놔둠. (PR에 명시)
+        @Schema(description = "마감 시각") LocalDateTime deadLine,
         @Schema(description = "출석 상태 (출석타입일 때만 사용)") AttendanceStatus attendanceStatus,
         @Schema(description = "과제 정보 (과제타입일 때만 사용)") AssignmentHistoryDto assignmentHistory,
         @Schema(description = "과제 제출 상태 (과제타입일 때만 사용)") AssignmentHistoryStatus assignmentHistoryStatus) {

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyTodoResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyTodoResponse.java
@@ -8,6 +8,7 @@ import com.gdschongik.gdsc.domain.studyv2.domain.*;
 import com.gdschongik.gdsc.domain.studyv2.dto.dto.AssignmentHistoryDto;
 import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudySessionStudentDto;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -37,14 +38,14 @@ public record StudyTodoResponse(
         );
     }
 
-    public static StudyTodoResponse assignmentType(AssignmentHistoryV2 assignmentHistory, LocalDateTime now) {
-        StudySessionV2 studySession = assignmentHistory.getStudySession();
+    public static StudyTodoResponse assignmentType(StudySessionV2 studySession, List<AssignmentHistoryV2> assignmentHistories, LocalDateTime now) {
+        AssignmentHistoryV2 assignmentHistory = getSubmittedAssignment(assignmentHistories, studySession);
         return new StudyTodoResponse(
                 StudySessionStudentDto.of(studySession),
                 ASSIGNMENT,
                 studySession.getAssignmentPeriod().getEndDate(),
                 null,
-                AssignmentHistoryDto.from(assignmentHistory),
+                assignmentHistory != null ? AssignmentHistoryDto.from(assignmentHistory) : null,
                 AssignmentHistoryStatus.of(assignmentHistory, studySession, now)
         );
     }
@@ -52,6 +53,13 @@ public record StudyTodoResponse(
     private static boolean isAttended(StudySessionV2 studySession, List<AttendanceV2> attendances) {
         return attendances.stream()
                 .anyMatch(attendance -> attendance.getStudySession().getId().equals(studySession.getId()));
+    }
+
+    private static AssignmentHistoryV2 getSubmittedAssignment(List<AssignmentHistoryV2> assignmentHistories, StudySessionV2 studySession) {
+        return assignmentHistories.stream()
+                .filter(assignmentHistory -> assignmentHistory.getStudySession().getId().equals(studySession.getId()))
+                .findFirst()
+                .orElse(null);
     }
 
     @Getter

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyTodoResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyTodoResponse.java
@@ -21,7 +21,7 @@ import static com.gdschongik.gdsc.domain.studyv2.dto.response.StudyTodoResponse.
 public record StudyTodoResponse(
         @Schema(description = "스터디 세션 정보") StudySessionStudentDto studySession,
         @Schema(description = "할 일 타입") StudyTodoResponse.StudyTodoType todoType,
-        @Schema(description = "마감 시각") LocalDateTime deadLine,
+        @Schema(description = "마감 시각") LocalDateTime deadLine, // 마감 시각이 lesson 의 end 인지, assignment end 인지 판단은 프론트보다 백이 하는 것이 맞다고 생각해서 놔둠. (PR에 명시)
         @Schema(description = "출석 상태 (출석타입일 때만 사용)") AttendanceStatus attendanceStatus,
         @Schema(description = "과제 정보 (과제타입일 때만 사용)") AssignmentHistoryDto assignmentHistory,
         @Schema(description = "과제 제출 상태 (과제타입일 때만 사용)") AssignmentHistoryStatus assignmentHistoryStatus

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyTodoResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyTodoResponse.java
@@ -1,7 +1,6 @@
 package com.gdschongik.gdsc.domain.studyv2.dto.response;
 
-import static com.gdschongik.gdsc.domain.studyv2.dto.response.StudyTodoResponse.StudyTodoType.ASSIGNMENT;
-import static com.gdschongik.gdsc.domain.studyv2.dto.response.StudyTodoResponse.StudyTodoType.ATTENDANCE;
+import static com.gdschongik.gdsc.domain.studyv2.dto.response.StudyTodoResponse.StudyTodoType.*;
 
 import com.gdschongik.gdsc.domain.study.domain.StudyType;
 import com.gdschongik.gdsc.domain.studyv2.domain.*;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #915 

## 📌 작업 내용 및 특이사항
- 과제 타입의 과제 정보가 이전보다 더 구체화되어 StudySessionDto, AssignmnetHistoryDto 를 사용하였습니다. 

## 📝 참고사항
- url 에서 `todo` 를 사용하고 있다보니 할 일 조회와 관련된 DTO 클래스 이름도 Task 에서 Todo 로 통일하였습니다.
- deadline 은 studySessionDTO 를 통해 알 수 있지만, 출석/과제 타입 여부에 따라 lessonPeriod, assignmentPeriod 사용 여부가 달라지므로 백엔드에서 이를 결정하여 담기 위해 필드 유지하였습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- 특정 학습에 대한 할 일 목록을 조회할 수 있는 기능이 추가되었습니다.
	- 사용자가 등록된 모든 학습에 대한 할 일 목록을 조회할 수 있는 기능이 추가되었습니다.
	- 출석 및 과제 관련 정보를 포함한 구조화된 응답을 통해 학습 진행 상황을 효과적으로 모니터링할 수 있습니다.
	- 과제 제출 가능 여부 및 수업 참석 가능 여부를 확인할 수 있는 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->