### PR TITLE
fix: `Errorcode` 오타 및 네이밍 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainService.java
@@ -91,7 +91,7 @@ public class EventParticipationDomainService {
     private void validateEventApplicationPeriod(Event event, LocalDateTime now) {
         Period applicationPeriod = event.getApplicationPeriod();
         if (!applicationPeriod.isWithin(now)) {
-            throw new CustomException(EVENT_NOT_APPLIABLE_APPLICATION_PERIOD_INVALID);
+            throw new CustomException(EVENT_NOT_APPLICABLE_APPLICATION_PERIOD_INVALID);
         }
     }
 
@@ -102,11 +102,11 @@ public class EventParticipationDomainService {
     private void validateAfterPartyApplicationStatus(
             Event event, AfterPartyApplicationStatus afterPartyApplicationStatus) {
         if (event.getAfterPartyStatus().isEnabled() && afterPartyApplicationStatus.isNone()) {
-            throw new CustomException(EVENT_NOT_APPLIABLE_AFTER_PARTY_NONE);
+            throw new CustomException(EVENT_NOT_APPLICABLE_AFTER_PARTY_NONE);
         }
 
         if (!event.getAfterPartyStatus().isEnabled() && !afterPartyApplicationStatus.isNone()) {
-            throw new CustomException(EVENT_NOT_APPLIABLE_AFTER_PARTY_NOT_NONE);
+            throw new CustomException(EVENT_NOT_APPLICABLE_AFTER_PARTY_DISABLED);
         }
     }
 
@@ -116,7 +116,7 @@ public class EventParticipationDomainService {
      */
     private void validateMemberWhenOnlyRegularRoleAllowed(Event event, Member member) {
         if (event.getRegularRoleOnlyStatus().isEnabled() && !member.isRegular()) {
-            throw new CustomException(EVENT_NOT_APPLIABLE_NOT_REGULAR_ROLE);
+            throw new CustomException(EVENT_NOT_APPLICABLE_NOT_REGULAR_ROLE);
         }
     }
 
@@ -126,7 +126,7 @@ public class EventParticipationDomainService {
      */
     private void validateNotRegularRoleAllowed(Event event) {
         if (event.getRegularRoleOnlyStatus().isEnabled()) {
-            throw new CustomException(EVENT_NOT_APPLIABLE_NOT_REGULAR_ROLE);
+            throw new CustomException(EVENT_NOT_APPLICABLE_NOT_REGULAR_ROLE);
         }
     }
 
@@ -135,7 +135,7 @@ public class EventParticipationDomainService {
      */
     public void validateAfterPartyEnabled(Event event) {
         if (event.getAfterPartyStatus().isDisabled()) {
-            throw new CustomException(EVENT_NOT_APPLIABLE_AFTER_PARTY_NOT_NONE);
+            throw new CustomException(EVENT_NOT_APPLICABLE_AFTER_PARTY_DISABLED);
         }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -195,10 +195,10 @@ public enum ErrorCode {
     EVENT_NOT_FOUND(NOT_FOUND, "존재하지 않는 이벤트입니다."),
     EVENT_NOT_CREATABLE_PAYMENT_ENABLED(CONFLICT, "뒤풀이 상태가 비활성화된 경우, 선입금 및 후정산 상태도 비활성화 되어야 합니다."),
     EVENT_NOT_CREATABLE_PAYMENTS_BOTH_ENABLED(CONFLICT, "선입금과 후정산은 동시에 활성화될 수 없습니다."),
-    EVENT_NOT_APPLIABLE_NOT_REGULAR_ROLE(CONFLICT, "정회원이 아닌 회원은 이벤트에 신청할 수 없습니다."),
-    EVENT_NOT_APPLIABLE_APPLICATION_PERIOD_INVALID(CONFLICT, "이벤트 신청 기간이 아닙니다."),
-    EVENT_NOT_APPLIABLE_AFTER_PARTY_NONE(CONFLICT, "뒤풀이가 활성화된 이벤트는 뒤풀이 신청 여부를 NONE으로 설정할 수 없습니다."),
-    EVENT_NOT_APPLIABLE_AFTER_PARTY_NOT_NONE(CONFLICT, "뒤풀이가 비활성화된 이벤트에 뒤풀이 신청을 할 수 없습니다."),
+    EVENT_NOT_APPLICABLE_NOT_REGULAR_ROLE(CONFLICT, "정회원이 아닌 회원은 이벤트에 신청할 수 없습니다."),
+    EVENT_NOT_APPLICABLE_APPLICATION_PERIOD_INVALID(CONFLICT, "이벤트 신청 기간이 아닙니다."),
+    EVENT_NOT_APPLICABLE_AFTER_PARTY_NONE(CONFLICT, "뒤풀이가 활성화된 이벤트는 뒤풀이 신청 여부를 NONE으로 설정할 수 없습니다."),
+    EVENT_NOT_APPLICABLE_AFTER_PARTY_DISABLED(CONFLICT, "뒤풀이가 비활성화된 이벤트에 뒤풀이 신청을 할 수 없습니다."),
     PARTICIPANT_NOT_CREATABLE_INFO_NOT_SATISFIED(
             INTERNAL_SERVER_ERROR, "기본 정보를 입력하지 않은 멤버로 참여자 정보 생성을 시도했습니다. 관리자에게 문의 바랍니다."),
     PARTICIPANT_ROLE_NOT_CREATABLE_BOTH_EXISTENCE_MISMATCH(

--- a/src/test/java/com/gdschongik/gdsc/domain/event/application/EventParticipationServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/application/EventParticipationServiceTest.java
@@ -200,7 +200,7 @@ class EventParticipationServiceTest extends IntegrationTest {
             // when & then
             assertThatThrownBy(() -> eventParticipationService.attendAfterParty(request))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(EVENT_NOT_APPLIABLE_AFTER_PARTY_NOT_NONE.getMessage());
+                    .hasMessage(EVENT_NOT_APPLICABLE_AFTER_PARTY_DISABLED.getMessage());
         }
     }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
@@ -38,7 +38,7 @@ public class EventParticipationDomainServiceTest {
             // when & then
             assertThatThrownBy(() -> domainService.applyEventForRegistered(member, status, event, invalidDate))
                     .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(EVENT_NOT_APPLIABLE_APPLICATION_PERIOD_INVALID.getMessage());
+                    .hasMessageContaining(EVENT_NOT_APPLICABLE_APPLICATION_PERIOD_INVALID.getMessage());
         }
 
         @Test
@@ -58,7 +58,7 @@ public class EventParticipationDomainServiceTest {
             // when & then
             assertThatThrownBy(() -> domainService.applyEventForRegistered(guestMember, status, event, now))
                     .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(EVENT_NOT_APPLIABLE_NOT_REGULAR_ROLE.getMessage());
+                    .hasMessageContaining(EVENT_NOT_APPLICABLE_NOT_REGULAR_ROLE.getMessage());
         }
 
         @Test
@@ -78,7 +78,7 @@ public class EventParticipationDomainServiceTest {
             // when & then
             assertThatThrownBy(() -> domainService.applyEventForRegistered(member, noneStatus, event, now))
                     .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(EVENT_NOT_APPLIABLE_AFTER_PARTY_NONE.getMessage());
+                    .hasMessageContaining(EVENT_NOT_APPLICABLE_AFTER_PARTY_NONE.getMessage());
         }
 
         @Test
@@ -98,7 +98,7 @@ public class EventParticipationDomainServiceTest {
             // when & then
             assertThatThrownBy(() -> domainService.applyEventForRegistered(member, appliedStatus, event, now))
                     .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(EVENT_NOT_APPLIABLE_AFTER_PARTY_NOT_NONE.getMessage());
+                    .hasMessageContaining(EVENT_NOT_APPLICABLE_AFTER_PARTY_DISABLED.getMessage());
         }
     }
 
@@ -123,7 +123,7 @@ public class EventParticipationDomainServiceTest {
             // when & then
             assertThatThrownBy(() -> domainService.applyEventForUnregistered(participant, status, event, invalidDate))
                     .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(EVENT_NOT_APPLIABLE_APPLICATION_PERIOD_INVALID.getMessage());
+                    .hasMessageContaining(EVENT_NOT_APPLICABLE_APPLICATION_PERIOD_INVALID.getMessage());
         }
 
         @Test
@@ -143,7 +143,7 @@ public class EventParticipationDomainServiceTest {
             // when & then
             assertThatThrownBy(() -> domainService.applyEventForUnregistered(participant, status, event, now))
                     .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(EVENT_NOT_APPLIABLE_NOT_REGULAR_ROLE.getMessage());
+                    .hasMessageContaining(EVENT_NOT_APPLICABLE_NOT_REGULAR_ROLE.getMessage());
         }
 
         @Test
@@ -163,7 +163,7 @@ public class EventParticipationDomainServiceTest {
             // when & then
             assertThatThrownBy(() -> domainService.applyEventForUnregistered(participant, noneStatus, event, now))
                     .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(EVENT_NOT_APPLIABLE_AFTER_PARTY_NONE.getMessage());
+                    .hasMessageContaining(EVENT_NOT_APPLICABLE_AFTER_PARTY_NONE.getMessage());
         }
 
         @Test
@@ -183,7 +183,7 @@ public class EventParticipationDomainServiceTest {
             // when & then
             assertThatThrownBy(() -> domainService.applyEventForUnregistered(participant, appliedStatus, event, now))
                     .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(EVENT_NOT_APPLIABLE_AFTER_PARTY_NOT_NONE.getMessage());
+                    .hasMessageContaining(EVENT_NOT_APPLICABLE_AFTER_PARTY_DISABLED.getMessage());
         }
     }
 
@@ -205,7 +205,7 @@ public class EventParticipationDomainServiceTest {
             // when & then
             assertThatThrownBy(() -> domainService.joinOnsiteForRegistered(guestMember, event))
                     .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(EVENT_NOT_APPLIABLE_NOT_REGULAR_ROLE.getMessage());
+                    .hasMessageContaining(EVENT_NOT_APPLICABLE_NOT_REGULAR_ROLE.getMessage());
         }
     }
 
@@ -227,7 +227,7 @@ public class EventParticipationDomainServiceTest {
             // when & then
             assertThatThrownBy(() -> domainService.joinOnsiteForUnregistered(participant, event))
                     .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(EVENT_NOT_APPLIABLE_NOT_REGULAR_ROLE.getMessage());
+                    .hasMessageContaining(EVENT_NOT_APPLICABLE_NOT_REGULAR_ROLE.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1148

## 📌 작업 내용 및 특이사항
- appliable을 applicable로 수정
- Event의 뒤풀이 비활성화는 NONE이 아닌 DISABLED이므로 수정

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 이벤트 관련 오류 코드 표기의 오탈자를 정정하고 명칭을 일관화했습니다.
  - 뒤풀이 비활성화 상태에 대한 오류 메시지 표현을 ‘비활성화(DISABLED)’로 명확히 했습니다.
  - 사용자에게 표시되는 오류 문구가 보다 일관되고 이해하기 쉽게 개선되었습니다.
- Tests
  - 변경된 오류 코드와 메시지에 맞춰 테스트 기대값을 갱신해 신뢰성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->