### PR TITLE
chore: hibernate default_batch_fetch_size 지정

### DIFF
--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -7,3 +7,7 @@ spring:
     url: jdbc:postgresql://${POSTGRESQL_HOST}:${POSTGRESQL_PORT}/${POSTGRESQL_DATABASE}
     username: ${POSTGRESQL_USER}
     password: ${POSTGRESQL_PASSWORD}
+  jpa:
+    properties:
+      hibernate:
+        default_batch_fetch_size: ${JPA_BATCH_FETCH_SIZE:1000}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1285

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * JPA Hibernate 데이터베이스 배치 페치 크기 설정을 추가했습니다. 환경 변수를 통해 기본값 1000으로 구성되며, 데이터베이스 성능을 최적화합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->