### PR TITLE
fix: 간헐적으로 실패하는 테스트 조사

### DIFF
--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -39,7 +39,7 @@ public class MembershipServiceTest extends IntegrationTest {
         @Test
         void 멤버십을_1차모집시_생성했지만_정회원_가입조건을_만족하지_않았다면_2차모집에서_멤버십_가입신청에_성공한다() {
             // given
-            createMember();
+            createAssociateMember();
             logoutAndReloginAs(1L, ASSOCIATE);
 
             RecruitmentRound firstRound = createRecruitmentRound(


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1159

## 📌 작업 내용 및 특이사항
- 아래 빌드 스캔 리포트를 보시면 validator 20번째 라인에서 예외를 던지는걸 확인할 수 있습니다. 이는 테스트 유저의 준회원 승급 이벤트가 실행되지 않았기 때문입니다. 
<img width="938" height="52" alt="image" src="https://github.com/user-attachments/assets/922d51ca-c910-4f78-a083-2095ee96f107" />

- IntegrationTest에 있는 멤버 생성 메서드들 중에서 준회원으로 승급까지 시켜주는 메서드를 사용하도록 수정했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 테스트
  * 준회원 가입 신청 플로우를 반영해 시나리오를 보완하고, 실제 운영 정책과 일치하도록 검증 범위를 정교화했습니다.
  * 1·2차 모집 라운드 간 신청 처리의 안정성 검증을 강화해 회귀를 조기에 탐지하도록 테스트 신뢰도를 높였습니다.
  * 사용자 기능 변경은 없으며, 품질 확보를 위한 테스트 개선만 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->