### PR TITLE
fix: 스터디 수강생 관리 NPE 문제

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryStatus.java
@@ -31,7 +31,8 @@ public enum AssignmentHistoryStatus {
             throws CustomException {
 
         // 제출기한이 설정되지 않았을 경우
-        if (studySession.getAssignmentPeriod() == null || studySession.getAssignmentPeriod().isEmpty()) {
+        if (studySession.getAssignmentPeriod() == null
+                || studySession.getAssignmentPeriod().isEmpty()) {
             return BEFORE_SUBMISSION;
         }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryStatus.java
@@ -21,6 +21,7 @@ public enum AssignmentHistoryStatus {
 
     /**
      * 과제 제출 상태를 반환합니다. 제출기한 이내에 있는 제츌이력만 인자로 받습니다.
+     * 제출기한이 설정되지 않았을 경우, 판정 대상에서 제외합니다.
      * 제출기한에 포함되지 않는 제출이력은 제출기한 변경 전 제출이력이므로, 판정 대상에서 제외합니다.
      *
      * @throws CustomException 제출기한에 포함되지 않는 제출이력을 인자로 받았을 때
@@ -28,6 +29,14 @@ public enum AssignmentHistoryStatus {
     public static AssignmentHistoryStatus of(
             @Nullable AssignmentHistoryV2 assignmentHistory, StudySessionV2 studySession, LocalDateTime now)
             throws CustomException {
+
+        // 제출기한이 설정되지 않았을 경우
+        if (studySession.getAssignmentPeriod() == null
+                || studySession.getAssignmentPeriod().getStartDate() == null
+                || studySession.getAssignmentPeriod().getEndDate() == null) {
+            return BEFORE_SUBMISSION;
+        }
+
         validateCommittedAtWithinAssignmentPeriod(assignmentHistory, studySession);
 
         Period assignmentPeriod = studySession.getAssignmentPeriod();

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryStatus.java
@@ -31,9 +31,7 @@ public enum AssignmentHistoryStatus {
             throws CustomException {
 
         // 제출기한이 설정되지 않았을 경우
-        if (studySession.getAssignmentPeriod() == null
-                || studySession.getAssignmentPeriod().getStartDate() == null
-                || studySession.getAssignmentPeriod().getEndDate() == null) {
+        if (studySession.getAssignmentPeriod() == null || studySession.getAssignmentPeriod().isEmpty()) {
             return BEFORE_SUBMISSION;
         }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AttendanceStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AttendanceStatus.java
@@ -22,7 +22,9 @@ public enum AttendanceStatus {
             return NOT_LIVE;
         }
 
-        if (studySession.getLessonPeriod().getStartDate().isAfter(now)) {
+        LocalDateTime startDate = studySession.getLessonPeriod().getStartDate();
+
+        if (startDate == null || startDate.isAfter(now)) {
             return BEFORE_ATTENDANCE;
         }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AttendanceStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AttendanceStatus.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.domain.studyv2.domain;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.study.domain.StudyType;
 import java.time.LocalDateTime;
 import lombok.Getter;
@@ -22,9 +23,9 @@ public enum AttendanceStatus {
             return NOT_LIVE;
         }
 
-        LocalDateTime startDate = studySession.getLessonPeriod().getStartDate();
+        Period lessonPeriod = studySession.getLessonPeriod();
 
-        if (startDate == null || startDate.isAfter(now)) {
+        if (lessonPeriod.isEmpty() || lessonPeriod.getStartDate().isAfter(now)) {
             return BEFORE_ATTENDANCE;
         }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1040

## 📌 작업 내용 및 특이사항
[문제 상황]
- 스터디 멘토, 수강생 관리 API에서 NPE가 발생중입니다.
- 스터디 타입에 따라 출석 상태 or 과제 제출 상태를 검증 후 'StudyTaskDto` 응답으로 반환합니다.
- 현재 시각이 출석 또는 과제 제출 시작 시간보다 이른 경우 "제출 전" 상태를 반환해야 하는데
이때 출석, 과제 제출 시간이 아직 등록되지 않은 경우 NPE가 발생합니다.

[해결]
상태 검증전 null 검사  로직을 추가했습니다.

그러나 일시적인 해결책이고, 이와 비슷한 로직이 얼마나 많이 있을지 잘 모르겠습니다.
`Period`를 사용하는 모든 로직에서 null 검사를 생략할 경우 NPE가 발생할 수 있습니다.

좋은 해결 방법이 있을까요..?

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
	- 과제 제출 상태가 비어 있거나 유효하지 않은 경우, 올바르게 평가되도록 검증 로직을 개선했습니다.
	- 출석 상태 평가 시 수업 기간이 비어 있거나 시작 시간이 현재 시간 이후인 경우에도 적절한 기본 상태가 적용되도록 수정하여, 상태 분류의 일관성과 안정성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->