### PR TITLE
fix: 진행중인 학기가 없을 때 예외가 아니라 빈 리스트를 반환하도록 개선

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyAnnouncementService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyAnnouncementService.java
@@ -1,15 +1,11 @@
 package com.gdschongik.gdsc.domain.study.application;
 
-import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
-
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.study.dao.StudyAnnouncementRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;
+import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyAnnouncement;
 import com.gdschongik.gdsc.domain.study.dto.response.StudyAnnouncementResponse;
-import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.util.MemberUtil;
 import jakarta.annotation.Nullable;
 import java.time.LocalDateTime;
@@ -23,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class StudentStudyAnnouncementService {
 
     private final MemberUtil memberUtil;
-    private final RecruitmentRepository recruitmentRepository;
     private final StudyAnnouncementRepository studyAnnouncementRepository;
     private final StudyHistoryRepository studyHistoryRepository;
 
@@ -40,13 +35,8 @@ public class StudentStudyAnnouncementService {
         Member currentMember = memberUtil.getCurrentMember();
         LocalDateTime now = LocalDateTime.now();
 
-        Recruitment recruitment = recruitmentRepository
-                .findCurrentRecruitment(now)
-                .orElseThrow(() -> new CustomException(RECRUITMENT_NOT_FOUND));
-
-        List<Long> currentStudyIds = studyHistoryRepository.findAllByStudent(currentMember).stream()
-                .filter(studyHistory -> studyHistory.getStudy().getSemester().equals(recruitment.getSemester()))
-                .map(studyHistory -> studyHistory.getStudy().getId())
+        List<Long> currentStudyIds = studyHistoryRepository.findCurrentStudiesByMember(currentMember, now).stream()
+                .map(Study::getId)
                 .toList();
 
         List<StudyAnnouncement> studyAnnouncements =

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyAnnouncementService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyAnnouncementService.java
@@ -35,7 +35,7 @@ public class StudentStudyAnnouncementService {
         Member currentMember = memberUtil.getCurrentMember();
         LocalDateTime now = LocalDateTime.now();
 
-        List<Long> currentStudyIds = studyHistoryRepository.findCurrentStudiesByMember(currentMember, now).stream()
+        List<Long> currentStudyIds = studyHistoryRepository.findMyCurrentStudiesByMember(currentMember, now).stream()
                 .map(Study::getId)
                 .toList();
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
@@ -108,10 +108,12 @@ public class StudentStudyService {
         Member currentMember = memberUtil.getCurrentMember();
         LocalDateTime now = LocalDateTime.now();
 
-        Recruitment recruitment = recruitmentRepository
-                .findCurrentRecruitment(now)
-                .orElseThrow(() -> new CustomException(RECRUITMENT_NOT_FOUND));
+        Optional<Recruitment> optionalRecruitment = recruitmentRepository.findCurrentRecruitment(now);
+        if (optionalRecruitment.isEmpty()) {
+            return List.of();
+        }
 
+        Recruitment recruitment = optionalRecruitment.get();
         List<Study> currentStudies = studyHistoryRepository.findAllByStudent(currentMember).stream()
                 .map(StudyHistory::getStudy)
                 .filter(study -> study.getSemester().equals(recruitment.getSemester()))

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
@@ -19,6 +19,8 @@ import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -71,14 +73,14 @@ public class StudentStudyService {
         Member currentMember = memberUtil.getCurrentMember();
         LocalDateTime now = LocalDateTime.now();
 
-        Recruitment recruitment = recruitmentRepository
+        return recruitmentRepository
                 .findCurrentRecruitment(now)
-                .orElseThrow(() -> new CustomException(RECRUITMENT_NOT_FOUND));
-
-        return studyHistoryRepository.findAllByStudent(currentMember).stream()
-                .filter(studyHistory -> studyHistory.getStudy().getSemester().equals(recruitment.getSemester()))
-                .map(studyHistory -> StudySimpleDto.from(studyHistory.getStudy()))
-                .toList();
+                .map(recruitment -> studyHistoryRepository.findAllByStudent(currentMember).stream()
+                        .filter(studyHistory ->
+                                studyHistory.getStudy().getSemester().equals(recruitment.getSemester()))
+                        .map(studyHistory -> StudySimpleDto.from(studyHistory.getStudy()))
+                        .toList())
+                .orElse(List.of());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
@@ -68,7 +68,7 @@ public class StudentStudyService {
         Member currentMember = memberUtil.getCurrentMember();
         LocalDateTime now = LocalDateTime.now();
 
-        return studyHistoryRepository.findCurrentStudiesByMember(currentMember, now).stream()
+        return studyHistoryRepository.findMyCurrentStudiesByMember(currentMember, now).stream()
                 .map(StudySimpleDto::from)
                 .toList();
     }
@@ -98,7 +98,7 @@ public class StudentStudyService {
         Member currentMember = memberUtil.getCurrentMember();
         LocalDateTime now = LocalDateTime.now();
 
-        List<Study> currentStudies = studyHistoryRepository.findCurrentStudiesByMember(currentMember, now);
+        List<Study> currentStudies = studyHistoryRepository.findMyCurrentStudiesByMember(currentMember, now);
 
         List<StudyTodoResponse> response = new ArrayList<>();
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/application/StudentStudyService.java
@@ -3,8 +3,6 @@ package com.gdschongik.gdsc.domain.study.application;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
-import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
-import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.study.dao.AssignmentHistoryRepository;
 import com.gdschongik.gdsc.domain.study.dao.AttendanceRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;
@@ -19,8 +17,6 @@ import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -36,7 +32,6 @@ public class StudentStudyService {
     private final AttendanceRepository attendanceRepository;
     private final AssignmentHistoryRepository assignmentHistoryRepository;
     private final StudyHistoryRepository studyHistoryRepository;
-    private final RecruitmentRepository recruitmentRepository;
 
     @Transactional(readOnly = true)
     public StudyDashboardResponse getMyStudyDashboard(Long studyId) {
@@ -73,14 +68,9 @@ public class StudentStudyService {
         Member currentMember = memberUtil.getCurrentMember();
         LocalDateTime now = LocalDateTime.now();
 
-        return recruitmentRepository
-                .findCurrentRecruitment(now)
-                .map(recruitment -> studyHistoryRepository.findAllByStudent(currentMember).stream()
-                        .filter(studyHistory ->
-                                studyHistory.getStudy().getSemester().equals(recruitment.getSemester()))
-                        .map(studyHistory -> StudySimpleDto.from(studyHistory.getStudy()))
-                        .toList())
-                .orElse(List.of());
+        return studyHistoryRepository.findCurrentStudiesByMember(currentMember, now).stream()
+                .map(StudySimpleDto::from)
+                .toList();
     }
 
     @Transactional(readOnly = true)
@@ -108,16 +98,7 @@ public class StudentStudyService {
         Member currentMember = memberUtil.getCurrentMember();
         LocalDateTime now = LocalDateTime.now();
 
-        Optional<Recruitment> optionalRecruitment = recruitmentRepository.findCurrentRecruitment(now);
-        if (optionalRecruitment.isEmpty()) {
-            return List.of();
-        }
-
-        Recruitment recruitment = optionalRecruitment.get();
-        List<Study> currentStudies = studyHistoryRepository.findAllByStudent(currentMember).stream()
-                .map(StudyHistory::getStudy)
-                .filter(study -> study.getSemester().equals(recruitment.getSemester()))
-                .toList();
+        List<Study> currentStudies = studyHistoryRepository.findCurrentStudiesByMember(currentMember, now);
 
         List<StudyTodoResponse> response = new ArrayList<>();
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryCustomRepository.java
@@ -1,7 +1,9 @@
 package com.gdschongik.gdsc.domain.study.dao;
 
+import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +15,8 @@ public interface StudyHistoryCustomRepository {
     List<StudyHistory> findAllByStudyIdAndStudentIds(Long studyId, List<Long> studentIds);
 
     List<StudyHistory> findAllByStudy(Study study);
+
+    List<Study> findCurrentStudiesByMember(Member member, LocalDateTime now);
 
     Page<StudyHistory> findByStudyId(Long studyId, Pageable pageable);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryCustomRepository.java
@@ -16,7 +16,7 @@ public interface StudyHistoryCustomRepository {
 
     List<StudyHistory> findAllByStudy(Study study);
 
-    List<Study> findCurrentStudiesByMember(Member member, LocalDateTime now);
+    List<Study> findMyCurrentStudiesByMember(Member member, LocalDateTime now);
 
     Page<StudyHistory> findByStudyId(Long studyId, Pageable pageable);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryCustomRepositoryImpl.java
@@ -1,13 +1,16 @@
 package com.gdschongik.gdsc.domain.study.dao;
 
 import static com.gdschongik.gdsc.domain.member.domain.QMember.*;
+import static com.gdschongik.gdsc.domain.recruitment.domain.QRecruitment.*;
 import static com.gdschongik.gdsc.domain.study.domain.QStudyHistory.*;
 
+import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -47,6 +50,17 @@ public class StudyHistoryCustomRepositoryImpl implements StudyHistoryCustomRepos
     }
 
     @Override
+    public List<Study> findCurrentStudiesByMember(Member member, LocalDateTime now) {
+        return queryFactory
+                .select(studyHistory.study)
+                .from(studyHistory)
+                .innerJoin(recruitment)
+                .where(eqMember(member), isWithinSemesterPeriod(now), eqStudySemesterToRecruitmentSemester())
+                .distinct()
+                .fetch();
+    }
+
+    @Override
     public Page<StudyHistory> findByStudyId(Long studyId, Pageable pageable) {
         List<StudyHistory> fetch = queryFactory
                 .selectFrom(studyHistory)
@@ -68,5 +82,22 @@ public class StudyHistoryCustomRepositoryImpl implements StudyHistoryCustomRepos
 
     private BooleanExpression eqStudyId(Long studyId) {
         return studyHistory.study.id.eq(studyId);
+    }
+
+    private BooleanExpression eqMember(Member member) {
+        return studyHistory.student.eq(member);
+    }
+
+    private BooleanExpression isWithinSemesterPeriod(LocalDateTime now) {
+        return recruitment.semesterPeriod.startDate.loe(now).and(recruitment.semesterPeriod.endDate.goe(now));
+    }
+
+    private BooleanExpression eqStudySemesterToRecruitmentSemester() {
+        return studyHistory
+                .study
+                .semester
+                .academicYear
+                .eq(recruitment.semester.academicYear)
+                .and(studyHistory.study.semester.semesterType.eq(recruitment.semester.semesterType));
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryCustomRepositoryImpl.java
@@ -51,7 +51,7 @@ public class StudyHistoryCustomRepositoryImpl implements StudyHistoryCustomRepos
     }
 
     @Override
-    public List<Study> findCurrentStudiesByMember(Member member, LocalDateTime now) {
+    public List<Study> findMyCurrentStudiesByMember(Member member, LocalDateTime now) {
         return queryFactory
                 .select(studyHistory.study)
                 .from(studyHistory)

--- a/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/dao/StudyHistoryCustomRepositoryImpl.java
@@ -8,6 +8,7 @@ import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.study.domain.Study;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
@@ -54,8 +55,7 @@ public class StudyHistoryCustomRepositoryImpl implements StudyHistoryCustomRepos
         return queryFactory
                 .select(studyHistory.study)
                 .from(studyHistory)
-                .innerJoin(recruitment)
-                .where(eqMember(member), isWithinSemesterPeriod(now), eqStudySemesterToRecruitmentSemester())
+                .where(eqMember(member), isInCurrentRecruitment(now))
                 .distinct()
                 .fetch();
     }
@@ -88,16 +88,22 @@ public class StudyHistoryCustomRepositoryImpl implements StudyHistoryCustomRepos
         return studyHistory.student.eq(member);
     }
 
+    private BooleanExpression isInCurrentRecruitment(LocalDateTime now) {
+        return JPAExpressions.selectOne()
+                .from(recruitment)
+                .where(isWithinSemesterPeriod(now), eqStudySemesterToRecruitmentSemester())
+                .exists();
+    }
+
     private BooleanExpression isWithinSemesterPeriod(LocalDateTime now) {
         return recruitment.semesterPeriod.startDate.loe(now).and(recruitment.semesterPeriod.endDate.goe(now));
     }
 
     private BooleanExpression eqStudySemesterToRecruitmentSemester() {
-        return studyHistory
-                .study
+        return recruitment
                 .semester
                 .academicYear
-                .eq(recruitment.semester.academicYear)
-                .and(studyHistory.study.semester.semesterType.eq(recruitment.semester.semesterType));
+                .eq(studyHistory.study.semester.academicYear)
+                .and(recruitment.semester.semesterType.eq(studyHistory.study.semester.semesterType));
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyAnnouncementServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyAnnouncementServiceTest.java
@@ -32,10 +32,10 @@ class StudentStudyAnnouncementServiceTest extends IntegrationTest {
             logoutAndReloginAs(member.getId(), MemberRole.ASSOCIATE);
 
             // when
-            List<StudyAnnouncementResponse> response = studentStudyAnnouncementService.getStudiesAnnouncements();
+            List<StudyAnnouncementResponse> result = studentStudyAnnouncementService.getStudiesAnnouncements();
 
             // then
-            assertThat(response).isEmpty();
+            assertThat(result).isEmpty();
         }
 
         @Test
@@ -59,14 +59,14 @@ class StudentStudyAnnouncementServiceTest extends IntegrationTest {
             createStudyAnnouncement("이전 공지", DESCRIPTION_LINK, previousStudy);
 
             // when
-            List<StudyAnnouncementResponse> response = studentStudyAnnouncementService.getStudiesAnnouncements();
+            List<StudyAnnouncementResponse> result = studentStudyAnnouncementService.getStudiesAnnouncements();
 
             // then
-            assertThat(response).hasSize(1);
-            assertThat(response.get(0).study().studyId()).isEqualTo(currentStudy.getId());
-            assertThat(response.get(0).studyAnnouncement().studyAnnouncementId())
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).study().studyId()).isEqualTo(currentStudy.getId());
+            assertThat(result.get(0).studyAnnouncement().studyAnnouncementId())
                     .isEqualTo(currentAnnouncement.getId());
-            assertThat(response.get(0).studyAnnouncement().title()).isEqualTo("현재 공지");
+            assertThat(result.get(0).studyAnnouncement().title()).isEqualTo("현재 공지");
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyAnnouncementServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyAnnouncementServiceTest.java
@@ -50,13 +50,13 @@ class StudentStudyAnnouncementServiceTest extends IntegrationTest {
 
             createRecruitment(currentSemester, now.minusDays(1), now.plusDays(1));
 
-            Study currentStudy = createStudy("현재 스터디", currentSemester, member);
-            Study previousStudy = createStudy("이전 스터디", previousSemester, member);
+            Study currentStudy = createStudy("현재 학기 스터디", currentSemester, member);
+            Study previousStudy = createStudy("이전 학기 스터디", previousSemester, member);
             createStudyHistory(member, currentStudy);
             createStudyHistory(member, previousStudy);
 
-            StudyAnnouncement currentAnnouncement = createStudyAnnouncement("현재 공지", DESCRIPTION_LINK, currentStudy);
-            createStudyAnnouncement("이전 공지", DESCRIPTION_LINK, previousStudy);
+            StudyAnnouncement currentAnnouncement = createStudyAnnouncement("현재 학기 공지", DESCRIPTION_LINK, currentStudy);
+            createStudyAnnouncement("이전 학기 공지", DESCRIPTION_LINK, previousStudy);
 
             // when
             List<StudyAnnouncementResponse> result = studentStudyAnnouncementService.getStudiesAnnouncements();
@@ -66,7 +66,7 @@ class StudentStudyAnnouncementServiceTest extends IntegrationTest {
             assertThat(result.get(0).study().studyId()).isEqualTo(currentStudy.getId());
             assertThat(result.get(0).studyAnnouncement().studyAnnouncementId())
                     .isEqualTo(currentAnnouncement.getId());
-            assertThat(result.get(0).studyAnnouncement().title()).isEqualTo("현재 공지");
+            assertThat(result.get(0).studyAnnouncement().title()).isEqualTo("현재 학기 공지");
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyAnnouncementServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyAnnouncementServiceTest.java
@@ -1,0 +1,72 @@
+package com.gdschongik.gdsc.domain.study.application;
+
+import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.vo.Semester;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.domain.study.domain.StudyAnnouncement;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyAnnouncementResponse;
+import com.gdschongik.gdsc.helper.IntegrationTest;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class StudentStudyAnnouncementServiceTest extends IntegrationTest {
+
+    @Autowired
+    StudentStudyAnnouncementService studentStudyAnnouncementService;
+
+    @Nested
+    class 내_모든_스터디_공지를_조회할때 {
+
+        @Test
+        void 진행중인_학기가_없으면_빈_리스트를_반환한다() {
+            // given
+            Member member = createAssociateMember();
+            logoutAndReloginAs(member.getId(), MemberRole.ASSOCIATE);
+
+            // when
+            List<StudyAnnouncementResponse> response = studentStudyAnnouncementService.getStudiesAnnouncements();
+
+            // then
+            assertThat(response).isEmpty();
+        }
+
+        @Test
+        void 진행중인_학기와_일치하는_스터디의_공지들만_반환한다() {
+            // given
+            Member member = createAssociateMember();
+            logoutAndReloginAs(member.getId(), MemberRole.ASSOCIATE);
+
+            LocalDateTime now = LocalDateTime.now();
+            Semester currentSemester = Semester.of(2026, SemesterType.FIRST);
+            Semester previousSemester = Semester.of(2025, SemesterType.SECOND);
+
+            createRecruitment(currentSemester, now.minusDays(1), now.plusDays(1));
+
+            Study currentStudy = createStudy("현재 스터디", currentSemester, member);
+            Study previousStudy = createStudy("이전 스터디", previousSemester, member);
+            createStudyHistory(member, currentStudy);
+            createStudyHistory(member, previousStudy);
+
+            StudyAnnouncement currentAnnouncement = createStudyAnnouncement("현재 공지", DESCRIPTION_LINK, currentStudy);
+            createStudyAnnouncement("이전 공지", DESCRIPTION_LINK, previousStudy);
+
+            // when
+            List<StudyAnnouncementResponse> response = studentStudyAnnouncementService.getStudiesAnnouncements();
+
+            // then
+            assertThat(response).hasSize(1);
+            assertThat(response.get(0).study().studyId()).isEqualTo(currentStudy.getId());
+            assertThat(response.get(0).studyAnnouncement().studyAnnouncementId())
+                    .isEqualTo(currentAnnouncement.getId());
+            assertThat(response.get(0).studyAnnouncement().title()).isEqualTo("현재 공지");
+        }
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyAnnouncementServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyAnnouncementServiceTest.java
@@ -64,8 +64,7 @@ class StudentStudyAnnouncementServiceTest extends IntegrationTest {
             // then
             assertThat(result).hasSize(1);
             assertThat(result.get(0).study().studyId()).isEqualTo(currentStudy.getId());
-            assertThat(result.get(0).studyAnnouncement().studyAnnouncementId())
-                    .isEqualTo(currentAnnouncement.getId());
+            assertThat(result.get(0).studyAnnouncement().studyAnnouncementId()).isEqualTo(currentAnnouncement.getId());
             assertThat(result.get(0).studyAnnouncement().title()).isEqualTo("현재 학기 공지");
         }
     }

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyAnnouncementServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyAnnouncementServiceTest.java
@@ -23,7 +23,7 @@ class StudentStudyAnnouncementServiceTest extends IntegrationTest {
     StudentStudyAnnouncementService studentStudyAnnouncementService;
 
     @Nested
-    class 내_모든_스터디_공지를_조회할때 {
+    class 내가_수강중인_모든_스터디_공지를_조회할때 {
 
         @Test
         void 진행중인_학기가_없으면_빈_리스트를_반환한다() {

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyServiceTest.java
@@ -34,10 +34,10 @@ class StudentStudyServiceTest extends IntegrationTest {
             logoutAndReloginAs(member.getId(), MemberRole.ASSOCIATE);
 
             // when
-            List<StudySimpleDto> response = studentStudyService.getMyCurrentStudies();
+            List<StudySimpleDto> result = studentStudyService.getMyCurrentStudies();
 
             // then
-            assertThat(response).isEmpty();
+            assertThat(result).isEmpty();
         }
 
         @Test
@@ -58,11 +58,11 @@ class StudentStudyServiceTest extends IntegrationTest {
             createStudyHistory(member, previousStudy);
 
             // when
-            List<StudySimpleDto> response = studentStudyService.getMyCurrentStudies();
+            List<StudySimpleDto> result = studentStudyService.getMyCurrentStudies();
 
             // then
-            assertThat(response).extracting(StudySimpleDto::studyId).containsExactly(currentStudy.getId());
-            assertThat(response).extracting(StudySimpleDto::studyName).containsExactly("현재 스터디");
+            assertThat(result).extracting(StudySimpleDto::studyId).containsExactly(currentStudy.getId());
+            assertThat(result).extracting(StudySimpleDto::studyName).containsExactly("현재 스터디");
         }
     }
 
@@ -76,10 +76,10 @@ class StudentStudyServiceTest extends IntegrationTest {
             logoutAndReloginAs(member.getId(), MemberRole.ASSOCIATE);
 
             // when
-            List<StudyTodoResponse> response = studentStudyService.getMyStudiesTodos();
+            List<StudyTodoResponse> result = studentStudyService.getMyStudiesTodos();
 
             // then
-            assertThat(response).isEmpty();
+            assertThat(result).isEmpty();
         }
 
         @Test
@@ -102,14 +102,14 @@ class StudentStudyServiceTest extends IntegrationTest {
             updateSessionPeriodToNow(previousStudy, now);
 
             // when
-            List<StudyTodoResponse> response = studentStudyService.getMyStudiesTodos();
+            List<StudyTodoResponse> result = studentStudyService.getMyStudiesTodos();
 
             // then
-            assertThat(response).hasSize(2);
-            assertThat(response)
+            assertThat(result).hasSize(2);
+            assertThat(result)
                     .extracting(studyTodoResponse -> studyTodoResponse.study().studyId())
                     .containsOnly(currentStudy.getId());
-            assertThat(response)
+            assertThat(result)
                     .extracting(StudyTodoResponse::todoType)
                     .containsExactlyInAnyOrder(
                             StudyTodoResponse.StudyTodoType.ATTENDANCE, StudyTodoResponse.StudyTodoType.ASSIGNMENT);

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyServiceTest.java
@@ -52,8 +52,8 @@ class StudentStudyServiceTest extends IntegrationTest {
 
             createRecruitment(currentSemester, now.minusDays(1), now.plusDays(1));
 
-            Study currentStudy = createStudy("현재 스터디", currentSemester, member);
-            Study previousStudy = createStudy("이전 스터디", previousSemester, member);
+            Study currentStudy = createStudy("현재 학기 스터디", currentSemester, member);
+            Study previousStudy = createStudy("이전 학기 스터디", previousSemester, member);
             createStudyHistory(member, currentStudy);
             createStudyHistory(member, previousStudy);
 
@@ -62,7 +62,7 @@ class StudentStudyServiceTest extends IntegrationTest {
 
             // then
             assertThat(result).extracting(StudySimpleDto::studyId).containsExactly(currentStudy.getId());
-            assertThat(result).extracting(StudySimpleDto::studyName).containsExactly("현재 스터디");
+            assertThat(result).extracting(StudySimpleDto::studyName).containsExactly("현재 학기 스터디");
         }
     }
 
@@ -94,8 +94,8 @@ class StudentStudyServiceTest extends IntegrationTest {
 
             createRecruitment(currentSemester, now.minusDays(1), now.plusDays(1));
 
-            Study currentStudy = createStudy("현재 스터디", currentSemester, member);
-            Study previousStudy = createStudy("이전 스터디", previousSemester, member);
+            Study currentStudy = createStudy("현재 학기 스터디", currentSemester, member);
+            Study previousStudy = createStudy("이전 학기 스터디", previousSemester, member);
             createStudyHistory(member, currentStudy);
             createStudyHistory(member, previousStudy);
             updateSessionPeriodToNow(currentStudy, now);

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/StudentStudyServiceTest.java
@@ -1,0 +1,127 @@
+package com.gdschongik.gdsc.domain.study.application;
+
+import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Semester;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.domain.MemberRole;
+import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.domain.study.domain.StudyUpdateCommand;
+import com.gdschongik.gdsc.domain.study.dto.dto.StudySimpleDto;
+import com.gdschongik.gdsc.domain.study.dto.response.StudyTodoResponse;
+import com.gdschongik.gdsc.helper.IntegrationTest;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class StudentStudyServiceTest extends IntegrationTest {
+
+    @Autowired
+    StudentStudyService studentStudyService;
+
+    @Nested
+    class 내_수강중인_스터디를_조회할때 {
+
+        @Test
+        void 진행중인_학기가_없으면_빈_리스트를_반환한다() {
+            // given
+            Member member = createAssociateMember();
+            logoutAndReloginAs(member.getId(), MemberRole.ASSOCIATE);
+
+            // when
+            List<StudySimpleDto> response = studentStudyService.getMyCurrentStudies();
+
+            // then
+            assertThat(response).isEmpty();
+        }
+
+        @Test
+        void 진행중인_학기와_일치하는_스터디만_반환한다() {
+            // given
+            Member member = createAssociateMember();
+            logoutAndReloginAs(member.getId(), MemberRole.ASSOCIATE);
+
+            LocalDateTime now = LocalDateTime.now();
+            Semester currentSemester = Semester.of(2026, SemesterType.FIRST);
+            Semester previousSemester = Semester.of(2025, SemesterType.SECOND);
+
+            createRecruitment(currentSemester, now.minusDays(1), now.plusDays(1));
+
+            Study currentStudy = createStudy("현재 스터디", currentSemester, member);
+            Study previousStudy = createStudy("이전 스터디", previousSemester, member);
+            createStudyHistory(member, currentStudy);
+            createStudyHistory(member, previousStudy);
+
+            // when
+            List<StudySimpleDto> response = studentStudyService.getMyCurrentStudies();
+
+            // then
+            assertThat(response).extracting(StudySimpleDto::studyId).containsExactly(currentStudy.getId());
+            assertThat(response).extracting(StudySimpleDto::studyName).containsExactly("현재 스터디");
+        }
+    }
+
+    @Nested
+    class 내_모든_스터디_할일을_조회할때 {
+
+        @Test
+        void 진행중인_학기가_없으면_빈_리스트를_반환한다() {
+            // given
+            Member member = createAssociateMember();
+            logoutAndReloginAs(member.getId(), MemberRole.ASSOCIATE);
+
+            // when
+            List<StudyTodoResponse> response = studentStudyService.getMyStudiesTodos();
+
+            // then
+            assertThat(response).isEmpty();
+        }
+
+        @Test
+        void 진행중인_학기와_일치하는_스터디의_할일만_반환한다() {
+            // given
+            Member member = createAssociateMember();
+            logoutAndReloginAs(member.getId(), MemberRole.ASSOCIATE);
+
+            LocalDateTime now = LocalDateTime.now();
+            Semester currentSemester = Semester.of(2026, SemesterType.FIRST);
+            Semester previousSemester = Semester.of(2025, SemesterType.SECOND);
+
+            createRecruitment(currentSemester, now.minusDays(1), now.plusDays(1));
+
+            Study currentStudy = createStudy("현재 스터디", currentSemester, member);
+            Study previousStudy = createStudy("이전 스터디", previousSemester, member);
+            createStudyHistory(member, currentStudy);
+            createStudyHistory(member, previousStudy);
+            updateSessionPeriodToNow(currentStudy, now);
+            updateSessionPeriodToNow(previousStudy, now);
+
+            // when
+            List<StudyTodoResponse> response = studentStudyService.getMyStudiesTodos();
+
+            // then
+            assertThat(response).hasSize(2);
+            assertThat(response)
+                    .extracting(studyTodoResponse -> studyTodoResponse.study().studyId())
+                    .containsOnly(currentStudy.getId());
+            assertThat(response)
+                    .extracting(StudyTodoResponse::todoType)
+                    .containsExactlyInAnyOrder(
+                            StudyTodoResponse.StudyTodoType.ATTENDANCE, StudyTodoResponse.StudyTodoType.ASSIGNMENT);
+        }
+    }
+
+    private void updateSessionPeriodToNow(Study study, LocalDateTime now) {
+        var session = study.getStudySessions().get(0);
+        Period currentPeriod = Period.of(now.minusHours(1), now.plusHours(1));
+
+        session.update(new StudyUpdateCommand.Session(
+                session.getId(), "진행 중인 세션", "설명", currentPeriod, "진행 중인 과제", DESCRIPTION_LINK, currentPeriod));
+        studyRepository.save(study);
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -38,9 +38,11 @@ import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
+import com.gdschongik.gdsc.domain.study.dao.StudyAnnouncementRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyHistoryRepository;
 import com.gdschongik.gdsc.domain.study.dao.StudyRepository;
 import com.gdschongik.gdsc.domain.study.domain.Study;
+import com.gdschongik.gdsc.domain.study.domain.StudyAnnouncement;
 import com.gdschongik.gdsc.domain.study.domain.StudyFactory;
 import com.gdschongik.gdsc.domain.study.domain.StudyHistory;
 import com.gdschongik.gdsc.domain.study.domain.StudyType;
@@ -97,6 +99,9 @@ public abstract class IntegrationTest {
 
     @Autowired
     protected StudyHistoryRepository studyHistoryRepository;
+
+    @Autowired
+    protected StudyAnnouncementRepository studyAnnouncementRepository;
 
     @Autowired
     protected EventRepository eventRepository;
@@ -231,6 +236,11 @@ public abstract class IntegrationTest {
         return recruitmentRepository.save(recruitment);
     }
 
+    protected Recruitment createRecruitment(Semester semester, LocalDateTime startDate, LocalDateTime endDate) {
+        Recruitment recruitment = Recruitment.create(FEE_NAME, FEE, Period.of(startDate, endDate), semester);
+        return recruitmentRepository.save(recruitment);
+    }
+
     protected Membership createMembership(Member member, RecruitmentRound recruitmentRound) {
         Membership membership = Membership.create(member, recruitmentRound);
         return membershipRepository.save(membership);
@@ -262,9 +272,33 @@ public abstract class IntegrationTest {
         return studyRepository.save(study);
     }
 
+    protected Study createStudy(String title, Semester semester, Member mentor) {
+        Study study = studyFactory.create(
+                StudyType.OFFLINE,
+                title,
+                semester,
+                TOTAL_ROUND,
+                DAY_OF_WEEK,
+                STUDY_START_TIME,
+                STUDY_END_TIME,
+                STUDY_APPLICATION_PERIOD,
+                STUDY_DISCORD_CHANNEL_ID,
+                STUDY_DISCORD_ROLE_ID,
+                mentor,
+                () -> "0000",
+                MIN_ASSIGNMENT_CONTENT_LENGTH);
+
+        return studyRepository.save(study);
+    }
+
     protected StudyHistory createStudyHistory(Member member, Study study) {
         StudyHistory studyHistory = StudyHistory.create(member, study);
         return studyHistoryRepository.save(studyHistory);
+    }
+
+    protected StudyAnnouncement createStudyAnnouncement(String title, String link, Study study) {
+        StudyAnnouncement studyAnnouncement = StudyAnnouncement.create(title, link, study);
+        return studyAnnouncementRepository.save(studyAnnouncement);
     }
 
     protected Event createEvent() {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1346

## 📌 작업 내용 및 특이사항
- 나의 수강중인 스터디 리스트, 수강중인 스터디의 할 일 리스트, 수강중인 스터디 공지 리스트 조회시 진행중인 학기가 없는 경우 빈 리스트를 응답하도록 해당 데이터를 쿼리로 조회하는 방향으로 수정하였습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 스터디 서비스의 현재 스터디 조회 방식을 최적화하여 더 정확한 데이터 검색을 지원합니다.

* **Tests**
  * 스터디 공지사항 및 스터디 목록 조회 기능에 대한 포괄적인 테스트 커버리지를 추가했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gdg-hongik-univ/gdsc-server/pull/1378)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->