### PR TITLE
refactor: 테스트 토큰 발급 시에도 깃허브 핸들명 사용하도록 개선

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/TestMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/TestMemberController.java
@@ -3,7 +3,7 @@ package com.gdschongik.gdsc.domain.member.api;
 import com.gdschongik.gdsc.domain.member.application.AdminMemberService;
 import com.gdschongik.gdsc.domain.member.application.OnboardingMemberService;
 import com.gdschongik.gdsc.domain.member.application.TestMemberService;
-import com.gdschongik.gdsc.domain.member.dto.request.MemberTokenRequest;
+import com.gdschongik.gdsc.domain.member.dto.request.MemberTokenByOauthIdRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberTokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,10 +29,11 @@ public class TestMemberController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "임시 토큰 생성", description = "테스트용 API입니다. oauth_id를 입력받아 해당하는 유저의 토큰을 생성합니다.")
-    @PostMapping("/token")
-    public ResponseEntity<MemberTokenResponse> createTemporaryToken(@Valid @RequestBody MemberTokenRequest request) {
-        MemberTokenResponse response = onboardingMemberService.createTemporaryToken(request);
+    @Operation(summary = "oauthId 이용 임시 토큰 생성", description = "테스트용 API입니다. oauth_id를 입력받아 해당하는 유저의 토큰을 생성합니다.")
+    @PostMapping("/token/oauthId")
+    public ResponseEntity<MemberTokenResponse> createTemporaryTokenByOauthId(
+            @Valid @RequestBody MemberTokenByOauthIdRequest request) {
+        MemberTokenResponse response = onboardingMemberService.createTemporaryTokenByOauthId(request);
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/TestMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/TestMemberController.java
@@ -3,6 +3,7 @@ package com.gdschongik.gdsc.domain.member.api;
 import com.gdschongik.gdsc.domain.member.application.AdminMemberService;
 import com.gdschongik.gdsc.domain.member.application.OnboardingMemberService;
 import com.gdschongik.gdsc.domain.member.application.TestMemberService;
+import com.gdschongik.gdsc.domain.member.dto.request.MemberTokenByGithubHandleRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberTokenByOauthIdRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberTokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,6 +35,14 @@ public class TestMemberController {
     public ResponseEntity<MemberTokenResponse> createTemporaryTokenByOauthId(
             @Valid @RequestBody MemberTokenByOauthIdRequest request) {
         MemberTokenResponse response = onboardingMemberService.createTemporaryTokenByOauthId(request);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(summary = "깃허브 핸들 이용 임시 토큰 생성", description = "테스트용 API입니다. 깃허브 핸들명을 입력받아 해당하는 유저의 토큰을 생성합니다.")
+    @PostMapping("/token/github-handle")
+    public ResponseEntity<MemberTokenResponse> createTemporaryTokenByGithubHandle(
+            @Valid @RequestBody MemberTokenByGithubHandleRequest request) {
+        MemberTokenResponse response = onboardingMemberService.createTemporaryTokenByGithubHandle(request);
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/TestMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/TestMemberController.java
@@ -34,7 +34,7 @@ public class TestMemberController {
     @PostMapping("/token/oauthId")
     public ResponseEntity<MemberTokenResponse> createTemporaryTokenByOauthId(
             @Valid @RequestBody MemberTokenByOauthIdRequest request) {
-        MemberTokenResponse response = onboardingMemberService.createTemporaryTokenByOauthId(request);
+        var response = onboardingMemberService.createTemporaryTokenByOauthId(request);
         return ResponseEntity.ok().body(response);
     }
 
@@ -42,7 +42,7 @@ public class TestMemberController {
     @PostMapping("/token/github-handle")
     public ResponseEntity<MemberTokenResponse> createTemporaryTokenByGithubHandle(
             @Valid @RequestBody MemberTokenByGithubHandleRequest request) {
-        MemberTokenResponse response = onboardingMemberService.createTemporaryTokenByGithubHandle(request);
+        var response = onboardingMemberService.createTemporaryTokenByGithubHandle(request);
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
@@ -12,7 +12,7 @@ import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.dto.UnivVerificationStatus;
 import com.gdschongik.gdsc.domain.member.dto.request.BasicMemberInfoRequest;
-import com.gdschongik.gdsc.domain.member.dto.request.MemberTokenRequest;
+import com.gdschongik.gdsc.domain.member.dto.request.MemberTokenByOauthIdRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberBasicInfoResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberDashboardResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberTokenResponse;
@@ -76,7 +76,7 @@ public class OnboardingMemberService {
                 member, univVerificationStatus, currentRecruitmentRound.orElse(null), myMembership.orElse(null));
     }
 
-    public MemberTokenResponse createTemporaryToken(MemberTokenRequest request) {
+    public MemberTokenResponse createTemporaryTokenByOauthId(MemberTokenByOauthIdRequest request) {
         validateProfile();
 
         final Member member = memberRepository

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
@@ -12,6 +12,7 @@ import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.dto.UnivVerificationStatus;
 import com.gdschongik.gdsc.domain.member.dto.request.BasicMemberInfoRequest;
+import com.gdschongik.gdsc.domain.member.dto.request.MemberTokenByGithubHandleRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberTokenByOauthIdRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberBasicInfoResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberDashboardResponse;
@@ -25,6 +26,7 @@ import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.security.MemberAuthInfo;
 import com.gdschongik.gdsc.global.util.EnvironmentUtil;
 import com.gdschongik.gdsc.global.util.MemberUtil;
+import com.gdschongik.gdsc.infra.github.client.GithubClient;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -43,6 +45,7 @@ public class OnboardingMemberService {
     private final MemberRepository memberRepository;
     private final EnvironmentUtil environmentUtil;
     private final EmailVerificationStatusService emailVerificationStatusService;
+    private final GithubClient githubClient;
 
     public MemberUnivStatusResponse checkUnivVerificationStatus() {
         Member currentMember = memberUtil.getCurrentMember();
@@ -82,6 +85,20 @@ public class OnboardingMemberService {
         final Member member = memberRepository
                 .findByOauthId(request.oauthId())
                 .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+        AccessTokenDto accessTokenDto = jwtService.createAccessToken(MemberAuthInfo.from(member));
+        RefreshTokenDto refreshTokenDto = jwtService.createRefreshToken(member.getId());
+
+        return new MemberTokenResponse(accessTokenDto.tokenValue(), refreshTokenDto.tokenValue());
+    }
+
+    public MemberTokenResponse createTemporaryTokenByGithubHandle(MemberTokenByGithubHandleRequest request) {
+        validateProfile();
+
+        final String oauthId = githubClient.getOauthId(request.githubHandle());
+
+        final Member member =
+                memberRepository.findByOauthId(oauthId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 
         AccessTokenDto accessTokenDto = jwtService.createAccessToken(MemberAuthInfo.from(member));
         RefreshTokenDto refreshTokenDto = jwtService.createRefreshToken(member.getId());

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberTokenByGithubHandleRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberTokenByGithubHandleRequest.java
@@ -1,0 +1,5 @@
+package com.gdschongik.gdsc.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MemberTokenByGithubHandleRequest(@NotBlank String githubHandle) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberTokenByOauthIdRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberTokenByOauthIdRequest.java
@@ -2,4 +2,4 @@ package com.gdschongik.gdsc.domain.member.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record MemberTokenRequest(@NotBlank String oauthId) {}
+public record MemberTokenByOauthIdRequest(@NotBlank String oauthId) {}

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/GithubConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/GithubConstant.java
@@ -4,7 +4,7 @@ public class GithubConstant {
 
     public static final String GITHUB_DOMAIN = "github.com/";
     public static final String GITHUB_ASSIGNMENT_PATH = "week%d/wil.md";
-    public static final String GITHUB_USER_API_URL = "https://api.github.com/user/%s";
+    public static final String GITHUB_USER_BY_OAUTH_ID_API_URL = "https://api.github.com/user/%s";
 
     private GithubConstant() {}
 }

--- a/src/main/java/com/gdschongik/gdsc/global/common/constant/GithubConstant.java
+++ b/src/main/java/com/gdschongik/gdsc/global/common/constant/GithubConstant.java
@@ -5,6 +5,7 @@ public class GithubConstant {
     public static final String GITHUB_DOMAIN = "github.com/";
     public static final String GITHUB_ASSIGNMENT_PATH = "week%d/wil.md";
     public static final String GITHUB_USER_BY_OAUTH_ID_API_URL = "https://api.github.com/user/%s";
+    public static final String GITHUB_USER_BY_HANDLE_API_URL = "https://api.github.com/users/%s";
 
     private GithubConstant() {}
 }

--- a/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
@@ -8,6 +8,7 @@ import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmission;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionFetchExecutor;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionFetcher;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.infra.github.dto.request.GithubUserByHandleRequest;
 import com.gdschongik.gdsc.infra.github.dto.request.GithubUserByOauthIdRequest;
 import java.io.IOException;
 import java.io.InputStream;
@@ -53,6 +54,18 @@ public class GithubClient {
                 InputStream inputStream = response.bodyStream(); ) {
             // api가 login이라는 이름으로 사용자의 github handle을 반환합니다.
             return (String) new ObjectMapper().readValue(inputStream, Map.class).get("login");
+        } catch (IOException e) {
+            throw new CustomException(GITHUB_USER_NOT_FOUND);
+        }
+    }
+
+    // github handle -> oauthId를 가져오는 메서드
+    public String getOauthId(String githubHandle) {
+        try (GitHubConnectorResponse response = gitHubConnector.send(new GithubUserByHandleRequest(githubHandle));
+                InputStream inputStream = response.bodyStream(); ) {
+            // api가 id라는 이름으로 사용자의 oauth id를 반환합니다.
+            return String.valueOf(
+                    new ObjectMapper().readValue(inputStream, Map.class).get("id"));
         } catch (IOException e) {
             throw new CustomException(GITHUB_USER_NOT_FOUND);
         }

--- a/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/client/GithubClient.java
@@ -8,7 +8,7 @@ import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmission;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionFetchExecutor;
 import com.gdschongik.gdsc.domain.study.domain.AssignmentSubmissionFetcher;
 import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.infra.github.dto.request.GithubUserRequest;
+import com.gdschongik.gdsc.infra.github.dto.request.GithubUserByOauthIdRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.LocalDateTime;
@@ -47,8 +47,9 @@ public class GithubClient {
         }
     }
 
+    // oauthId -> github handle을 가져오는 메서드
     public String getGithubHandle(String oauthId) {
-        try (GitHubConnectorResponse response = gitHubConnector.send(new GithubUserRequest(oauthId));
+        try (GitHubConnectorResponse response = gitHubConnector.send(new GithubUserByOauthIdRequest(oauthId));
                 InputStream inputStream = response.bodyStream(); ) {
             // api가 login이라는 이름으로 사용자의 github handle을 반환합니다.
             return (String) new ObjectMapper().readValue(inputStream, Map.class).get("login");

--- a/src/main/java/com/gdschongik/gdsc/infra/github/dto/request/GithubUserByHandleRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/dto/request/GithubUserByHandleRequest.java
@@ -1,0 +1,58 @@
+package com.gdschongik.gdsc.infra.github.dto.request;
+
+import static com.gdschongik.gdsc.global.common.constant.GithubConstant.*;
+
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.exception.ErrorCode;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.kohsuke.github.connector.GitHubConnectorRequest;
+
+@RequiredArgsConstructor
+public class GithubUserByHandleRequest implements GitHubConnectorRequest {
+
+    private final String githubHandle;
+
+    @Override
+    public String method() {
+        return "GET";
+    }
+
+    @Override
+    public Map<String, List<String>> allHeaders() {
+        return Map.of();
+    }
+
+    @Override
+    public String header(String s) {
+        return "";
+    }
+
+    @Override
+    public String contentType() {
+        return "";
+    }
+
+    @Override
+    public InputStream body() {
+        return null;
+    }
+
+    @Override
+    public URL url() {
+        try {
+            return new URL(GITHUB_USER_BY_HANDLE_API_URL.formatted(githubHandle));
+        } catch (MalformedURLException e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Override
+    public boolean hasBody() {
+        return false;
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/infra/github/dto/request/GithubUserByOauthIdRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/infra/github/dto/request/GithubUserByOauthIdRequest.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.infra.github.dto.request;
 
-import static com.gdschongik.gdsc.global.common.constant.GithubConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.GithubConstant.GITHUB_USER_BY_OAUTH_ID_API_URL;
 
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.exception.ErrorCode;
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.kohsuke.github.connector.GitHubConnectorRequest;
 
 @RequiredArgsConstructor
-public class GithubUserRequest implements GitHubConnectorRequest {
+public class GithubUserByOauthIdRequest implements GitHubConnectorRequest {
 
     private final String oauthId;
 
@@ -45,7 +45,7 @@ public class GithubUserRequest implements GitHubConnectorRequest {
     @Override
     public URL url() {
         try {
-            return new URL(GITHUB_USER_API_URL.formatted(oauthId));
+            return new URL(GITHUB_USER_BY_OAUTH_ID_API_URL.formatted(oauthId));
         } catch (MalformedURLException e) {
             throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
         }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #588

## 📌 작업 내용 및 특이사항
- 기존 방식으로 스웨거 테스트용 토큰 발급시 유저의 깃허브 oauthId를 입력해서 토큰을 발급해야 합니다. 
따라서 토큰을 발급하려는 유저의 oauthId를 외워두거나 DB에서 복사해와야 하는 번거로움이 있습니다.
- 스웨거 테스트용 토큰을 깃허브 핸들명을 이용해서도 발급할 수 있도록 개선했습니다.
- 핸들명은 DB에 저장하고 있지 않기 때문에 `GithubClient` 를 이용해 깃허브 API 에서 핸들명으로 유저 정보를 조회해온 후 토큰을 발급합니다.

## 📝 참고사항
- 기존 로직 중 깃허브 핸들 -> oauthId 구해오는 로직이 `TestMemberService`에 구현이 되어 있었습니다. (Spring RestClient 주입받아 사용중)
- 근데 반대로 이번에 필요한 oauthId -> 깃허브 핸들 구해오는 로직은 `GithubClient`에 구현이 되어 있습니다. (kohsuke 라이브러리 사용 중)
- 하나로 통일 하는게 좋아보여서, `GithubClient`에 핸들 -> oauthId 를 구하는 로직을 추가했습니다.

## 📚 기타
- 나중에 `TestMemberService`를 GithubClient 사용하도록 변경하면 좋을 듯 합니다.
- 또 테스트 유저와 관련된 로직은 호출 시 프로파일을 확인해 PROD 일 경우 오류를 뱉는 식으로 막아두고 있습니다.
테스트 관련 로직을 `TestMemberService`로 이동시키고, `TestMemberController`와 `TestMemberController`를 DEV, LOCAL 환경에서만 빈으로 등록하도록 변경하면 더 좋을 것 같습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 임시 토큰 생성 API가 개선되어, OAuth ID와 GitHub 핸들을 통한 토큰 생성이 지원됩니다.
  - GitHub 연동 기능이 강화되어 사용자 정보 조회가 보다 정확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->