### PR TITLE
refactor: 무료 주문 처리 로직 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipEventHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/membership/application/MembershipEventHandler.java
@@ -2,7 +2,6 @@ package com.gdschongik.gdsc.domain.membership.application;
 
 import com.gdschongik.gdsc.domain.order.domain.event.OrderCanceledEvent;
 import com.gdschongik.gdsc.domain.order.domain.event.OrderCompletedEvent;
-import com.gdschongik.gdsc.domain.order.domain.event.OrderCreatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.modulith.events.ApplicationModuleListener;
@@ -14,18 +13,6 @@ import org.springframework.stereotype.Component;
 public class MembershipEventHandler {
 
     private final MembershipService membershipService;
-
-    @ApplicationModuleListener
-    public void handleOrderCreatedEvent(OrderCreatedEvent orderCreatedEvent) {
-        log.info(
-                "[MembershipEventHandler] 주문 생성 이벤트 수신: nanoId={}, isFree={}",
-                orderCreatedEvent.nanoId(),
-                orderCreatedEvent.isFree());
-        // TODO: 히스토리 파악 후 내부에서 isFree 필터링하도록 변경
-        if (orderCreatedEvent.isFree()) {
-            membershipService.verifyPaymentStatus(orderCreatedEvent.nanoId());
-        }
-    }
 
     @ApplicationModuleListener
     public void handleOrderCompletedEvent(OrderCompletedEvent orderCompletedEvent) {

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
@@ -7,7 +7,6 @@ import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.membership.domain.Membership;
 import com.gdschongik.gdsc.domain.order.domain.event.OrderCanceledEvent;
 import com.gdschongik.gdsc.domain.order.domain.event.OrderCompletedEvent;
-import com.gdschongik.gdsc.domain.order.domain.event.OrderCreatedEvent;
 import com.gdschongik.gdsc.domain.order.domain.service.OrderValidator;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.annotation.Nullable;
@@ -83,8 +82,6 @@ public class Order extends BaseEntity {
         this.recruitmentRoundId = recruitmentRoundId;
         this.issuedCouponId = issuedCouponId;
         this.moneyInfo = moneyInfo;
-
-        registerEvent(new OrderCreatedEvent(nanoId, isFree()));
     }
 
     /**

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/Order.java
@@ -104,10 +104,15 @@ public class Order extends BaseEntity {
                 .build();
     }
 
+    /**
+     * 무료 주문을 생성합니다.
+     * 결제가 필요하지 않으므로 주문 완료 상태로 생성됩니다.
+     * 주문 완료 상태로 생성되므로 주문 완료 이벤트 {@link OrderCompletedEvent} 를 함께 발행합니다.
+     */
     public static Order createFree(
             String nanoId, MoneyInfo moneyInfo, Membership membership, @Nullable IssuedCoupon issuedCoupon) {
         validateFreeOrder(moneyInfo);
-        return Order.builder()
+        Order order = Order.builder()
                 .status(OrderStatus.COMPLETED)
                 .nanoId(nanoId)
                 .memberId(membership.getMember().getId())
@@ -116,6 +121,10 @@ public class Order extends BaseEntity {
                 .issuedCouponId(issuedCoupon != null ? issuedCoupon.getId() : null)
                 .moneyInfo(moneyInfo)
                 .build();
+
+        order.registerEvent(new OrderCompletedEvent(nanoId));
+
+        return order;
     }
 
     private static void validateFreeOrder(MoneyInfo moneyInfo) {

--- a/src/main/java/com/gdschongik/gdsc/domain/order/domain/event/OrderCreatedEvent.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/domain/event/OrderCreatedEvent.java
@@ -1,3 +1,0 @@
-package com.gdschongik.gdsc.domain.order.domain.event;
-
-public record OrderCreatedEvent(String nanoId, boolean isFree) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1376

## 📌 작업 내용 및 특이사항
- 기존
  - 주문 생성 -> `OrderCreatedEvent` 발행 -> `handleOrderCreatedEvent` 에서 **무료 주문**에 한해 `verifyPaymentStatus`
  - 주문 완료 (사실상 **임시(유료) 주문**만 **완료** 라는 행위가 가능) -> `OrderCompletedEvent` 발행 -> `handleOrderCompletedEvent` 에서 `verifyPaymentStatus`
  -  결과적으로 무료, 임시 주문 모두 verifyPaymentStatus 호출이 목적 
  - 그렇다면 애초에 무료 주문이 생성될 때 OrderCompletedEvent를 발행하면 되지 않는가?
- 따라서 다음과 같이 변경
  - **무료 주문** 생성 -> `OrderCompletedEvent` 발행 -> `handleOrderCompletedEvent` 에서 `verifyPaymentStatus`
  - 주문 완료 (사실상 **임시(유료) 주문**만 **완료** 라는 행위가 가능) -> `OrderCompletedEvent` 발행 -> `handleOrderCompletedEvent` 에서 `verifyPaymentStatus`

결과적으로 핸들러 로직에서 **무료 주문 구분**이라는 비즈니스 로직을 수행하지 않습니다.

## 📝 참고사항
- 이런 방안도 고민할 수 있을 것 같습니다. 
  - 기존 및 변경안 모두 `createFree`가 무료 주문 생성 및 주문 완료를 동시에 수행합니다.
  - 임시(유료) 주문만 가능한 `Order.complete` 메서드를 `completePending`, `completeFree` 로 분리하여, 주문 완료를 이쪽 메서드로 분리하는 방향은 어떨까요? 이러면 `OrderCompletedEvent` 발행 책임도 `completeFree` 메서드쪽으로 옮길 수 있을 것 같네요.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 주문 취소 시 결제 상태가 자동으로 철회됩니다.
* 무료 주문의 상태 처리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->