### PR TITLE
docs: 뒤풀이가 있는 행사라면 뒤풀이 신청 상태로 추가되는 점을 스웨거에 명시

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventParticipationController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventParticipationController.java
@@ -87,7 +87,7 @@ public class AdminEventParticipationController {
 
     @Operation(
             summary = "행사 및 뒤풀이 수동 신청 (회원)",
-            description = "관리자가 회원의 정보를 바탕으로 행사를 수동으로 신청 처리합니다. 이벤트 뒤풀이가 있는 행사라면 뒤풀이 참석 상태로 신청처리합니다.")
+            description = "관리자가 회원의 정보를 바탕으로 행사를 수동으로 신청 처리합니다. 이벤트 뒤풀이가 있는 행사라면 뒤풀이 신청 상태로 신청 처리합니다.")
     @PostMapping("/apply/manual/registered")
     public ResponseEntity<Void> applyManualForRegistered(@Valid @RequestBody EventRegisteredApplyRequest request) {
         eventParticipationService.applyManualForRegistered(request);
@@ -96,7 +96,7 @@ public class AdminEventParticipationController {
 
     @Operation(
             summary = "행사 및 뒤풀이 수동 신청 (비회원)",
-            description = "관리자가 비회원의 정보를 바탕으로 행사를 수동으로 신청 처리합니다. 이벤트 뒤풀이가 있는 행사라면 뒤풀이 참석 상태로 신청처리합니다.")
+            description = "관리자가 비회원의 정보를 바탕으로 행사를 수동으로 신청 처리합니다. 이벤트 뒤풀이가 있는 행사라면 뒤풀이 신청 상태로 신청 처리합니다.")
     @PostMapping("/apply/manual/unregistered")
     public ResponseEntity<Void> applyManualForUnregistered(@Valid @RequestBody EventUnregisteredApplyRequest request) {
         eventParticipationService.applyManualForUnregistered(request);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1158

## 📌 작업 내용 및 특이사항
- 뒤풀이 참석자를 추가하는 API 를 구현하려고 했는데, 현재 구현된 로직으로 처리가 가능하여 스웨거에 명시하도록 내용만 추가하였습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 관리자용 수동 신청 관련 두 API의 공개 문서(OpenAPI) 설명을 보강했습니다.
  * 애프터파티가 포함된 이벤트의 참석 처리 방식(애프터파티 참석 반영)을 명확히 안내합니다.
  * 동작·호환성·공개 시그니처에는 변경이 없으므로 기존 사용에 영향이 없습니다.
  * API 이용자가 예상 동작을 더 쉽게 이해할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->