### PR TITLE
feat: 디스코드 스터디 공지 스타일링 개선

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
@@ -4,6 +4,8 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.property.DiscordProperty;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,9 @@ import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 
 @RequiredArgsConstructor
 public class DiscordUtil {
+
+    public static final String IMAGE_GENERATOR_URL =
+            "https://image.wawoo.dev/api/v1/study-announcement";
 
     private final JDA jda;
     private final DiscordProperty discordProperty;
@@ -84,14 +89,41 @@ public class DiscordUtil {
 
         String studyRoleMention = findRoleById(discordRoleId).getAsMention();
 
+        String theme = "indigo"; // 디폴트 값
+
         MessageEmbed embed = new EmbedBuilder()
-                .setTitle("[" + title + "]", link)
+                .setTitle("[" + title + "]")
                 .appendDescription(studyRoleMention + "\n\n")
                 .appendDescription(studyName + " 공지가 업로드 되었어요.\n")
                 .appendDescription("공지는 [와우클래스](<https://study.wawoo.dev/landing>)에서도 확인 가능해요.\n")
+                .appendDescription(String.format("## [► 공지 확인하러 가기](<%s>)\n", link))
                 .setTimestamp(createdAt)
+                .setImage(buildImageUrl(studyName, title, createdAt, theme))
                 .build();
 
         channel.sendMessageEmbeds(embed).queue();
+    }
+
+    private String buildImageUrl(String studyName, String title, LocalDateTime dateTime, String theme) {
+        String encodedTitle = URLEncoder.encode(title, StandardCharsets.UTF_8);
+        String encodedStudy = URLEncoder.encode(studyName, StandardCharsets.UTF_8);
+
+        StringBuilder urlBuilder = new StringBuilder(IMAGE_GENERATOR_URL)
+                .append("?title=")
+                .append(encodedTitle)
+                .append("&study=")
+                .append(encodedStudy);
+
+        if (dateTime != null) {
+            String encodedDate = URLEncoder.encode(dateTime.toString(), StandardCharsets.UTF_8);
+            urlBuilder.append("&date=").append(encodedDate);
+        }
+
+        if (theme != null && !theme.isEmpty()) {
+            String encodedTheme = URLEncoder.encode(theme, StandardCharsets.UTF_8);
+            urlBuilder.append("&theme=").append(encodedTheme);
+        }
+
+        return urlBuilder.toString();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
@@ -89,8 +89,7 @@ public class DiscordUtil {
                 .orElseThrow(() -> new CustomException(DISCORD_CHANNEL_NOT_FOUND));
 
         String studyRoleMention = findRoleById(discordRoleId).getAsMention();
-
-        String theme = "indigo"; // 디폴트 값
+        String theme = determineThemeByStudyName(studyName);
 
         MessageEmbed embed = new EmbedBuilder()
                 .setTitle("[" + title + "]")
@@ -110,6 +109,28 @@ public class DiscordUtil {
                 .atZone(ZoneId.of("Asia/Seoul"))
                 .withZoneSameInstant(ZoneId.of("UTC"))
                 .toInstant();
+    }
+
+    private String determineThemeByStudyName(String studyName) {
+        if (studyName.contains("프론트엔드")) {
+            return "react";
+        }
+        if (studyName.contains("백엔드")) {
+            return "spring";
+        }
+        if (studyName.contains("인공지능")) {
+            return "ai";
+        }
+
+        String[] availableThemes = {"indigo", "rose", "emerald", "amber"};
+
+        int hash = 0;
+        for (int i = 0; i < studyName.length(); i++) {
+            hash = (hash + studyName.charAt(i)) % 1000;
+        }
+
+        int themeIndex = hash % availableThemes.length;
+        return availableThemes[themeIndex];
     }
 
     private String buildImageUrl(String studyName, String title, LocalDateTime dateTime, String theme) {

--- a/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
@@ -6,7 +6,9 @@ import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.property.DiscordProperty;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -20,8 +22,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 @RequiredArgsConstructor
 public class DiscordUtil {
 
-    public static final String IMAGE_GENERATOR_URL =
-            "https://image.wawoo.dev/api/v1/study-announcement";
+    public static final String IMAGE_GENERATOR_URL = "https://image.wawoo.dev/api/v1/study-announcement";
 
     private final JDA jda;
     private final DiscordProperty discordProperty;
@@ -97,11 +98,18 @@ public class DiscordUtil {
                 .appendDescription(studyName + " 공지가 업로드 되었어요.\n")
                 .appendDescription("공지는 [와우클래스](<https://study.wawoo.dev/landing>)에서도 확인 가능해요.\n")
                 .appendDescription(String.format("## [► 공지 확인하러 가기](<%s>)\n", link))
-                .setTimestamp(createdAt)
+                .setTimestamp(convertKstToUtc(createdAt))
                 .setImage(buildImageUrl(studyName, title, createdAt, theme))
                 .build();
 
         channel.sendMessageEmbeds(embed).queue();
+    }
+
+    private Instant convertKstToUtc(LocalDateTime kstCreatedAt) {
+        return kstCreatedAt
+                .atZone(ZoneId.of("Asia/Seoul"))
+                .withZoneSameInstant(ZoneId.of("UTC"))
+                .toInstant();
     }
 
     private String buildImageUrl(String studyName, String title, LocalDateTime dateTime, String theme) {

--- a/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/DiscordUtil.java
@@ -84,7 +84,6 @@ public class DiscordUtil {
             String title,
             String link,
             LocalDateTime createdAt) {
-
         TextChannel channel = Optional.ofNullable(jda.getTextChannelById(channelId))
                 .orElseThrow(() -> new CustomException(DISCORD_CHANNEL_NOT_FOUND));
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1047

## 📌 작업 내용 및 특이사항
사진으로 대체합니다.

(AS-IS)
<img width="432" alt="image" src="https://github.com/user-attachments/assets/844bcada-e35c-4863-8a99-9c262f47e26d" />
(TO-BE)
<img width="359" alt="image" src="https://github.com/user-attachments/assets/0b46fb1d-ed97-4a55-b242-084ac8367dbe" />
- 날짜 kst-utc 오류 해결 (내일로 찍힘)
- h2 하이퍼링크 바로가기 버튼 추가
- 썸네일 추가

### 썸네일 정책
- https://github.com/GDSC-Hongik/wawoo-image 사용
- 테마는 react, spring, ai, indigo(디폴트), rose, emerald, amber 선택 가능
- 스터디 이름에 프론트 포함 -> react / 백엔드 -> spring / 인공지능 -> ai 사용
- 그 외 경우 indigo (디폴트), rose, emerald, amber 중 랜덤하게 하나를 사용. 
- 단 스터디 이름이 같은 경우 항상 같은 테마를 선택. (해시 기반)

### 썸네일 미리보기 (react / spring / ai /indigo / rose / emeral / amber 순)
![image](https://github.com/user-attachments/assets/c35a5f44-f6c8-4d33-bae3-0d317c8f1540)
![image](https://github.com/user-attachments/assets/5b0f7737-7c45-4efc-a237-6bfa12a195f0)
![image](https://github.com/user-attachments/assets/18d7897e-1a3c-4f6b-8f9a-c56810c0bf07)
![image](https://github.com/user-attachments/assets/01eba4e4-7be0-4d44-bdfe-7a215d9750d1)
![image](https://github.com/user-attachments/assets/cf095b59-b267-4cd1-bcd0-d044308ee86e)
![image](https://github.com/user-attachments/assets/1322cf08-0d4f-4ace-a799-e4859c0b1a34)


## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 공지 메시지의 표현 방식이 개선되어 정보 전달이 더욱 명확해졌습니다.
  - 동적 테마 선택 및 이미지 연동 기능이 추가되어 메시지 내용이 다양해졌습니다.
  - 시간대 변환 처리 업데이트로 전 세계 사용자에게 일관된 시간 정보가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->