### PR TITLE
feat: 와우클래스 API에서 v2 접두사 제거

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/AdminStudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/AdminStudyController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Study - Admin", description = "스터디 어드민 API입니다.")
 @RestController
-@RequestMapping("/v2/admin/studies")
+@RequestMapping("/admin/studies")
 @RequiredArgsConstructor
 public class AdminStudyController {
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/CommonStudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/CommonStudyController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Study - Common", description = "공통 스터디 API입니다.")
 @RestController
-@RequestMapping("/v2/common/studies")
+@RequestMapping("/common/studies")
 @RequiredArgsConstructor
 public class CommonStudyController {
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyAchievementController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyAchievementController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Study Achievement - Mentor", description = "멘토 스터디 우수 스터디원 관리 API입니다.")
 @RestController
-@RequestMapping("/v2/mentor/study-achievements")
+@RequestMapping("/mentor/study-achievements")
 @RequiredArgsConstructor
 public class MentorStudyAchievementController {
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyAnnouncementController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyAnnouncementController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Study Announcement - Mentor", description = "스터디 공지 멘토 API입니다.")
 @RestController
-@RequestMapping("/v2/mentor/study-announcements")
+@RequestMapping("/mentor/study-announcements")
 @RequiredArgsConstructor
 public class MentorStudyAnnouncementController {
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Study - Mentor", description = "스터디 멘토 API입니다.")
 @RestController
-@RequestMapping("/v2/mentor/studies")
+@RequestMapping("/mentor/studies")
 @RequiredArgsConstructor
 public class MentorStudyController {
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyHistoryController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyHistoryController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Study History - Mentor", description = "멘토 스터디 수강 이력 API입니다.")
 @RestController
-@RequestMapping("/v2/mentor/study-histories")
+@RequestMapping("/mentor/study-histories")
 @RequiredArgsConstructor
 public class MentorStudyHistoryController {
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentAssignmentHistoryController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentAssignmentHistoryController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Study Assignment History - Student", description = "학생 과제 제출이력 API입니다.")
 @RestController
-@RequestMapping("/v2/assignment-histories")
+@RequestMapping("/assignment-histories")
 @RequiredArgsConstructor
 public class StudentAssignmentHistoryController {
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentAttendanceController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentAttendanceController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Study Attendance - Student", description = "사용자 스터디 출석체크 API입니다.")
 @RestController
-@RequestMapping("/v2/attendances")
+@RequestMapping("/attendances")
 @RequiredArgsConstructor
 public class StudentAttendanceController {
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyAnnouncementController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyAnnouncementController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Study Announcement - Student", description = "학생 스터디 공지 API입니다.")
 @RestController
-@RequestMapping("/v2/study-announcements")
+@RequestMapping("/study-announcements")
 @RequiredArgsConstructor
 public class StudentStudyAnnouncementController {
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Study - Student", description = "학생 스터디 API입니다.")
 @RestController
-@RequestMapping("/v2/studies")
+@RequestMapping("/studies")
 @RequiredArgsConstructor
 public class StudentStudyController {
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyHistoryController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyHistoryController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Study History - Student", description = "학생 스터디 수강이력 API입니다.")
 @RestController
-@RequestMapping("/v2/study-histories")
+@RequestMapping("/study-histories")
 @RequiredArgsConstructor
 public class StudentStudyHistoryController {
 

--- a/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/WebSecurityConfig.java
@@ -136,9 +136,9 @@ public class WebSecurityConfig {
                 .permitAll()
                 .requestMatchers("/onboarding/**")
                 .authenticated()
-                .requestMatchers("/admin/**", "/v2/admin/**")
+                .requestMatchers("/admin/**")
                 .hasRole("ADMIN")
-                .requestMatchers("/mentor/**", "/v2/mentor/**")
+                .requestMatchers("/mentor/**")
                 .hasAnyRole("MENTOR", "ADMIN")
                 .anyRequest()
                 .authenticated());


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1294

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * API 엔드포인트 경로가 간결하게 업데이트되었습니다
  * 모든 API의 "/v2/" 접두사가 제거되었습니다 (예: "/v2/studies" → "/studies")
  * 영향을 받는 엔드포인트: 학습, 관리자, 멘토, 학생 관련 API
  * API의 기능 및 동작은 변경되지 않습니다

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->