### PR TITLE
feat: 스터디 기본 정보 조회 V2 API 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/CommonStudyControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/CommonStudyControllerV2.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.studyv2.api;
 
 import com.gdschongik.gdsc.domain.studyv2.application.CommonStudyServiceV2;
-import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyStudentDto;
+import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyCommonDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,7 @@ public class CommonStudyControllerV2 {
 
     @Operation(summary = "스터디 기본 정보 조회", description = "스터디 기본 정보를 조회합니다.")
     @GetMapping("/{studyId}")
-    public ResponseEntity<StudyStudentDto> getStudyInformation(@PathVariable Long studyId) {
+    public ResponseEntity<StudyCommonDto> getStudyInformation(@PathVariable Long studyId) {
         var response = commonStudyService.getStudyInformation(studyId);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/CommonStudyControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/CommonStudyControllerV2.java
@@ -1,0 +1,28 @@
+package com.gdschongik.gdsc.domain.studyv2.api;
+
+import com.gdschongik.gdsc.domain.studyv2.application.CommonStudyServiceV2;
+import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyStudentDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Common Study V2", description = "공통 스터디 V2 API입니다.")
+@RestController
+@RequestMapping("/v2/common/studies")
+@RequiredArgsConstructor
+public class CommonStudyControllerV2 {
+
+    private final CommonStudyServiceV2 commonStudyService;
+
+    @Operation(summary = "스터디 기본 정보 조회", description = "스터디 기본 정보를 조회합니다.")
+    @GetMapping("/{studyId}")
+    public ResponseEntity<StudyStudentDto> getStudyInformation(@PathVariable Long studyId) {
+        var response = commonStudyService.getStudyInformation(studyId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/CommonStudyServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/CommonStudyServiceV2.java
@@ -4,7 +4,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.studyv2.dao.StudyV2Repository;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyV2;
-import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyStudentDto;
+import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyCommonDto;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,9 +15,9 @@ public class CommonStudyServiceV2 {
 
     private final StudyV2Repository studyV2Repository;
 
-    public StudyStudentDto getStudyInformation(Long studyId) {
+    public StudyCommonDto getStudyInformation(Long studyId) {
         StudyV2 study =
                 studyV2Repository.findFetchById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
-        return StudyStudentDto.from(study);
+        return StudyCommonDto.from(study);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/CommonStudyServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/CommonStudyServiceV2.java
@@ -1,0 +1,23 @@
+package com.gdschongik.gdsc.domain.studyv2.application;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.domain.studyv2.dao.StudyV2Repository;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyV2;
+import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyStudentDto;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommonStudyServiceV2 {
+
+    private final StudyV2Repository studyV2Repository;
+
+    public StudyStudentDto getStudyInformation(Long studyId) {
+        StudyV2 study =
+                studyV2Repository.findFetchById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
+        return StudyStudentDto.from(study);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyCommonDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyCommonDto.java
@@ -11,7 +11,7 @@ import java.time.LocalTime;
 /**
  * 스터디 학생 DTO입니다. 디스코드 관련 ID가 포함되어 있지 않습니다.
  */
-public record StudyStudentDto(
+public record StudyCommonDto(
         Long studyId,
         StudyType type,
         String title,
@@ -26,8 +26,8 @@ public record StudyStudentDto(
         LocalDateTime openingDate,
         Long mentorId,
         String mentorName) {
-    public static StudyStudentDto from(StudyV2 study) {
-        return new StudyStudentDto(
+    public static StudyCommonDto from(StudyV2 study) {
+        return new StudyCommonDto(
                 study.getId(),
                 study.getType(),
                 study.getTitle(),

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyAnnouncementResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyAnnouncementResponse.java
@@ -2,11 +2,11 @@ package com.gdschongik.gdsc.domain.studyv2.dto.response;
 
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyAnnouncementV2;
 import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyAnnouncementDto;
-import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyStudentDto;
+import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyCommonDto;
 
-public record StudyAnnouncementResponse(StudyStudentDto study, StudyAnnouncementDto studyAnnouncement) {
+public record StudyAnnouncementResponse(StudyCommonDto study, StudyAnnouncementDto studyAnnouncement) {
     public static StudyAnnouncementResponse from(StudyAnnouncementV2 studyAnnouncement) {
         return new StudyAnnouncementResponse(
-                StudyStudentDto.from(studyAnnouncement.getStudy()), StudyAnnouncementDto.from(studyAnnouncement));
+                StudyCommonDto.from(studyAnnouncement.getStudy()), StudyAnnouncementDto.from(studyAnnouncement));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyApplicableResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyApplicableResponse.java
@@ -2,15 +2,15 @@ package com.gdschongik.gdsc.domain.studyv2.dto.response;
 
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyHistoryV2;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyV2;
-import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyStudentDto;
+import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyCommonDto;
 import java.util.List;
 
-public record StudyApplicableResponse(List<Long> appliedStudyIds, List<StudyStudentDto> applicableStudies) {
+public record StudyApplicableResponse(List<Long> appliedStudyIds, List<StudyCommonDto> applicableStudies) {
     public static StudyApplicableResponse of(List<StudyHistoryV2> studyHistories, List<StudyV2> applicableStudies) {
         return new StudyApplicableResponse(
                 studyHistories.stream()
                         .map(studyHistory -> studyHistory.getStudy().getId())
                         .toList(),
-                applicableStudies.stream().map(StudyStudentDto::from).toList());
+                applicableStudies.stream().map(StudyCommonDto::from).toList());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyHistoryMyResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyHistoryMyResponse.java
@@ -4,17 +4,17 @@ import com.gdschongik.gdsc.domain.studyv2.domain.StudyAchievementV2;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyHistoryV2;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyV2;
 import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyAchievementDto;
+import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyCommonDto;
 import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyHistoryDto;
-import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyStudentDto;
 import java.util.List;
 
 public record StudyHistoryMyResponse(
-        StudyHistoryDto studyHistory, StudyStudentDto study, List<StudyAchievementDto> achievements) {
+        StudyHistoryDto studyHistory, StudyCommonDto study, List<StudyAchievementDto> achievements) {
     public static StudyHistoryMyResponse of(
             StudyHistoryV2 studyHistory, StudyV2 study, List<StudyAchievementV2> achievements) {
         return new StudyHistoryMyResponse(
                 StudyHistoryDto.from(studyHistory),
-                StudyStudentDto.from(study),
+                StudyCommonDto.from(study),
                 achievements.stream().map(StudyAchievementDto::from).toList());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyStudentResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyStudentResponse.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.studyv2.dto.response;
 
+import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyCommonDto;
 import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudySessionStudentDto;
-import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyStudentDto;
 import java.util.List;
 
-public record StudyStudentResponse(StudyStudentDto study, List<StudySessionStudentDto> studySessions) {}
+public record StudyStudentResponse(StudyCommonDto study, List<StudySessionStudentDto> studySessions) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #978

## 📌 작업 내용 및 특이사항
- StudyStudentDto외에 다른 dto 필요하지 않아서 response로 감싸지 않았습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - study ID를 통한 study 정보 조회 기능이 추가되어, 사용자가 입력한 study ID로 관련 세부 정보를 손쉽게 확인할 수 있습니다.
  
- **변경 사항**
  - `StudyStudentDto`가 `StudyCommonDto`로 이름이 변경되어, 관련된 데이터 구조가 업데이트되었습니다. 
  - 여러 응답 클래스에서 `StudyStudentDto`를 `StudyCommonDto`로 변경하여, 일관된 데이터 표현을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->