### PR TITLE
feat: 누락된 스터디 역할 부여 케이스 처리를 위한 디스코드 커맨드

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/CommonDiscordService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/CommonDiscordService.java
@@ -3,9 +3,15 @@ package com.gdschongik.gdsc.domain.discord.application;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.model.RequirementStatus;
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.vo.Semester;
 import com.gdschongik.gdsc.domain.discord.domain.DiscordValidator;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.studyv2.dao.StudyHistoryV2Repository;
+import com.gdschongik.gdsc.domain.studyv2.dao.StudyV2Repository;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyHistoryV2;
+import com.gdschongik.gdsc.domain.studyv2.domain.StudyV2;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.DiscordUtil;
 import java.util.List;
@@ -20,6 +26,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class CommonDiscordService {
 
     private final MemberRepository memberRepository;
+    private final StudyV2Repository studyV2Repository;
+    private final StudyHistoryV2Repository studyHistoryV2Repository;
     private final DiscordUtil discordUtil;
     private final DiscordValidator discordValidator;
 
@@ -49,6 +57,26 @@ public class CommonDiscordService {
                 log.info("[CommonDiscordService] 디스코드 id 배치 실패: 사유 = {} memberId = {}", e.getMessage(), member.getId());
             }
         });
+    }
+
+    @Transactional
+    public void assignDiscordStudyRole(
+            String currentMemberDiscordUsername, String studyTitle, Integer academicYear, String semester) {
+        Member currentMember = memberRepository
+                .findByDiscordUsername(currentMemberDiscordUsername)
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+        discordValidator.validateAdminPermission(currentMember);
+
+        StudyV2 study = studyV2Repository
+                .findByTitleAndSemester(studyTitle, Semester.of(academicYear, SemesterType.valueOf(semester)))
+                .orElseThrow(() -> new CustomException(STUDY_NOT_FOUND));
+
+        List<StudyHistoryV2> studyHistories = studyHistoryV2Repository.findAllByStudy(study);
+        studyHistories.forEach(studyHistoryV2 -> discordUtil.addRoleToMemberById(
+                study.getDiscordRoleId(), studyHistoryV2.getStudent().getDiscordId()));
+
+        log.info("[CommonDiscordService] 스터디 디스코드 역할 부여 완료: studyId = {}", study.getId());
     }
 
     /**

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/AssignStudyRoleCommandHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/AssignStudyRoleCommandHandler.java
@@ -1,0 +1,38 @@
+package com.gdschongik.gdsc.domain.discord.application.handler;
+
+import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.*;
+
+import com.gdschongik.gdsc.domain.discord.application.CommonDiscordService;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.events.GenericEvent;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AssignStudyRoleCommandHandler implements DiscordEventHandler {
+
+    private final CommonDiscordService commonDiscordService;
+
+    @Override
+    public void delegate(GenericEvent genericEvent) {
+        SlashCommandInteractionEvent event = (SlashCommandInteractionEvent) genericEvent;
+        event.deferReply(true).setContent(DEFER_MESSAGE_ASSIGN_STUDY_ROLE).queue();
+
+        String currentMemberDiscordUsername = event.getUser().getName();
+        String studyTitle =
+                Objects.requireNonNull(event.getOption(OPTION_NAME_STUDY_TITLE)).getAsString();
+        Integer academicYear =
+                Objects.requireNonNull(event.getOption(OPTION_NAME_STUDY_YEAR)).getAsInt();
+        String semester = Objects.requireNonNull(event.getOption(OPTION_NAME_STUDY_SEMESTER))
+                .getAsString();
+
+        commonDiscordService.assignDiscordStudyRole(currentMemberDiscordUsername, studyTitle, academicYear, semester);
+
+        event.getHook()
+                .sendMessage(REPLY_MESSAGE_ASSIGN_STUDY_ROLE)
+                .setEphemeral(true)
+                .queue();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/AssignStudyRoleCommandListener.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/listener/AssignStudyRoleCommandListener.java
@@ -1,0 +1,24 @@
+package com.gdschongik.gdsc.domain.discord.application.listener;
+
+import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.COMMAND_NAME_ASSIGN_STUDY_ROLE;
+
+import com.gdschongik.gdsc.domain.discord.application.handler.AssignStudyRoleCommandHandler;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+
+@Component
+@Listener
+@RequiredArgsConstructor
+public class AssignStudyRoleCommandListener extends ListenerAdapter {
+
+    private final AssignStudyRoleCommandHandler assignStudyRoleCommandHandler;
+
+    public void onSlashCommandInteraction(@NotNull SlashCommandInteractionEvent event) {
+        if (event.getName().equals(COMMAND_NAME_ASSIGN_STUDY_ROLE)) {
+            assignStudyRoleCommandHandler.delegate(event);
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dao/StudyV2Repository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dao/StudyV2Repository.java
@@ -1,11 +1,15 @@
 package com.gdschongik.gdsc.domain.studyv2.dao;
 
+import com.gdschongik.gdsc.domain.common.vo.Semester;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyV2;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudyV2Repository extends JpaRepository<StudyV2, Long>, StudyV2CustomRepository {
 
     List<StudyV2> findAllByMentor(Member mentor);
+
+    Optional<StudyV2> findByTitleAndSemester(String title, Semester semester);
 }

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/DiscordConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/DiscordConstant.java
@@ -43,7 +43,7 @@ public class DiscordConstant {
     public static final String OPTION_NAME_STUDY_TITLE = "스터디-이름";
     public static final String OPTION_DESCRIPTION_STUDY_TITLE = "스터디 이름을 입력해주세요.";
     public static final String OPTION_NAME_STUDY_YEAR = "스터디-연도";
-    public static final String OPTION_DESCRIPTION_STUDY_YEAR = "연도를 입력해주세요.";
+    public static final String OPTION_DESCRIPTION_STUDY_YEAR = "연도를 입력해주세요. YYYY 형식으로 입력해주세요.";
     public static final String OPTION_NAME_STUDY_SEMESTER = "스터디-학기";
-    public static final String OPTION_DESCRIPTION_STUDY_SEMESTER = "학기를 입력해주세요.";
+    public static final String OPTION_DESCRIPTION_STUDY_SEMESTER = "학기를 입력해주세요. FIRST 혹은 SECOND로 입력해주세요.";
 }

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/DiscordConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/DiscordConstant.java
@@ -34,4 +34,16 @@ public class DiscordConstant {
     public static final String REPLY_MESSAGE_ASSIGN_ADMIN_ROLE = "어드민 권한 부여 작업이 완료되었습니다.";
     public static final String OPTION_NAME_ASSIGN_ADMIN_ROLE = "학번";
     public static final String OPTION_DESCRIPTION_ASSIGN_ADMIN_ROLE = "어드민 권한을 부여할 멤버의 학번을 입력해주세요.";
+
+    // 스터디 역할 부여 누락자 부여 커맨드
+    public static final String COMMAND_NAME_ASSIGN_STUDY_ROLE = "스터디-역할-부여";
+    public static final String COMMAND_DESCRIPTION_ASSIGN_STUDY_ROLE = "스터디 역할을 부여합니다.";
+    public static final String DEFER_MESSAGE_ASSIGN_STUDY_ROLE = "스터디 역할 부여 작업을 진행하는 중입니다...";
+    public static final String REPLY_MESSAGE_ASSIGN_STUDY_ROLE = "스터디 역할 부여 작업이 완료되었습니다.";
+    public static final String OPTION_NAME_STUDY_TITLE = "스터디-이름";
+    public static final String OPTION_DESCRIPTION_STUDY_TITLE = "스터디 이름을 입력해주세요.";
+    public static final String OPTION_NAME_STUDY_YEAR = "스터디-연도";
+    public static final String OPTION_DESCRIPTION_STUDY_YEAR = "연도를 입력해주세요.";
+    public static final String OPTION_NAME_STUDY_SEMESTER = "스터디-학기";
+    public static final String OPTION_DESCRIPTION_STUDY_SEMESTER = "학기를 입력해주세요.";
 }

--- a/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/DiscordConfig.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.global.config;
 
 import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.*;
+import static net.dv8tion.jda.api.interactions.commands.OptionType.*;
 
 import com.gdschongik.gdsc.domain.discord.application.listener.ListenerBeanPostProcessor;
 import com.gdschongik.gdsc.global.property.DiscordProperty;
@@ -11,7 +12,6 @@ import lombok.SneakyThrows;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.entities.Activity;
-import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.utils.ChunkingFilter;
@@ -47,11 +47,11 @@ public class DiscordConfig {
                 .addCommands(
                         Commands.slash(COMMAND_NAME_ADVANCE_FAILED_MEMBER, COMMAND_DESCRIPTION_ADVANCE_FAILED_MEMBER))
                 .addCommands(Commands.slash(COMMAND_NAME_ASSIGN_ADMIN_ROLE, COMMAND_DESCRIPTION_ASSIGN_ADMIN_ROLE)
-                        .addOption(
-                                OptionType.STRING,
-                                OPTION_NAME_ASSIGN_ADMIN_ROLE,
-                                OPTION_DESCRIPTION_ASSIGN_ADMIN_ROLE,
-                                true))
+                        .addOption(STRING, OPTION_NAME_ASSIGN_ADMIN_ROLE, OPTION_DESCRIPTION_ASSIGN_ADMIN_ROLE, true))
+                .addCommands(Commands.slash(COMMAND_NAME_ASSIGN_STUDY_ROLE, COMMAND_DESCRIPTION_ASSIGN_STUDY_ROLE)
+                        .addOption(STRING, OPTION_NAME_STUDY_TITLE, OPTION_DESCRIPTION_STUDY_TITLE, true)
+                        .addOption(INTEGER, OPTION_NAME_STUDY_YEAR, OPTION_DESCRIPTION_STUDY_YEAR, true)
+                        .addOption(STRING, OPTION_NAME_STUDY_SEMESTER, OPTION_DESCRIPTION_STUDY_SEMESTER, true))
                 .queue();
 
         return jda;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1024

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **신규 기능**
  - Discord 봇에 슬래시 명령어를 통한 학습 역할 할당 기능이 추가되었습니다.
  - 사용자는 명령어 입력 시 학습 제목, 학년도, 학기를 제공하여, 해당 정보를 기반으로 자동 역할 부여를 받을 수 있습니다.
  - 요청 처리 과정 중 진행 상태와 완료 확인 메시지가 사용자에게 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->