### PR TITLE
feat: 스터디 세션의 제목을 과제 제목과 회차 제목으로 분리

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
@@ -37,13 +37,13 @@ public class StudySessionV2 extends BaseEntity {
     @Comment("회차 순서")
     private Integer position;
 
-    @Comment("회차 제목")
-    private String title;
-
     @Comment("회차 설명")
     private String description;
 
     // 수업 관련 필드
+
+    @Comment("수업 제목")
+    private String lessonTitle;
 
     @Comment("수업 출석 번호")
     private String lessonAttendanceNumber;
@@ -54,6 +54,9 @@ public class StudySessionV2 extends BaseEntity {
     private Period lessonPeriod;
 
     // 과제 관련 필드
+
+    @Comment("과제 제목")
+    private String assignmentTitle;
 
     @Comment("과제 명세 링크")
     private String assignmentDescriptionLink;
@@ -78,18 +81,20 @@ public class StudySessionV2 extends BaseEntity {
     @Builder(access = AccessLevel.PRIVATE)
     private StudySessionV2(
             Integer position,
-            String title,
+            String lessonTitle,
             String description,
             String lessonAttendanceNumber,
             Period lessonPeriod,
+            String assignmentTitle,
             String assignmentDescriptionLink,
             Period assignmentPeriod,
             StudyV2 study) {
         this.position = position;
-        this.title = title;
+        this.lessonTitle = lessonTitle;
         this.description = description;
         this.lessonAttendanceNumber = lessonAttendanceNumber;
         this.lessonPeriod = lessonPeriod;
+        this.assignmentTitle = assignmentTitle;
         this.assignmentDescriptionLink = assignmentDescriptionLink;
         this.assignmentPeriod = assignmentPeriod;
         this.study = study;
@@ -128,9 +133,10 @@ public class StudySessionV2 extends BaseEntity {
 
     public void update(StudyUpdateCommand.Session command) {
         validateLessonFieldNullWhenAssignmentStudy(command.lessonPeriod());
-        this.title = command.title();
+        this.lessonTitle = command.lessonTitle();
         this.description = command.description();
         this.lessonPeriod = command.lessonPeriod();
+        this.assignmentTitle = command.assignmentTitle();
         this.assignmentDescriptionLink = command.assignmentDescriptionLink();
         this.assignmentPeriod = command.assignmentPeriod();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyUpdateCommand.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyUpdateCommand.java
@@ -17,9 +17,10 @@ public record StudyUpdateCommand(
 
     public record Session(
             Long studySessionId,
-            String title,
+            String lessonTitle,
             String description,
             Period lessonPeriod,
+            @Nullable String assignmentTitle,
             @Nullable String assignmentDescriptionLink,
             @Nullable Period assignmentPeriod) {}
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudySessionManagerDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudySessionManagerDto.java
@@ -9,10 +9,11 @@ import com.gdschongik.gdsc.domain.studyv2.domain.StudySessionV2;
 public record StudySessionManagerDto(
         Long studySessionId,
         Integer position,
-        String title,
+        String lessonTitle,
         String description,
         String lessonAttendanceNumber,
         Period lessonPeriod,
+        String assignmentTitle,
         String assignmentDescriptionLink,
         Period assignmentPeriod,
         Long studyId) {
@@ -20,10 +21,11 @@ public record StudySessionManagerDto(
         return new StudySessionManagerDto(
                 studySession.getId(),
                 studySession.getPosition(),
-                studySession.getTitle(),
+                studySession.getLessonTitle(),
                 studySession.getDescription(),
                 studySession.getLessonAttendanceNumber(),
                 studySession.getLessonPeriod(),
+                studySession.getAssignmentTitle(),
                 studySession.getAssignmentDescriptionLink(),
                 studySession.getAssignmentPeriod(),
                 studySession.getStudy().getId());

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudySessionStudentDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudySessionStudentDto.java
@@ -9,9 +9,10 @@ import com.gdschongik.gdsc.domain.studyv2.domain.StudySessionV2;
 public record StudySessionStudentDto(
         Long studySessionId,
         Integer position,
-        String title,
+        String lessonTitle,
         String description,
         Period lessonPeriod,
+        String assignmentTitle,
         String assignmentDescriptionLink,
         Period assignmentPeriod,
         Long studyId) {
@@ -19,9 +20,10 @@ public record StudySessionStudentDto(
         return new StudySessionStudentDto(
                 studySession.getId(),
                 studySession.getPosition(),
-                studySession.getTitle(),
+                studySession.getLessonTitle(),
                 studySession.getDescription(),
                 studySession.getLessonPeriod(),
+                studySession.getAssignmentTitle(),
                 studySession.getAssignmentDescriptionLink(),
                 studySession.getAssignmentPeriod(),
                 studySession.getStudy().getId());

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyTaskDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyTaskDto.java
@@ -47,7 +47,7 @@ public record StudyTaskDto(
                 ASSIGNMENT,
                 studySession.getAssignmentPeriod().getEndDate(),
                 null,
-                studySession.getTitle(),
+                studySession.getAssignmentTitle(),
                 AssignmentHistoryStatus.of(assignmentHistory, studySession, now));
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyUpdateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyUpdateRequest.java
@@ -17,9 +17,10 @@ public record StudyUpdateRequest(
         List<StudySessionUpdateDto> studySessions) {
     public record StudySessionUpdateDto(
             Long studySessionId,
-            String title,
+            String lessonTitle,
             String description,
             Period lessonPeriod,
+            @Nullable String assignmentTitle,
             @Nullable String assignmentDescriptionLink,
             @Nullable Period assignmentPeriod) {}
 
@@ -27,9 +28,10 @@ public record StudyUpdateRequest(
         var sessionCommands = studySessions().stream()
                 .map(studySession -> new StudyUpdateCommand.Session(
                         studySession.studySessionId(),
-                        studySession.title(),
+                        studySession.lessonTitle(),
                         studySession.description(),
                         studySession.lessonPeriod(),
+                        studySession.assignmentTitle(),
                         studySession.assignmentDescriptionLink(),
                         studySession.assignmentPeriod()))
                 .toList();

--- a/src/test/java/com/gdschongik/gdsc/domain/studyv2/application/MentorStudyServiceV2Test.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/studyv2/application/MentorStudyServiceV2Test.java
@@ -37,7 +37,7 @@ class MentorStudyServiceV2Test extends IntegrationTest {
                     null,
                     null,
                     List.of(new StudyUpdateRequest.StudySessionUpdateDto(
-                            1L, "수정된 1회차 스터디 제목", null, null, null, null)));
+                            1L, "수정된 1회차 스터디 제목", null, null, null, null, null)));
 
             // when
             mentorStudyServiceV2.updateStudy(1L, request);
@@ -48,7 +48,7 @@ class MentorStudyServiceV2Test extends IntegrationTest {
 
             StudyV2 study = optionalStudy.get();
             assertThat(study.getTitle()).isEqualTo("수정된 제목");
-            assertThat(study.getStudySessions().get(0).getTitle()).isEqualTo("수정된 1회차 스터디 제목");
+            assertThat(study.getStudySessions().get(0).getLessonTitle()).isEqualTo("수정된 1회차 스터디 제목");
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2Test.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2Test.java
@@ -40,7 +40,8 @@ class StudyV2Test {
                     null,
                     null,
                     null,
-                    List.of(new StudyUpdateCommand.Session(1L, updatedFirstSessionTitle, null, null, null, null)));
+                    List.of(new StudyUpdateCommand.Session(
+                            1L, updatedFirstSessionTitle, null, null, null, null, null)));
 
             // when
             study.update(command);
@@ -50,7 +51,7 @@ class StudyV2Test {
 
             StudySessionV2 firstSession = study.getStudySessions().get(0);
             assertThat(firstSession).isNotNull();
-            assertThat(firstSession.getTitle()).isEqualTo(updatedFirstSessionTitle);
+            assertThat(firstSession.getLessonTitle()).isEqualTo(updatedFirstSessionTitle);
         }
 
         @Test
@@ -67,7 +68,7 @@ class StudyV2Test {
                     null,
                     null,
                     null,
-                    List.of(new StudyUpdateCommand.Session(1L, null, null, lessonPeriodToUpdate, null, null)));
+                    List.of(new StudyUpdateCommand.Session(1L, null, null, lessonPeriodToUpdate, null, null, null)));
 
             // when & then
             assertThatThrownBy(() -> study.update(command))
@@ -87,7 +88,7 @@ class StudyV2Test {
                     null,
                     null,
                     null,
-                    List.of(new StudyUpdateCommand.Session(9999L, null, null, null, null, null)));
+                    List.of(new StudyUpdateCommand.Session(9999L, null, null, null, null, null, null)));
 
             // when & then
             assertThatThrownBy(() -> study.update(command))
@@ -102,13 +103,13 @@ class StudyV2Test {
         private StudyUpdateCommand.Session createSession(Long sessionId, LocalDate date) {
             // 수업 시간을 null로 지정할 수 잇음
             if (date == null) {
-                return new StudyUpdateCommand.Session(sessionId, null, null, null, null, null);
+                return new StudyUpdateCommand.Session(sessionId, null, null, null, null, null, null);
             }
 
             // 아니라면, 18:00 ~ 20:00 고정
             LocalDateTime startDateTime = date.atTime(18, 0);
             return new StudyUpdateCommand.Session(
-                    sessionId, null, null, Period.of(startDateTime, startDateTime.plusHours(2)), null, null);
+                    sessionId, null, null, Period.of(startDateTime, startDateTime.plusHours(2)), null, null, null);
         }
 
         private StudyUpdateCommand createCommand(LocalDate... dates) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #975

## 📌 작업 내용 및 특이사항
- 코어멤버와 논의 후, 스터디 세션의 제목을 lessonTitle과 assignmentTitle로 분리했습니다.

## 📝 참고사항
- main 배포시 db 작업 필요

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 스터디 세션에 수업 제목과 과제 제목으로 구분된 정보를 제공합니다.
  
- **Refactor**
	- 기존의 일반적인 제목 필드를 보다 구체적인 수업 제목 필드로 변경하고, 과제 제목 필드를 추가하여 데이터 구조와 명명 규칙의 일관성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->