### PR TITLE
fix: 정회원이 준회원 승급 시도 시 잘못 성공하는 문제

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/domain/Member.java
@@ -144,6 +144,10 @@ public class Member extends BaseEntity {
             throw new CustomException(MEMBER_ALREADY_ASSOCIATE);
         }
 
+        if (!isGuest()) {
+            throw new CustomException(MEMBER_NOT_GUEST);
+        }
+
         associateRequirement.validateAllSatisfied();
     }
 
@@ -219,6 +223,7 @@ public class Member extends BaseEntity {
      * 조건 1 : 기본 회원정보 작성
      * 조건 2 : 재학생 인증
      * 조건 3 : 디스코드 인증
+     * 조건 4 : 멤버가 게스트이어야 함
      */
     public void advanceToAssociate() {
         validateStatusUpdatable();

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode {
     MEMBER_DISCORD_USERNAME_DUPLICATE(CONFLICT, "이미 등록된 디스코드 유저네임입니다."),
     MEMBER_NICKNAME_DUPLICATE(CONFLICT, "이미 사용중인 닉네임입니다."),
     MEMBER_NOT_APPLIED(CONFLICT, "가입신청서를 제출하지 않은 회원입니다."),
+    MEMBER_NOT_GUEST(CONFLICT, "게스트가 아닌 회원입니다."),
     MEMBER_NOT_ASSOCIATE(CONFLICT, "준회원이 아닌 회원입니다."),
 
     // Requirement


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1214

## 📌 작업 내용 및 특이사항
``` java
    /**
     * 준회원 승급 가능 여부를 검증합니다.
     */
    private void validateAssociateAvailable() {
        if (isAssociate()) {
            throw new CustomException(MEMBER_ALREADY_ASSOCIATE);
        }

        if (!isGuest()) {
            throw new CustomException(MEMBER_NOT_GUEST);
        }

        associateRequirement.validateAllSatisfied();
    }

    /**
     * 정회원 승급 가능 여부를 검증합니다.
     */
    private void validateRegularAvailable() {
        if (isRegular()) {
            throw new CustomException(MEMBER_ALREADY_REGULAR);
        }

        if (!isAssociate()) {
            throw new CustomException(MEMBER_NOT_ASSOCIATE);
        }
    }
```

준회원 승급 체크 메서드를 정회원 승급 체크 메서드와 동일한 방식으로 작성했습니다.
처음엔 그냥 `!isGuest()` 하나만 써도 되는거 아닌가? 라고 생각했는데
에러 코드 상세하게 분리하는게 더 낫다고 판단했을거라고 생각해 저도 기존 로직처럼 구현했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 어소시에이트 승급 조건을 명확화하여, 게스트 회원만 승급 요청이 가능하도록 제한되었습니다.
  - 게스트가 아닌 회원이 승급을 시도할 경우 새로운 오류 메시지로 안내됩니다(충돌 상태).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->