### PR TITLE
refactor: QueryDsl 쿼리 메서드 네이밍 정리

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipService.java
@@ -62,7 +62,7 @@ public class MembershipService {
                 .findById(recruitmentRoundId)
                 .orElseThrow(() -> new CustomException(RECRUITMENT_ROUND_NOT_FOUND));
 
-        boolean isMembershipDuplicate = membershipRepository.existsByMemberAndRecruitmentWithSatisfiedRequirements(
+        boolean isMembershipDuplicate = membershipRepository.existsSatisfiedMembershipByRecruitment(
                 currentMember, recruitmentRound.getRecruitment());
 
         membershipValidator.validateMembershipSubmit(currentMember, recruitmentRound, isMembershipDuplicate);

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipCustomRepository.java
@@ -5,5 +5,5 @@ import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 
 public interface MembershipCustomRepository {
 
-    boolean existsByMemberAndRecruitmentWithSatisfiedRequirements(Member member, Recruitment recruitment);
+    boolean existsSatisfiedMembershipByRecruitment(Member member, Recruitment recruitment);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/dao/MembershipCustomRepositoryImpl.java
@@ -16,7 +16,7 @@ public class MembershipCustomRepositoryImpl implements MembershipCustomRepositor
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public boolean existsByMemberAndRecruitmentWithSatisfiedRequirements(Member member, Recruitment recruitment) {
+    public boolean existsSatisfiedMembershipByRecruitment(Member member, Recruitment recruitment) {
         Integer fetchOne = queryFactory
                 .selectOne()
                 .from(membership)


### PR DESCRIPTION
## 🌱 관련 이슈
- close #860

## 📌 작업 내용 및 특이사항
- 잔뜩 있을 줄 알고 미뤘는데 하나밖에 없네요.
- data jpa 사용하지 않는 메서드에서 굳이 장황한 메서드명을 유지할 필요가 없을 것 같아서 의도 파악이 쉬운 이름으로 수정했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **리팩터링**
  * 멤버십 검증 로직의 내부 구현을 개선하여 코드 품질과 유지보수성을 향상시켰습니다. 사용자 기능에는 변화가 없는 백엔드 최적화 작업입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->