### PR TITLE
feat: 수강신청 철회시 출석 및 과제 이력 삭제

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/CommonStudyServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/CommonStudyServiceV2.java
@@ -2,6 +2,8 @@ package com.gdschongik.gdsc.domain.studyv2.application;
 
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
+import com.gdschongik.gdsc.domain.studyv2.dao.AssignmentHistoryV2Repository;
+import com.gdschongik.gdsc.domain.studyv2.dao.AttendanceV2Repository;
 import com.gdschongik.gdsc.domain.studyv2.dao.StudyV2Repository;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyV2;
 import com.gdschongik.gdsc.domain.studyv2.dto.dto.StudyCommonDto;
@@ -14,10 +16,26 @@ import org.springframework.stereotype.Service;
 public class CommonStudyServiceV2 {
 
     private final StudyV2Repository studyV2Repository;
+    private final AttendanceV2Repository attendanceV2Repository;
+    private final AssignmentHistoryV2Repository assignmentHistoryV2Repository;
 
     public StudyCommonDto getStudyInformation(Long studyId) {
         StudyV2 study =
                 studyV2Repository.findFetchById(studyId).orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
         return StudyCommonDto.from(study);
+    }
+
+    /**
+     * 이벤트 핸들러에서 사용되므로, `@Transactional` 을 사용하지 않습니다.
+     */
+    public void deleteAttendance(Long studyId, Long memberId) {
+        attendanceV2Repository.deleteByStudyIdAndMemberId(studyId, memberId);
+    }
+
+    /**
+     * 이벤트 핸들러에서 사용되므로, `@Transactional` 을 사용하지 않습니다.
+     */
+    public void deleteAssignmentHistory(Long studyId, Long memberId) {
+        assignmentHistoryV2Repository.deleteByStudyIdAndMemberId(studyId, memberId);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/handler/StudyEventHandlerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/handler/StudyEventHandlerV2.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.studyv2.application.handler;
 
 import com.gdschongik.gdsc.domain.discord.application.CommonDiscordService;
+import com.gdschongik.gdsc.domain.studyv2.application.CommonStudyServiceV2;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyApplyCanceledEvent;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyApplyCompletedEvent;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class StudyEventHandlerV2 {
 
     private final CommonDiscordService commonDiscordService;
+    private final CommonStudyServiceV2 commonStudyServiceV2;
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handleStudyApplyCompletedEvent(StudyApplyCompletedEvent event) {
@@ -34,5 +36,7 @@ public class StudyEventHandlerV2 {
                 event.studyDiscordRoleId());
 
         commonDiscordService.removeStudyRoleFromMember(event.studyDiscordRoleId(), event.memberDiscordId());
+        commonStudyServiceV2.deleteAttendance(event.studyId(), event.memberId());
+        commonStudyServiceV2.deleteAssignmentHistory(event.studyId(), event.memberId());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyApplyCanceledEvent.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyApplyCanceledEvent.java
@@ -1,3 +1,3 @@
 package com.gdschongik.gdsc.domain.studyv2.domain;
 
-public record StudyApplyCanceledEvent(String studyDiscordRoleId, String memberDiscordId) {}
+public record StudyApplyCanceledEvent(String studyDiscordRoleId, String memberDiscordId, Long studyId, Long memberId) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyHistoryV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyHistoryV2.java
@@ -75,7 +75,7 @@ public class StudyHistoryV2 extends BaseEntity {
 
     @PreRemove
     private void preRemove() {
-        registerEvent(new StudyApplyCanceledEvent(this.study.getDiscordRoleId(), this.student.getDiscordId()));
+        registerEvent(new StudyApplyCanceledEvent(this.study.getDiscordRoleId(), this.student.getDiscordId(), this.study.getId(), this.student.getId()));
     }
 
     /**

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyHistoryV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyHistoryV2.java
@@ -75,7 +75,8 @@ public class StudyHistoryV2 extends BaseEntity {
 
     @PreRemove
     private void preRemove() {
-        registerEvent(new StudyApplyCanceledEvent(this.study.getDiscordRoleId(), this.student.getDiscordId(), this.study.getId(), this.student.getId()));
+        registerEvent(new StudyApplyCanceledEvent(
+                this.study.getDiscordRoleId(), this.student.getDiscordId(), this.study.getId(), this.student.getId()));
     }
 
     /**


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1013

## 📌 작업 내용 및 특이사항
- 수강 신청 철회시 출석 및 과제 제출 이력 삭제

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 스터디 신청 취소 시, 관련 출석 기록과 과제 내역이 자동으로 삭제됩니다.
	- 취소 이벤트에 스터디 및 사용자 식별 정보가 추가되어, 보다 명확한 이벤트 처리가 이루어집니다.

이번 업데이트로 스터디 신청 취소 프로세스가 개선되어, 변경 사항이 발생할 경우 자동으로 관련 데이터가 정리되고, 이벤트 발생 시 더 많은 정보가 기록됩니다. 이는 서비스 안정성과 관리 효율성을 높이는 데 기여합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->