### PR TITLE
fix: 이벤트 참여자 조회 시 탈퇴한 회원이 유발하는 문제 해결

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/ParticipantRole.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/ParticipantRole.java
@@ -40,7 +40,7 @@ public enum ParticipantRole {
         boolean memberExists = member != null;
         boolean participationMemberExists = participation.getMemberId() != null;
 
-        if (memberExists != participationMemberExists) {
+        if (memberExists && !participationMemberExists) {
             throw new CustomException(PARTICIPANT_ROLE_NOT_CREATABLE_BOTH_EXISTENCE_MISMATCH);
         }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/ParticipantRoleTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/ParticipantRoleTest.java
@@ -72,18 +72,6 @@ class ParticipantRoleTest {
         }
 
         @Test
-        void 회원이_null이고_참여정보의_멤버_ID가_존재할때_예외를_발생시킨다() {
-            // given
-            Member ignored = fixtureHelper.createRegularMember(1L);
-            EventParticipation participationWithRegistered = createEventParticipation(ignored);
-
-            // when & then
-            assertThatThrownBy(() -> ParticipantRole.of(participationWithRegistered, null))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(PARTICIPANT_ROLE_NOT_CREATABLE_BOTH_EXISTENCE_MISMATCH.getMessage());
-        }
-
-        @Test
         void 회원이_존재하지만_참여정보의_멤버_ID가_null일때_예외를_발생시킨다() {
             // given
             Member registeredRegularMember = fixtureHelper.createRegularMember(1L);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1342

## 📌 작업 내용 및 특이사항
- 신청자 중 탈퇴한 회원이 있어서 신청 내역에는 길동이가 있는데 멤버 테이블에서는 길동이를 찾을 수가 없어서 발생한 예외입니다.
- leftjoin을 innerjoin으로 바꿔서 해결하려고 했으나 이렇게 하면 비회원들이 조회에 포함되지 않으므로 leftjoin으로 롤백했습니다.
- ParticipantRole.validateParticipationAndMember의 첫번째 if문(memberExists와 participationMemberExists가 false, true 조합)에서 탈퇴한 회원이 걸려버립니다. 
true, false 조합일 때만 데이터에 진짜 문제가 생긴 것이므로 예외를 던지는 것이 맞습니다.


## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 이벤트 신청자 조회 시 회원 정보가 없는 레코드를 제외하도록 개선하여 데이터 정확성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->