### PR TITLE
fix: 발급된 쿠폰 조회 시 잘못된 엔티티 필드 참조

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/dao/IssuedCouponQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/dao/IssuedCouponQueryMethod.java
@@ -14,7 +14,7 @@ public interface IssuedCouponQueryMethod {
     }
 
     default BooleanExpression eqMemberName(String memberName) {
-        return memberName != null ? issuedCoupon.coupon.name.containsIgnoreCase(memberName) : null;
+        return memberName != null ? issuedCoupon.member.name.containsIgnoreCase(memberName) : null;
     }
 
     default BooleanExpression eqMember(Member member) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1334

## 📌 작업 내용 및 특이사항
- 받은 건 멤버 이름인데 쿠폰 이름과 일치하는게 있는지 검색하고 있었음

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 발급된 쿠폰 조회 시 회원 이름 필터링이 올바르게 작동하도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->