### PR TITLE
refactor: 선입금, 후정산 동시 활성화 제한 검증 제거

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/Event.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/Event.java
@@ -134,7 +134,6 @@ public class Event extends BaseEntity {
             Integer mainEventMaxApplicantCount,
             Integer afterPartyMaxApplicantCount) {
         validatePaymentDisabledWhenAfterPartyDisabled(afterPartyStatus, prePaymentStatus, postPaymentStatus);
-        validatePrePaymentAndPostPayment(prePaymentStatus, postPaymentStatus);
 
         return Event.builder()
                 .name(name)
@@ -158,12 +157,6 @@ public class Event extends BaseEntity {
             UsageStatus afterPartyStatus, UsageStatus prePaymentStatus, UsageStatus postPaymentStatus) {
         if (afterPartyStatus == DISABLED && (prePaymentStatus == ENABLED || postPaymentStatus == ENABLED)) {
             throw new CustomException(EVENT_NOT_CREATABLE_PAYMENT_ENABLED);
-        }
-    }
-
-    private static void validatePrePaymentAndPostPayment(UsageStatus prePaymentStatus, UsageStatus postPaymentStatus) {
-        if (prePaymentStatus == ENABLED && postPaymentStatus == ENABLED) {
-            throw new CustomException(EVENT_NOT_CREATABLE_PAYMENTS_BOTH_ENABLED);
         }
     }
 

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -194,7 +194,6 @@ public enum ErrorCode {
     // Event
     EVENT_NOT_FOUND(NOT_FOUND, "존재하지 않는 이벤트입니다."),
     EVENT_NOT_CREATABLE_PAYMENT_ENABLED(CONFLICT, "뒤풀이 상태가 비활성화된 경우, 선입금 및 후정산 상태도 비활성화 되어야 합니다."),
-    EVENT_NOT_CREATABLE_PAYMENTS_BOTH_ENABLED(CONFLICT, "선입금과 후정산은 동시에 활성화될 수 없습니다."),
     EVENT_NOT_APPLICABLE_NOT_REGULAR_ROLE(CONFLICT, "정회원이 아닌 회원은 이벤트에 신청할 수 없습니다."),
     EVENT_NOT_APPLICABLE_APPLICATION_PERIOD_INVALID(CONFLICT, "이벤트 신청 기간이 아닙니다."),
     EVENT_NOT_APPLICABLE_AFTER_PARTY_NONE(CONFLICT, "뒤풀이가 활성화된 이벤트는 뒤풀이 신청 여부를 NONE으로 설정할 수 없습니다."),

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventTest.java
@@ -38,31 +38,5 @@ public class EventTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessage(EVENT_NOT_CREATABLE_PAYMENT_ENABLED.getMessage());
         }
-
-        @Test
-        void 선입금과_후정산이_둘_다_활성화되면_실패한다() {
-            // given
-            UsageStatus afterPartyStatus = UsageStatus.ENABLED; // 뒤풀이 활성화
-            UsageStatus prePaymentStatus = UsageStatus.ENABLED; // 선입금 활성화
-            UsageStatus postPaymentStatus = UsageStatus.ENABLED; // 후정산 활성화
-
-            // when & then
-            assertThatThrownBy(() -> Event.create(
-                            EVENT_NAME,
-                            VENUE,
-                            EVENT_START_AT,
-                            APPLICATION_DESCRIPTION,
-                            EVENT_APPLICATION_PERIOD,
-                            REGULAR_ROLE_ONLY_STATUS,
-                            afterPartyStatus,
-                            prePaymentStatus,
-                            postPaymentStatus,
-                            RSVP_QUESTION_STATUS,
-                            NOTICE_CONFIRM_QUESTION_STATUS,
-                            MAIN_EVENT_MAX_APPLICATION_COUNT,
-                            AFTER_PARTY_MAX_APPLICATION_COUNT))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(EVENT_NOT_CREATABLE_PAYMENTS_BOTH_ENABLED.getMessage());
-        }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- #1216

## 📌 작업 내용 및 특이사항
- 정책 변경에 따라 검증 제거

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 이벤트 생성 시 선입금과 후정산을 동시에 활성화할 수 있습니다.
  - 애프터파티가 비활성화된 상태에서 결제를 활성화할 수 없다는 검증은 그대로 유지됩니다.
- Tests
  - 선입금과 후정산 동시 활성화 시 실패하던 테스트를 제거하고, 기존 검증 관련 테스트는 유지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->