### PR TITLE
feat: 뒤풀이 참석자 조회 시 이름 가나다순 정렬 기능 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventParticipationService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventParticipationService.java
@@ -89,7 +89,8 @@ public class EventParticipationService {
         Event event = eventRepository.findById(eventId).orElseThrow(() -> new CustomException(EVENT_NOT_FOUND));
         validateEventEnabledForAfterParty(event);
 
-        List<EventParticipation> eventParticipations = eventParticipationRepository.findAllByEvent(event);
+        List<EventParticipation> eventParticipations =
+                eventParticipationRepository.findAllByEventOrderByParticipantName(event);
 
         long attendedAfterApplyingCount = eventParticipations.stream()
                 .filter(eventParticipation -> eventParticipation

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationRepository.java
@@ -11,6 +11,8 @@ public interface EventParticipationRepository
 
     List<EventParticipation> findAllByEvent(Event event);
 
+    List<EventParticipation> findAllByEventOrderByParticipantName(Event event);
+
     long countByEvent(Event event);
 
     boolean existsByEvent(Event event);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1274

## 📌 작업 내용 및 특이사항
- 프론트 측 요청에 따라 가나다순 정렬 추가했습니다

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **기타**
  * 행사 참가자 목록을 참가자 이름 순서로 정렬하여 표시하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->