### PR TITLE
fix: 스터디 시작일 조회 시 발생하는 NPE 해결

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/Study.java
@@ -220,9 +220,9 @@ public class Study extends BaseEntity {
         return studySessions.stream()
                 .filter(studySession -> studySession.getPosition() == 1)
                 .findFirst()
-                .map(studySession -> type.isLive()
-                        ? studySession.getLessonPeriod().getStartDate()
-                        : studySession.getAssignmentPeriod().getStartDate())
+                .map(studySession ->
+                        type.isLive() ? studySession.getLessonPeriod() : studySession.getAssignmentPeriod())
+                .map(Period::getStartDate)
                 .orElse(null);
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1339

## 📌 작업 내용 및 특이사항
- 아래 코드에서 getLessonPeriod나 getAssignmentPeriod가 null일 때(아직 상세정보를 입력하지 않았을 때)  getStartDate 호출하면서 npe가 발생합니다
```java
.map(studySession -> type.isLive()
                        ? studySession.getLessonPeriod().getStartDate()
                        : studySession.getAssignmentPeriod().getStartDate())
```

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 개설 날짜 조회 로직을 개선하여 코드 가독성을 향상했습니다. 기능적인 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->