### PR TITLE
refactor: 이벤트 신청 dto 스웨거에 설명 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventCreateRequest.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.domain.event.dto.request;
 
 import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.event.domain.UsageStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -19,5 +20,5 @@ public record EventCreateRequest(
         @NotNull UsageStatus postPaymentStatus,
         @NotNull UsageStatus rsvpQuestionStatus,
         @NotNull UsageStatus noticeConfirmQuestionStatus,
-        @Positive Integer mainEventMaxApplicantCount,
-        @Positive Integer afterPartyMaxApplicantCount) {}
+        @Positive @Schema(description = "본 행사 최대 신청 가능 인원. 제한 없음은 null을 입력합니다.") Integer mainEventMaxApplicantCount,
+        @Positive @Schema(description = "뒤풀이 최대 신청 가능 인원. 제한 없음은 null을 입력합니다.") Integer afterPartyMaxApplicantCount) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1200

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 문서
  - API 문서(Swagger/OpenAPI)에서 이벤트 신청 인원 관련 필드 설명을 보강했습니다.
  - 본행사 및 뒤풀이의 최대 신청 가능 인원 의미를 명확히 안내합니다.
  - 제한 없음 설정 방법을 “null 입력”으로 분명히 표기하여 작성 시 혼선을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->