### PR TITLE
feat: 어드민 권한 부여 디스코드 커맨드 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/AssignAdminRoleCommandHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/AssignAdminRoleCommandHandler.java
@@ -1,0 +1,34 @@
+package com.gdschongik.gdsc.domain.discord.application.handler;
+
+import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.*;
+
+import com.gdschongik.gdsc.domain.member.application.AdminMemberService;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.events.GenericEvent;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AssignAdminRoleCommandHandler implements DiscordEventHandler {
+
+    private final AdminMemberService adminMemberService;
+
+    @Override
+    public void delegate(GenericEvent genericEvent) {
+        SlashCommandInteractionEvent event = (SlashCommandInteractionEvent) genericEvent;
+        event.deferReply(true).setContent(DEFER_MESSAGE_ASSIGN_ADMIN_ROLE).queue();
+
+        String discordUsername = event.getUser().getName();
+        String studentId = Objects.requireNonNull(event.getOption(OPTION_NAME_ASSIGN_ADMIN_ROLE))
+                .getAsString();
+
+        adminMemberService.assignAdminRole(discordUsername, studentId);
+
+        event.getHook()
+                .sendMessage(REPLY_MESSAGE_ASSIGN_ADMIN_ROLE)
+                .setEphemeral(true)
+                .queue();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/AssignAdminRoleCommandListener.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/AssignAdminRoleCommandListener.java
@@ -1,0 +1,24 @@
+package com.gdschongik.gdsc.domain.discord.application.listener;
+
+import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.COMMAND_NAME_ASSIGN_ADMIN_ROLE;
+
+import com.gdschongik.gdsc.domain.discord.application.handler.AssignAdminRoleCommandHandler;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+
+@Component
+@Listener
+@RequiredArgsConstructor
+public class AssignAdminRoleCommandListener extends ListenerAdapter {
+
+    private final AssignAdminRoleCommandHandler assignAdminRoleCommandHandler;
+
+    public void onSlashCommandInteraction(@NotNull SlashCommandInteractionEvent event) {
+        if (event.getName().equals(COMMAND_NAME_ASSIGN_ADMIN_ROLE)) {
+            assignAdminRoleCommandHandler.delegate(event);
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -131,13 +131,13 @@ public class AdminMemberService {
 
         memberValidator.validateAdminPermission(currentMember.getManageRole());
 
-        Member member =
+        Member memberToAssign =
                 memberRepository.findByStudentId(studentId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 
-        member.assignToAdmin();
-        memberRepository.save(member);
+        memberToAssign.assignToAdmin();
+        memberRepository.save(memberToAssign);
 
-        log.info("[AdminMemberService] 어드민 권한 부여: memberId={}", member.getId());
+        log.info("[AdminMemberService] 어드민 권한 부여: memberId={}", memberToAssign.getId());
     }
 
     private void validateProfile() {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -14,7 +14,6 @@ import com.gdschongik.gdsc.domain.membership.application.MembershipService;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.global.exception.ErrorCode;
 import com.gdschongik.gdsc.global.util.EnvironmentUtil;
 import com.gdschongik.gdsc.global.util.ExcelUtil;
 import com.gdschongik.gdsc.global.util.MemberUtil;
@@ -54,8 +53,7 @@ public class AdminMemberService {
 
     @Transactional
     public void updateMember(Long memberId, MemberUpdateRequest request) {
-        Member member =
-                memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
         member.updateMemberInfo(
                 request.studentId(),
                 request.name(),
@@ -98,6 +96,18 @@ public class AdminMemberService {
         membershipService.deleteMembership(member);
 
         log.info("[AdminMemberService] 게스트로 강등: demotedMemberId={}", member.getId());
+    }
+
+    @Transactional
+    public void assignAdminRole(String discordUsername, String studentId) {
+        // todo: discordUsername으로 어드민 권한 확인
+        Member member =
+                memberRepository.findByStudentId(studentId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+        member.assignToAdmin();
+        memberRepository.save(member);
+
+        log.info("[AdminMemberService] 어드민 권한 부여: memberId={}", member.getId());
     }
 
     private void validateProfile() {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -123,17 +123,17 @@ public class AdminMemberService {
                 advanceFailedMembers.stream().map(Member::getId).toList());
     }
 
-	@Transactional
-	public void assignAdminRole(String discordUsername, String studentId) {
-		// todo: discordUsername으로 어드민 권한 확인
-		Member member =
-			memberRepository.findByStudentId(studentId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+    @Transactional
+    public void assignAdminRole(String discordUsername, String studentId) {
+        // todo: discordUsername으로 어드민 권한 확인
+        Member member =
+                memberRepository.findByStudentId(studentId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 
-		member.assignToAdmin();
-		memberRepository.save(member);
+        member.assignToAdmin();
+        memberRepository.save(member);
 
-		log.info("[AdminMemberService] 어드민 권한 부여: memberId={}", member.getId());
-	}
+        log.info("[AdminMemberService] 어드민 권한 부여: memberId={}", member.getId());
+    }
 
     private void validateProfile() {
         if (!environmentUtil.isDevAndLocalProfile()) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -125,7 +125,12 @@ public class AdminMemberService {
 
     @Transactional
     public void assignAdminRole(String discordUsername, String studentId) {
-        // todo: discordUsername으로 어드민 권한 확인
+        Member currentMember = memberRepository
+                .findByDiscordUsername(discordUsername)
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+        memberValidator.validateAdminPermission(currentMember.getManageRole());
+
         Member member =
                 memberRepository.findByStudentId(studentId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -124,9 +124,9 @@ public class AdminMemberService {
     }
 
     @Transactional
-    public void assignAdminRole(String discordUsername, String studentId) {
+    public void assignAdminRole(String currentMemberDiscordUsername, String studentId) {
         Member currentMember = memberRepository
-                .findByDiscordUsername(discordUsername)
+                .findByDiscordUsername(currentMemberDiscordUsername)
                 .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 
         memberValidator.validateAdminPermission(currentMember.getManageRole());

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberRepository.java
@@ -14,4 +14,6 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberCus
     Optional<Member> findByDiscordUsername(String discordUsername);
 
     Optional<Member> findByOauthId(String oauthId);
+
+    Optional<Member> findByStudentId(String studentId);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -278,6 +278,11 @@ public class Member extends BaseEntity {
         studyRole = MENTOR;
     }
 
+    public void assignToAdmin() {
+        validateStatusUpdatable();
+        manageRole = ADMIN;
+    }
+
     // 기타 상태 변경 로직
 
     public void updateLastLoginAt(LocalDateTime now) {

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/DiscordConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/DiscordConstant.java
@@ -20,4 +20,12 @@ public class DiscordConstant {
     public static final String COMMAND_DESCRIPTION_BATCH_DISCORD_ID = "디스코드 인증이 완료된 멤버들의 디스코드 ID를 저장합니다.";
     public static final String DEFER_MESSAGE_BATCH_DISCORD_ID = "디스코드 ID 저장 배치 작업을 진행하는 중입니다...";
     public static final String REPLY_MESSAGE_BATCH_DISCORD_ID = "디스코드 ID 저장 배치 작업이 완료되었습니다.";
+
+    // 어드민 권한 부여 커맨드
+    public static final String COMMAND_NAME_ASSIGN_ADMIN_ROLE = "어드민-권한-부여";
+    public static final String COMMAND_DESCRIPTION_ASSIGN_ADMIN_ROLE = "지정한 멤버에게 어드민 권한을 부여합니다.";
+    public static final String DEFER_MESSAGE_ASSIGN_ADMIN_ROLE = "어드민 권한 부여 작업을 진행하는 중입니다...";
+    public static final String REPLY_MESSAGE_ASSIGN_ADMIN_ROLE = "어드민 권한 부여 작업이 완료되었습니다.";
+    public static final String OPTION_NAME_ASSIGN_ADMIN_ROLE = "학번";
+    public static final String OPTION_DESCRIPTION_ASSIGN_ADMIN_ROLE = "어드민 권한을 부여할 멤버의 학번을 입력해주세요.";
 }

--- a/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
@@ -11,6 +11,7 @@ import lombok.SneakyThrows;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.entities.Activity;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.utils.ChunkingFilter;
@@ -43,6 +44,12 @@ public class DiscordConfig {
                 .updateCommands()
                 .addCommands(Commands.slash(COMMAND_NAME_ISSUING_CODE, COMMAND_DESCRIPTION_ISSUING_CODE))
                 .addCommands(Commands.slash(COMMAND_NAME_BATCH_DISCORD_ID, COMMAND_DESCRIPTION_BATCH_DISCORD_ID))
+                .addCommands(Commands.slash(COMMAND_NAME_ASSIGN_ADMIN_ROLE, COMMAND_DESCRIPTION_ASSIGN_ADMIN_ROLE)
+                        .addOption(
+                                OptionType.STRING,
+                                OPTION_NAME_ASSIGN_ADMIN_ROLE,
+                                OPTION_DESCRIPTION_ASSIGN_ADMIN_ROLE,
+                                true))
                 .queue();
 
         return jda;

--- a/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
@@ -46,12 +46,12 @@ public class DiscordConfig {
                 .addCommands(Commands.slash(COMMAND_NAME_BATCH_DISCORD_ID, COMMAND_DESCRIPTION_BATCH_DISCORD_ID))
                 .addCommands(
                         Commands.slash(COMMAND_NAME_ADVANCE_FAILED_MEMBER, COMMAND_DESCRIPTION_ADVANCE_FAILED_MEMBER))
-			.addCommands(Commands.slash(COMMAND_NAME_ASSIGN_ADMIN_ROLE, COMMAND_DESCRIPTION_ASSIGN_ADMIN_ROLE)
-				.addOption(
-					OptionType.STRING,
-					OPTION_NAME_ASSIGN_ADMIN_ROLE,
-					OPTION_DESCRIPTION_ASSIGN_ADMIN_ROLE,
-					true))
+                .addCommands(Commands.slash(COMMAND_NAME_ASSIGN_ADMIN_ROLE, COMMAND_DESCRIPTION_ASSIGN_ADMIN_ROLE)
+                        .addOption(
+                                OptionType.STRING,
+                                OPTION_NAME_ASSIGN_ADMIN_ROLE,
+                                OPTION_DESCRIPTION_ASSIGN_ADMIN_ROLE,
+                                true))
                 .queue();
 
         return jda;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1011

## 📌 작업 내용 및 특이사항
- 동일 인물이 두 개 이상의 깃허브 계정으로 가입한 경우 repository의 `findByStudentId`에서 unique result를 반환할 수 없기 때문에 깃허브 핸들을 사용하는 등의 방식을 고려했으나, 흔한 케이스가 아니기도 하고 핸들로 oauthId를 가져오려면 깃허브 api 호출까지 해야하는 번거로움이 있어서 **_unique result를 반환하지 않는_** 케이스를 그냥 뒀습니다.

## 📝 참고사항
![image](https://github.com/user-attachments/assets/ef978968-300c-48fd-b210-b126dccad3df)


## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Discord 봇에 관리자 역할 할당 기능이 추가되었습니다.
	- 슬래시 커맨드를 통해 학생 번호를 입력받아 특정 회원에게 관리 권한을 부여할 수 있습니다.
	- 역할 할당 진행 및 완료 상태를 안내하는 메시지가 제공되어 사용자 경험이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->