### PR TITLE
fix: wil.md 파일이 없는 제출 이력에 대한 커밋 시점 검증 에러

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryStatus.java
@@ -8,6 +8,8 @@ import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import static com.gdschongik.gdsc.global.exception.ErrorCode.ASSIGNMENT_HISTORY_NOT_WITHIN_PERIOD;
+
 @Getter
 @RequiredArgsConstructor
 public enum AssignmentHistoryStatus {
@@ -27,8 +29,6 @@ public enum AssignmentHistoryStatus {
     public static AssignmentHistoryStatus of(
             @Nullable AssignmentHistoryV2 assignmentHistory, StudySessionV2 studySession, LocalDateTime now)
             throws CustomException {
-        validateCommittedAtWithinAssignmentPeriod(assignmentHistory, studySession);
-
         Period assignmentPeriod = studySession.getAssignmentPeriod();
 
         if (now.isBefore(assignmentPeriod.getStartDate())) {
@@ -41,20 +41,21 @@ public enum AssignmentHistoryStatus {
         }
 
         // 과제 제출 이력이 있는 경우
+        validateCommittedAtWithinAssignmentPeriod(assignmentHistory, studySession);
         return assignmentHistory.isSucceeded() ? SUCCEEDED : FAILED;
     }
 
     private static void validateCommittedAtWithinAssignmentPeriod(
-            @Nullable AssignmentHistoryV2 assignmentHistory, StudySessionV2 studySession) throws CustomException {
-        if (assignmentHistory == null) {
+            AssignmentHistoryV2 assignmentHistory, StudySessionV2 studySession) throws CustomException {
+        LocalDateTime committedAt = assignmentHistory.getCommittedAt();
+        if (committedAt == null) {
             return;
         }
 
-        LocalDateTime committedAt = assignmentHistory.getCommittedAt();
         Period assignmentPeriod = studySession.getAssignmentPeriod();
 
         if (!assignmentPeriod.isWithin(committedAt)) {
-            throw new CustomException(ErrorCode.ASSIGNMENT_HISTORY_NOT_WITHIN_PERIOD);
+            throw new CustomException(ASSIGNMENT_HISTORY_NOT_WITHIN_PERIOD);
         }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryStatus.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.studyv2.domain;
 
-import static com.gdschongik.gdsc.global.exception.ErrorCode.ASSIGNMENT_HISTORY_NOT_WITHIN_PERIOD;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
@@ -28,6 +28,8 @@ public enum AssignmentHistoryStatus {
     public static AssignmentHistoryStatus of(
             @Nullable AssignmentHistoryV2 assignmentHistory, StudySessionV2 studySession, LocalDateTime now)
             throws CustomException {
+        validateCommittedAtWithinAssignmentPeriod(assignmentHistory, studySession);
+
         Period assignmentPeriod = studySession.getAssignmentPeriod();
 
         if (now.isBefore(assignmentPeriod.getStartDate())) {
@@ -40,12 +42,15 @@ public enum AssignmentHistoryStatus {
         }
 
         // 과제 제출 이력이 있는 경우
-        validateCommittedAtWithinAssignmentPeriod(assignmentHistory, studySession);
         return assignmentHistory.isSucceeded() ? SUCCEEDED : FAILED;
     }
 
     private static void validateCommittedAtWithinAssignmentPeriod(
-            AssignmentHistoryV2 assignmentHistory, StudySessionV2 studySession) throws CustomException {
+            @Nullable AssignmentHistoryV2 assignmentHistory, StudySessionV2 studySession) throws CustomException {
+        if (assignmentHistory == null) {
+            return;
+        }
+
         LocalDateTime committedAt = assignmentHistory.getCommittedAt();
         if (committedAt == null) {
             return;

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryStatus.java
@@ -1,14 +1,13 @@
 package com.gdschongik.gdsc.domain.studyv2.domain;
 
+import static com.gdschongik.gdsc.global.exception.ErrorCode.ASSIGNMENT_HISTORY_NOT_WITHIN_PERIOD;
+
 import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.global.exception.ErrorCode;
 import jakarta.annotation.Nullable;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import static com.gdschongik.gdsc.global.exception.ErrorCode.ASSIGNMENT_HISTORY_NOT_WITHIN_PERIOD;
 
 @Getter
 @RequiredArgsConstructor


### PR DESCRIPTION
## 🌱 관련 이슈
- close #973

## 📌 작업 내용 및 특이사항
- `LOCATION_UNIDENTIFIABLE` 타입의 제출 에러가 발생했을 때 `commitAt` 필드가 null 입니다. 이 상황에서 과제 제출 커밋 시점이 제출 기한 내에 있는지 검증하는 로직을 타면 NPE 가 발생하는 문제를 수정했습니다.
- 에러코드 정적 import 문 추가
- 커밋 시점에 대한 검증 단계는 과제를 제출했다는 것이 전제가 된 이후에 검증하면 과제 제출 여부를 검사하는 로직의 중복을 제거할 수 있을 것 같아 뒷쪽으로 옮겼습니다. 

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **버그 수정**
  - 할당 기록 검증 과정에서 null 값으로 인한 오류 발생 가능성을 줄였습니다.
- **리팩토링**
  - 검증 로직을 개선하여 안정성과 코드 일관성을 높이고 오류 처리 방식을 간소화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->