### PR TITLE
fix: Period VO가 Hibernate에 의해 빈 객체로 초기화되는 문제

### DIFF
--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -7,8 +7,3 @@ spring:
     url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}
     username: ${MYSQL_USER}
     password: ${MYSQL_PASSWORD}
-  jpa:
-    properties:
-      hibernate:
-        create_empty_composites:
-          enabled: true


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1260

## 📌 작업 내용 및 특이사항
- jpa create_empty_composites 옵션에 의해 VO를 구성하는 두 필드가 null이면 내부 필드가 모두 null인 객체 생성됨
- `@JsonCreator` 에 의해 validation 로직 넣더라도 해당 옵션은 jpa가 엔티티를 초기화할 때 동작하며 jpa는 기본 생성자 사용하므로 validate 로직 우회됨
- 해당 옵션은 hibernate 7에서 제거 예정이며 권장되지 않으므로 제거함 (ref. https://hibernate.atlassian.net/browse/HHH-11936)

## 📝 참고사항
-

## 📚 기타
-
