### PR TITLE
fix: 과제 스터디에서 출석 마감 시간 조회로 인한 NPE 발생

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyTaskDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyTaskDto.java
@@ -29,7 +29,9 @@ public record StudyTaskDto(
                 studySession.getId(),
                 studySession.getPosition(),
                 ATTENDANCE,
-                studySession.getLessonPeriod().getEndDate(),
+                type == StudyType.ASSIGNMENT
+                        ? null
+                        : studySession.getLessonPeriod().getEndDate(),
                 AttendanceStatus.of(studySession, type, isAttended, now),
                 null,
                 null);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1263

## 📌 작업 내용 및 특이사항
- 과제 스터디는 출석체크를 미실시하므로 studySession.getLessonPeriod().getEndDate()가 npe를 발생시키는데 접근하려고 하여 발생하는 문제입니다

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 과제(ASSIGNMENT) 유형의 스터디 태스크에서 마감일이 잘못 표시되던 문제를 수정했습니다. 이제 해당 경우 마감일이 표시되지 않습니다.
  * 그 외 유형의 태스크는 기존대로 수업 기간의 종료 시점이 마감일로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->