### PR TITLE
refactor: 테스트용 게스트 회원 생성시 `GithubClient` 사용하도록 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/TestMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/TestMemberService.java
@@ -5,27 +5,23 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.global.exception.CustomException;
-import java.util.Optional;
+import com.gdschongik.gdsc.infra.github.client.GithubClient;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestClient;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class TestMemberService {
 
     private final MemberRepository memberRepository;
-    private final RestClient restClient;
-
-    public TestMemberService(MemberRepository memberRepository) {
-        this.memberRepository = memberRepository;
-        this.restClient = RestClient.builder().baseUrl("https://api.github.com").build();
-    }
+    private final GithubClient githubClient;
 
     @Transactional
     public void createTestMember(String githubHandle) {
-        String githubOauthId = getGithubOauthId(githubHandle);
+        String githubOauthId = githubClient.getOauthId(githubHandle);
 
         if (memberRepository.findByOauthId(githubOauthId).isPresent()) {
             throw new CustomException(INTERNAL_SERVER_ERROR);
@@ -34,16 +30,4 @@ public class TestMemberService {
         Member guestMember = Member.createGuest(githubOauthId);
         memberRepository.save(guestMember);
     }
-
-    private String getGithubOauthId(String githubHandle) {
-        return Optional.ofNullable(restClient
-                        .get()
-                        .uri("/users/{githubHandle}", githubHandle)
-                        .retrieve()
-                        .body(GithubUser.class))
-                .map(GithubUser::id)
-                .orElseThrow(() -> new CustomException(INTERNAL_SERVER_ERROR));
-    }
-
-    private record GithubUser(String id) {}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1045

## 📌 작업 내용 및 특이사항
- 기존 테스트용 게스트 회원 생성 API 에서 깃허브 핸들을 이용해 oauthId를 조회하는 로직이 RestClient를 이용해 진행중이었습니다.
- 해당 내부 로직을 `GithubClient`를 사용하도록 변경했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - OAuth 인증 프로세스가 개선되어 GitHub 인증 정보 조회가 보다 안정적이고 효율적으로 진행됩니다.
  - 내부 구현 방식 변경을 통해 서비스의 신뢰성과 유지보수성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->