### PR TITLE
refactor: `oauthId` 기반 테스트용 로그인 API 제거

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/TestMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/TestMemberController.java
@@ -4,7 +4,6 @@ import com.gdschongik.gdsc.domain.member.application.AdminMemberService;
 import com.gdschongik.gdsc.domain.member.application.OnboardingMemberService;
 import com.gdschongik.gdsc.domain.member.application.TestMemberService;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberTokenByGithubHandleRequest;
-import com.gdschongik.gdsc.domain.member.dto.request.MemberTokenByOauthIdRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberTokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -28,14 +27,6 @@ public class TestMemberController {
     public ResponseEntity<Void> createTemporaryMember(@RequestParam("handle") String githubHandle) {
         testMemberService.createTestMember(githubHandle);
         return ResponseEntity.ok().build();
-    }
-
-    @Operation(summary = "oauthId 이용 임시 토큰 생성", description = "테스트용 API입니다. oauth_id를 입력받아 해당하는 유저의 토큰을 생성합니다.")
-    @PostMapping("/token/oauthId")
-    public ResponseEntity<MemberTokenResponse> createTemporaryTokenByOauthId(
-            @Valid @RequestBody MemberTokenByOauthIdRequest request) {
-        var response = onboardingMemberService.createTemporaryTokenByOauthId(request);
-        return ResponseEntity.ok().body(response);
     }
 
     @Operation(summary = "깃허브 핸들 이용 임시 토큰 생성", description = "테스트용 API입니다. 깃허브 핸들명을 입력받아 해당하는 유저의 토큰을 생성합니다.")

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberService.java
@@ -13,7 +13,6 @@ import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.dto.UnivVerificationStatus;
 import com.gdschongik.gdsc.domain.member.dto.request.BasicMemberInfoRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberTokenByGithubHandleRequest;
-import com.gdschongik.gdsc.domain.member.dto.request.MemberTokenByOauthIdRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberBasicInfoResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberDashboardResponse;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberTokenResponse;
@@ -77,19 +76,6 @@ public class OnboardingMemberService {
 
         return MemberDashboardResponse.of(
                 member, univVerificationStatus, currentRecruitmentRound.orElse(null), myMembership.orElse(null));
-    }
-
-    public MemberTokenResponse createTemporaryTokenByOauthId(MemberTokenByOauthIdRequest request) {
-        validateProfile();
-
-        final Member member = memberRepository
-                .findByOauthId(request.oauthId())
-                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
-
-        AccessTokenDto accessTokenDto = jwtService.createAccessToken(MemberAuthInfo.from(member));
-        RefreshTokenDto refreshTokenDto = jwtService.createRefreshToken(member.getId());
-
-        return new MemberTokenResponse(accessTokenDto.tokenValue(), refreshTokenDto.tokenValue());
     }
 
     public MemberTokenResponse createTemporaryTokenByGithubHandle(MemberTokenByGithubHandleRequest request) {

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberTokenByOauthIdRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dto/request/MemberTokenByOauthIdRequest.java
@@ -1,5 +1,0 @@
-package com.gdschongik.gdsc.domain.member.dto.request;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record MemberTokenByOauthIdRequest(@NotBlank String oauthId) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1036

## 📌 작업 내용 및 특이사항
- #1032 
- 해당 이슈에서 이야기한 내용 적용해 oauthId 를 이용해서 테스트용 토큰을 발급받는 기존 API 제거

## 📝 참고사항
-

## 📚 기타
-
