### PR TITLE
chore: 도커 컴포즈 네트워크 설정 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,4 +26,3 @@ services:
       - "6379:6379"
     environment:
       - TZ=Asia/Seoul
-    network_mode: host


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1295

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Docker 컴포저 네트워킹 구성을 개선했습니다. 백엔드 및 Redis 서비스가 이제 호스트 네트워킹 대신 기본 브리지 네트워킹을 사용하며, 백엔드 서비스는 포트 80:8080을 통해 노출됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->