### PR TITLE
feat: 대시보드 조회 응답에 레포지토리 링크 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyServiceV2.java
@@ -42,12 +42,15 @@ public class StudentStudyServiceV2 {
         Member member = memberUtil.getCurrentMember();
         StudyV2 study =
                 studyV2Repository.findFetchById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
+        StudyHistoryV2 studyHistory = studyHistoryV2Repository
+                .findByStudentAndStudy(member, study)
+                .orElseThrow(() -> new CustomException(STUDY_HISTORY_NOT_FOUND));
         List<AttendanceV2> attendances = attendanceV2Repository.findFetchByMemberAndStudy(member, study);
         List<AssignmentHistoryV2> assignmentHistories =
                 assignmentHistoryV2Repository.findByMemberAndStudy(member, study);
         LocalDateTime now = LocalDateTime.now();
 
-        return StudyDashboardResponse.of(study, attendances, assignmentHistories, now);
+        return StudyDashboardResponse.of(study, studyHistory, attendances, assignmentHistories, now);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyDashboardResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyDashboardResponse.java
@@ -1,17 +1,15 @@
 package com.gdschongik.gdsc.domain.studyv2.dto.response;
 
-import com.gdschongik.gdsc.domain.studyv2.domain.AssignmentHistoryStatus;
-import com.gdschongik.gdsc.domain.studyv2.domain.AssignmentHistoryV2;
-import com.gdschongik.gdsc.domain.studyv2.domain.AttendanceV2;
-import com.gdschongik.gdsc.domain.studyv2.domain.StudySessionV2;
-import com.gdschongik.gdsc.domain.studyv2.domain.StudyV2;
+import com.gdschongik.gdsc.domain.studyv2.domain.*;
+import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyHistoryDto;
 import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudySessionMyDto;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record StudyDashboardResponse(List<StudySessionMyDto> sessions) {
+public record StudyDashboardResponse(StudyHistoryDto studyHistory, List<StudySessionMyDto> sessions) {
     public static StudyDashboardResponse of(
             StudyV2 study,
+            StudyHistoryV2 studyHistory,
             List<AttendanceV2> attendances,
             List<AssignmentHistoryV2> assignmentHistories,
             LocalDateTime now) {
@@ -24,7 +22,7 @@ public record StudyDashboardResponse(List<StudySessionMyDto> sessions) {
                         now))
                 .toList();
 
-        return new StudyDashboardResponse(studySessions);
+        return new StudyDashboardResponse(StudyHistoryDto.from(studyHistory), studySessions);
     }
 
     private static boolean isAttended(StudySessionV2 studySession, List<AttendanceV2> attendances) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #917 

## 📌 작업 내용 및 특이사항
- 기존에는 '나의 과제' 탭에서 레포지토리 링크 입력과 제출 가능한 과제 리스트를 조회했다면, 해당 기능이 커리큘럼 탭으로 넘어오면서 굳이 별도 api 로 분리할 필요가 없을 것 같다고 생각해서 기존 대시보드 조회 api 에서 `study history` 정보를 함께 조회하도록 추가했습니다.

## 📝 참고사항
- 

## 📚 기타
- 기존의 StudyHistoryDto 에서 레포지토리 링크 필드가 'githubLink' 로 되어있는데, 필드명을 'repositoryLink' 로 수정하면 더 직관적일 것 같다고 생각하는데, 혹시 어떻게 생각하시나요?

- 기능 구현하면서 궁금한 점이 있는데, 지금과 같이 '레포지토리 링크' 필드 하나가 필요한 상황에서 StudyHistoryDto 전체를 필드로 받으면 실제로 응답에 필요하지 않은 필드들도 다수 응답하게 되는데, 이런 경우에도 Dto를 사용하여 응답하면 될까요? @uwoobeat 
