### PR TITLE
feat: 누락된 정회원 승급 케이스 처리를 위한 디스코드 커맨드 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/AdvanceFailedMemberCommandHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/AdvanceFailedMemberCommandHandler.java
@@ -1,0 +1,30 @@
+package com.gdschongik.gdsc.domain.discord.application.handler;
+
+import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.*;
+
+import com.gdschongik.gdsc.domain.member.application.AdminMemberService;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.events.GenericEvent;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdvanceFailedMemberCommandHandler implements DiscordEventHandler {
+
+    private final AdminMemberService adminMemberService;
+
+    @Override
+    public void delegate(GenericEvent genericEvent) {
+        SlashCommandInteractionEvent event = (SlashCommandInteractionEvent) genericEvent;
+        event.deferReply(true).setContent(DEFER_MESSAGE_ADVANCE_FAILED_MEMBER).queue();
+
+        String discordUsername = event.getUser().getName();
+        adminMemberService.advanceAllAdvanceFailedMembersToRegular(discordUsername);
+
+        event.getHook()
+                .sendMessage(REPLY_MESSAGE_ADVANCE_FAILED_MEMBER)
+                .setEphemeral(true)
+                .queue();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/AdvanceFailedMemberCommandListener.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/AdvanceFailedMemberCommandListener.java
@@ -1,0 +1,24 @@
+package com.gdschongik.gdsc.domain.discord.application.listener;
+
+import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.*;
+
+import com.gdschongik.gdsc.domain.discord.application.handler.AdvanceFailedMemberCommandHandler;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.springframework.stereotype.Component;
+
+@Component
+@Listener
+@RequiredArgsConstructor
+public class AdvanceFailedMemberCommandListener extends ListenerAdapter {
+
+    private final AdvanceFailedMemberCommandHandler advanceFailedMemberCommandHandler;
+
+    public void onSlashCommandInteraction(@NotNull SlashCommandInteractionEvent event) {
+        if (event.getName().equals(COMMAND_NAME_ADVANCE_FAILED_MEMBER)) {
+            advanceFailedMemberCommandHandler.delegate(event);
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepository.java
@@ -1,11 +1,13 @@
 package com.gdschongik.gdsc.domain.member.dao;
 
 import com.gdschongik.gdsc.domain.common.model.RequirementStatus;
+import com.gdschongik.gdsc.domain.common.vo.Semester;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryOption;
 import jakarta.annotation.Nullable;
 import java.util.List;
+import lombok.NonNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -16,4 +18,6 @@ public interface MemberCustomRepository {
     List<Member> findAllByRole(@Nullable MemberRole role);
 
     List<Member> findAllByDiscordStatus(RequirementStatus discordStatus);
+
+    List<Member> findAllAdvanceFailedMembers(@NonNull Semester semester);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -65,8 +65,8 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository, Membe
                 .leftJoin(member, membership.member)
                 .where(
                         eqRole(MemberRole.ASSOCIATE),
-                        membership.regularRequirement.paymentStatus.eq(SATISFIED),
-                        eqSemester(semester))
+                        eqSemester(semester),
+                        membership.regularRequirement.paymentStatus.eq(SATISFIED))
                 .fetch();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -62,7 +62,8 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository, Membe
     public List<Member> findAllAdvanceFailedMembers(@NonNull Semester semester) {
         return queryFactory
                 .selectFrom(member)
-                .leftJoin(member, membership.member)
+                .leftJoin(membership)
+                .on(membership.member.eq(member))
                 .where(
                         eqRole(MemberRole.ASSOCIATE),
                         eqSemester(semester),

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/MemberValidator.java
@@ -21,4 +21,10 @@ public class MemberValidator {
         // 해당 학기의 모든 모집회차가 아직 시작되지 않았는지 검증
         recruitmentRounds.forEach(recruitmentRound -> recruitmentRound.validatePeriodNotStarted(now));
     }
+
+    public void validateAdminPermission(MemberManageRole memberManageRole) {
+        if (memberManageRole != MemberManageRole.ADMIN) {
+            throw new CustomException(INVALID_ROLE);
+        }
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/DiscordConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/DiscordConstant.java
@@ -20,4 +20,10 @@ public class DiscordConstant {
     public static final String COMMAND_DESCRIPTION_BATCH_DISCORD_ID = "디스코드 인증이 완료된 멤버들의 디스코드 ID를 저장합니다.";
     public static final String DEFER_MESSAGE_BATCH_DISCORD_ID = "디스코드 ID 저장 배치 작업을 진행하는 중입니다...";
     public static final String REPLY_MESSAGE_BATCH_DISCORD_ID = "디스코드 ID 저장 배치 작업이 완료되었습니다.";
+
+    // 정회원 승급 누락자 승급 커맨드
+    public static final String COMMAND_NAME_ADVANCE_FAILED_MEMBER = "정회원-승급-누락자-승급하기";
+    public static final String COMMAND_DESCRIPTION_ADVANCE_FAILED_MEMBER = "정회원 승급 누락자를 승급합니다.";
+    public static final String DEFER_MESSAGE_ADVANCE_FAILED_MEMBER = "정회원 승급 누락자 승급 작업을 진행하는 중입니다...";
+    public static final String REPLY_MESSAGE_ADVANCE_FAILED_MEMBER = "정회원 승급 누락자 승급 작업이 완료되었습니다.";
 }

--- a/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
@@ -43,6 +43,8 @@ public class DiscordConfig {
                 .updateCommands()
                 .addCommands(Commands.slash(COMMAND_NAME_ISSUING_CODE, COMMAND_DESCRIPTION_ISSUING_CODE))
                 .addCommands(Commands.slash(COMMAND_NAME_BATCH_DISCORD_ID, COMMAND_DESCRIPTION_BATCH_DISCORD_ID))
+                .addCommands(
+                        Commands.slash(COMMAND_NAME_ADVANCE_FAILED_MEMBER, COMMAND_DESCRIPTION_ADVANCE_FAILED_MEMBER))
                 .queue();
 
         return jda;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1007

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- Discord 봇에 새로운 슬래시 명령어가 추가되어, 실패한 멤버를 정규 멤버로 전환하는 프로세스를 자동으로 처리합니다.
	- 명령 실행 시 진행 중 메시지와 완료 메시지가 사용자에게 제공되어 상호작용이 보다 원활해졌습니다.
	- 관리자 권한 검증 로직이 추가되어, 명령어 수행의 안정성과 신뢰성이 향상되었습니다.
	- 실패한 멤버 목록을 조회하는 기능이 추가되어, 관리자가 필요한 멤버를 쉽게 확인할 수 있게 되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->