### PR TITLE
fix: 공지 목록 조회 시 레포지토리로 잘못 넘어가고 있는 인자 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudyAnnouncementServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudyAnnouncementServiceV2.java
@@ -8,7 +8,6 @@ import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.studyv2.dao.StudyAnnouncementV2Repository;
 import com.gdschongik.gdsc.domain.studyv2.dao.StudyHistoryV2Repository;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyAnnouncementV2;
-import com.gdschongik.gdsc.domain.studyv2.domain.StudyHistoryV2;
 import com.gdschongik.gdsc.domain.studyv2.dto.response.StudyAnnouncementResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
@@ -47,7 +46,7 @@ public class StudyAnnouncementServiceV2 {
 
         List<Long> currentStudyHistories = studyHistoryV2Repository.findAllByStudent(currentMember).stream()
                 .filter(studyHistory -> studyHistory.getStudy().getSemester().equals(recruitment.getSemester()))
-                .map(StudyHistoryV2::getId)
+                .map(studyHistoryV2 -> studyHistoryV2.getStudy().getId())
                 .toList();
 
         List<StudyAnnouncementV2> studyAnnouncements =

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudyAnnouncementServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudyAnnouncementServiceV2.java
@@ -44,13 +44,13 @@ public class StudyAnnouncementServiceV2 {
                 .findCurrentRecruitment(now)
                 .orElseThrow(() -> new CustomException(RECRUITMENT_NOT_FOUND));
 
-        List<Long> currentStudyHistories = studyHistoryV2Repository.findAllByStudent(currentMember).stream()
+        List<Long> currentStudyIds = studyHistoryV2Repository.findAllByStudent(currentMember).stream()
                 .filter(studyHistory -> studyHistory.getStudy().getSemester().equals(recruitment.getSemester()))
                 .map(studyHistoryV2 -> studyHistoryV2.getStudy().getId())
                 .toList();
 
         List<StudyAnnouncementV2> studyAnnouncements =
-                studyAnnouncementV2Repository.findAllByStudyIdsOrderByCreatedAtDesc(currentStudyHistories);
+                studyAnnouncementV2Repository.findAllByStudyIdsOrderByCreatedAtDesc(currentStudyIds);
 
         return studyAnnouncements.stream().map(StudyAnnouncementResponse::from).toList();
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1000

## 📌 작업 내용 및 특이사항
- studyId를 넘겨야 하는데 studyHistoryId를 넘기고 있는 부분이 있어서 수정했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩토링**
	- 스터디 공지사항 처리 로직을 개선하여 내부 변수 명칭과 데이터 매핑 방식을 명확하게 변경했습니다. 이로 인해 코드 가독성과 유지보수성이 향상되었으며, 사용자에게 제공되는 기능에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->