### PR TITLE
fix: JWT 토큰 존재 시 스웨거 Basic Auth가 올바르게 작동하지 않는 문제

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
@@ -75,7 +75,7 @@ public class WebSecurityConfig {
         http.authorizeHttpRequests(
                 environmentUtil.isDevProfile()
                         ? authorize -> authorize.anyRequest().authenticated()
-                        : authorize -> authorize.anyRequest().authenticated());
+                        : authorize -> authorize.anyRequest().permitAll());
 
         return http.build();
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1065

## 📌 작업 내용 및 특이사항

###  문제 상황
- 기존에 로그인 한 기록이 있는 상황에서 (브라우저 쿠키에 AccessToken 존재)
- dev swagger url에 로그인한 경우 (Authorization 헤더에 Basic 토큰 존재)

두 조건 충족한 상황에서 dev swagger 로그인시 500에러 발생

정상 동작
- `/swagger-ui/**` 와 같은 스웨거 관련 url은 스웨거 전용 시큐리티 필터체인으로 분기, 로그인 성공

문제 상황
- 스웨거 필터 체인에는  없는 `JwtFilter` 가 호출됨
- Authorization헤더에 존재하는 Basic 토큰을 Bearer 토큰으로 인식, 파싱 중 에러 발생

### 원인
<img width="1038" alt="스크린샷 2025-05-28 오후 9 14 43" src="https://github.com/user-attachments/assets/363d3e2b-95b3-45d2-ab68-81f4fab8ad73" />

로그 확인 결과 스웨거 전용 스프링 시큐리티 필터 체인은 잘 타는 상황. 
`/swagger-ui/index.html`  요청이 12개의 시큐리티 필터 체인을 타는 동안 `JwtFilter` 는 호출되지 않고 잘 동작해 인증을 마침.

<img width="1110" alt="스크린샷 2025-05-28 오후 9 23 36" src="https://github.com/user-attachments/assets/e445b170-e9eb-47fb-89ee-78454932e2ed" />

그러나 인증이 종료된 후 `SentryUserFilter` → `LoggingFilter` → `JwtFilter` 를 거치며 에러가 발생함.

<img width="1089" alt="스크린샷 2025-05-28 오후 9 25 09" src="https://github.com/user-attachments/assets/59a9d28a-9cb1-48fc-bdcb-7119504b13dd" />

즉 SecurityFilterChain의 동작에는 문제가 없음. `JwtFilter` 가 시큐리티와 상관 없이, `LoggingFilter` 처럼 기본 Servlet Filter Chain에도 함께 등록되어 있어 같이 호출되는 상황이었음.

https://docs.spring.io/spring-security/reference/servlet/architecture.html#servlet-filters-review

### Declaring Your Filter as a Bean
> When you declare a `Filter` as a Spring bean, either by annotating it with `@Component` or by declaring it as a bean in your configuration, Spring Boot automatically [[registers it with the embedded container](https://docs.spring.io/spring-boot/3.3.3/reference/web/servlet.html#web.servlet.embedded-container.servlets-filters-listeners.beans)](https://docs.spring.io/spring-boot/3.3.3/reference/web/servlet.html#web.servlet.embedded-container.servlets-filters-listeners.beans). That may cause the filter to be invoked twice, once by the container and once by Spring Security and in a different order.

Filter 를 스프링 빈으로 등록하는 순간 스프링 부트는 필터를 embedded container (Servlet Filter Chain)에 추가한다. 해당 필터를 시큐리티 필터 체인에 등록한다면 필터가 두 번 호출될 수 있다.

### 해결 방법 - 빈으로 등록하지 않고 사용하기

```java
@Bean
public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
    defaultFilterChain(http);

    http.addFilterAfter(new JwtExceptionFilter(objectMapper), LogoutFilter.class);
    http.addFilterAfter(new JwtFilter(jwtService, cookieUtil), LogoutFilter.class);
```

빈으로 등록하지 않고 필터 체인 메서드에서 생성자로 직접 생성.
어차피 SecurityFilterChain이 빈으로 등록되기 때문에 싱글톤 보장.
공식문서에서도 필터 등록하는 첫번째 방법으로 소개.

빈으로 등록하되 Servlet Filter Chain에 자동 등록되지 않게 하는 설정 방법도 있지만 
필터가 스프링 빈으로 등록될 필요가 있다면 (복잡한 의존성 주입 등) 사용하라는 공식문서 설명.

우리 프로젝트의 필터는 의존성이 복잡하지 않아서 굳이 빈으로 등록할 필요가 없을 듯 함.

## 📝 참고사항
-

## 📚 기타
-
