### PR TITLE
fix: 스터디 대시보드 조회시 커밋 시점이 null 인 경우 NPE 발생

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyDashboardResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/response/StudyDashboardResponse.java
@@ -57,6 +57,10 @@ public record StudyDashboardResponse(StudyHistoryDto studyHistory, List<StudySes
         }
 
         LocalDateTime committedAt = assignmentHistory.getCommittedAt();
+        if (committedAt == null) {
+            return true;
+        }
+
         return studySession.getAssignmentPeriod().isWithin(committedAt);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #994

## 📌 작업 내용 및 특이사항
- 스터디 대시보드 조회시에도 #988 과 비슷한 이유로 NPE 가 발생하여 null 체크 로직 추가했습니다

## 📝 참고사항
-

## 📚 기타
-
