### PR TITLE
fix: Test 상수 import 오류 해결

### DIFF
--- a/.claude/TESTING.md
+++ b/.claude/TESTING.md
@@ -421,21 +421,30 @@ Spring Modulith의 Scenario API를 기반으로 비동기 이벤트 처리를 �
 
 ### 테스트 상수 클래스
 
-테스트에서 공통으로 사용되는 상수는 도메인별 상수 클래스에 정의합니다:
+테스트에서 공통으로 사용되는 상수는 별도의 상수 클래스에 정의합니다:
 
 위치: `src/test/java/com/gdschongik/gdsc/global/common/constant/`
 
-```java
-// MemberConstant.java
-public static final String OAUTH_ID = "testOauthId";
-public static final String UNIV_EMAIL = "b000000@g.hongik.ac.kr";
-public static final String NAME = "김홍익";
-public static final String STUDENT_ID = "C123456";
+#### 테스트 상수 네이밍 규칙
+- 테스트 상수 클래스는 반드시 **`Test` 접두어**를 붙입니다.
+- `src/main`의 상수 클래스(`MemberConstant`, `TemporalConstant`, `DiscordConstant` 등)와 **동일 패키지 + 동일 클래스명**이 되면 충돌 발생
+- Gradle 증분 컴파일 시 한쪽의 stale `.class`가 남아 `clean` 전까지 필드를 찾지 못하는 간헐적 빌드/테스트 실패
 
-// StudyConstant.java
-public static final String STUDY_TITLE = "스터디 제목";
-public static final Long TOTAL_WEEK = 8L;
-public static final DayOfWeek DAY_OF_WEEK = DayOfWeek.FRIDAY;
+```java
+// TestMemberConstant.java
+public class TestMemberConstant {
+    public static final String OAUTH_ID = "testOauthId";
+    public static final String UNIV_EMAIL = "b000000@g.hongik.ac.kr";
+    public static final String NAME = "김홍익";
+    public static final String STUDENT_ID = "C123456";
+}
+
+// TestStudyConstant.java
+public class TestStudyConstant {
+    public static final String STUDY_TITLE = "스터디 제목";
+    public static final Long TOTAL_WEEK = 8L;
+    public static final DayOfWeek DAY_OF_WEEK = DayOfWeek.FRIDAY;
+}
 ```
 
 ### FixtureHelper

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/application/CouponServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/application/CouponServiceTest.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.coupon.application;
 
 import static com.gdschongik.gdsc.domain.coupon.domain.CouponType.*;
-import static com.gdschongik.gdsc.global.common.constant.CouponConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestCouponConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static java.math.BigDecimal.*;
 import static org.assertj.core.api.Assertions.*;

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/CouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/CouponTest.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.coupon.domain;
 
 import static com.gdschongik.gdsc.domain.coupon.domain.CouponType.*;
-import static com.gdschongik.gdsc.global.common.constant.CouponConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestCouponConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static java.math.BigDecimal.*;
 import static org.assertj.core.api.Assertions.*;

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/domain/IssuedCouponTest.java
@@ -1,8 +1,8 @@
 package com.gdschongik.gdsc.domain.coupon.domain;
 
 import static com.gdschongik.gdsc.domain.coupon.domain.CouponType.*;
-import static com.gdschongik.gdsc.global.common.constant.CouponConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestCouponConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestMemberConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static java.math.BigDecimal.*;
 import static org.assertj.core.api.Assertions.*;

--- a/src/test/java/com/gdschongik/gdsc/domain/coupon/util/CouponNameUtilTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/coupon/util/CouponNameUtilTest.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.coupon.util;
 
-import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestStudyConstant.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.study.domain.Study;

--- a/src/test/java/com/gdschongik/gdsc/domain/discord/DiscordValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/discord/DiscordValidatorTest.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.discord;
 
-import static com.gdschongik.gdsc.global.common.constant.DiscordConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestDiscordConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/com/gdschongik/gdsc/domain/email/application/UnivEmailVerificationServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/email/application/UnivEmailVerificationServiceTest.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.email.application;
 
-import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestMemberConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/src/test/java/com/gdschongik/gdsc/domain/event/application/EventParticipationServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/application/EventParticipationServiceTest.java
@@ -3,8 +3,8 @@ package com.gdschongik.gdsc.domain.event.application;
 import static com.gdschongik.gdsc.domain.event.domain.AfterPartyAttendanceStatus.*;
 import static com.gdschongik.gdsc.domain.event.domain.UsageStatus.*;
 import static com.gdschongik.gdsc.domain.member.domain.Department.*;
-import static com.gdschongik.gdsc.global.common.constant.EventConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestEventConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestMemberConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/com/gdschongik/gdsc/domain/event/application/EventServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/application/EventServiceTest.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.event.application;
 
-import static com.gdschongik.gdsc.global.common.constant.EventConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestEventConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventDomainServiceTest.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.event.domain;
 
-import static com.gdschongik.gdsc.global.common.constant.EventConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestEventConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.event.domain;
 
-import static com.gdschongik.gdsc.global.common.constant.EventConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestEventConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestMemberConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventTest.java
@@ -2,7 +2,7 @@ package com.gdschongik.gdsc.domain.event.domain;
 
 import static com.gdschongik.gdsc.domain.event.domain.UsageStatus.DISABLED;
 import static com.gdschongik.gdsc.domain.event.domain.UsageStatus.ENABLED;
-import static com.gdschongik.gdsc.global.common.constant.EventConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestEventConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/ParticipantRoleTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/ParticipantRoleTest.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.event.domain;
 
 import static com.gdschongik.gdsc.domain.member.domain.Department.*;
-import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestMemberConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/AdminMemberServiceTest.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.member.application;
 
-import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestMemberConstant.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;

--- a/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/application/OnboardingMemberServiceTest.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.member.application;
 
-import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestMemberConstant.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/dao/MemberRepositoryTest.java
@@ -2,7 +2,7 @@ package com.gdschongik.gdsc.domain.member.dao;
 
 import static com.gdschongik.gdsc.domain.member.domain.Department.*;
 import static com.gdschongik.gdsc.domain.member.domain.MemberRole.*;
-import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestMemberConstant.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberTest.java
@@ -4,7 +4,7 @@ import static com.gdschongik.gdsc.domain.common.model.RequirementStatus.*;
 import static com.gdschongik.gdsc.domain.member.domain.Department.*;
 import static com.gdschongik.gdsc.domain.member.domain.MemberRole.*;
 import static com.gdschongik.gdsc.domain.member.domain.MemberStatus.*;
-import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestMemberConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.member.domain;
 
-import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestRecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestTemporalConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/application/MembershipServiceTest.java
@@ -1,8 +1,8 @@
 package com.gdschongik.gdsc.domain.membership.application;
 
 import static com.gdschongik.gdsc.domain.member.domain.MemberRole.ASSOCIATE;
-import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestRecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestTemporalConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
@@ -2,9 +2,9 @@ package com.gdschongik.gdsc.domain.membership.domain;
 
 import static com.gdschongik.gdsc.domain.member.domain.Department.*;
 import static com.gdschongik.gdsc.domain.member.domain.Member.*;
-import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestMemberConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestRecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestTemporalConstant.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.common.vo.Period;

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
@@ -2,9 +2,9 @@ package com.gdschongik.gdsc.domain.membership.domain;
 
 import static com.gdschongik.gdsc.domain.member.domain.Department.*;
 import static com.gdschongik.gdsc.domain.member.domain.Member.*;
-import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestMemberConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestRecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestTemporalConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -1,9 +1,9 @@
 package com.gdschongik.gdsc.domain.order.application;
 
 import static com.gdschongik.gdsc.domain.coupon.domain.CouponType.*;
-import static com.gdschongik.gdsc.global.common.constant.OrderConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestOrderConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestRecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestTemporalConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.recruitment.application;
 
-import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestRecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestTemporalConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/PeriodTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/PeriodTest.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.recruitment.domain;
 
-import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestRecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.DATE_PRECEDENCE_INVALID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.recruitment.domain;
 
-import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestRecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestTemporalConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.recruitment.domain;
 
-import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestRecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestTemporalConstant.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.common.vo.Period;

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/AdminStudyServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/AdminStudyServiceTest.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.study.application;
 
-import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestStudyConstant.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;

--- a/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/application/MentorStudyServiceTest.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.study.application;
 
-import static com.gdschongik.gdsc.global.common.constant.StudyConstant.MIN_ASSIGNMENT_CONTENT_LENGTH;
+import static com.gdschongik.gdsc.global.common.constant.TestStudyConstant.MIN_ASSIGNMENT_CONTENT_LENGTH;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyFactoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyFactoryTest.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.study.domain;
 
-import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestStudyConstant.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/StudyTest.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.study.domain;
 
-import static com.gdschongik.gdsc.global.common.constant.StudyConstant.MIN_ASSIGNMENT_CONTENT_LENGTH;
+import static com.gdschongik.gdsc.global.common.constant.TestStudyConstant.MIN_ASSIGNMENT_CONTENT_LENGTH;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/TestCouponConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/TestCouponConstant.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.global.common.constant;
 
-public class CouponConstant {
+public class TestCouponConstant {
     public static final String COUPON_NAME = "테스트 쿠폰 이름";
 
-    private CouponConstant() {}
+    private TestCouponConstant() {}
 }

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/TestDiscordConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/TestDiscordConstant.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.global.common.constant;
 
-public class DiscordConstant {
-    private DiscordConstant() {}
+public class TestDiscordConstant {
+    private TestDiscordConstant() {}
 
     public static final String DISCORD_USERNAME = "유저네임";
     public static final Integer DISCORD_CODE = 1234;

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/TestEventConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/TestEventConstant.java
@@ -4,9 +4,9 @@ import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.event.domain.UsageStatus;
 import java.time.LocalDateTime;
 
-public class EventConstant {
+public class TestEventConstant {
 
-    private EventConstant() {}
+    private TestEventConstant() {}
 
     public static final String EVENT_NAME = "2025년 1학기 새내기 배움터";
     public static final String EVENT_DESCRIPTION =

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/TestMemberConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/TestMemberConstant.java
@@ -1,8 +1,8 @@
 package com.gdschongik.gdsc.global.common.constant;
 
-public class MemberConstant {
+public class TestMemberConstant {
 
-    private MemberConstant() {}
+    private TestMemberConstant() {}
 
     public static final String OAUTH_ID = "testOauthId";
     public static final String UNIV_EMAIL = "b000000@g.hongik.ac.kr";

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/TestOrderConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/TestOrderConstant.java
@@ -1,10 +1,10 @@
 package com.gdschongik.gdsc.global.common.constant;
 
-public class OrderConstant {
+public class TestOrderConstant {
 
     public static final String ORDER_NANO_ID = "HnbMWoSZRq3qK1W3tPXCW";
     public static final String ORDER_PAYMENT_KEY = "testPaymentKey";
     public static final String ORDER_CANCEL_REASON = "테스트 주문 취소 사유";
 
-    private OrderConstant() {}
+    private TestOrderConstant() {}
 }

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/TestRecruitmentConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/TestRecruitmentConstant.java
@@ -6,7 +6,7 @@ import com.gdschongik.gdsc.domain.recruitment.domain.RoundType;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-public class RecruitmentConstant {
+public class TestRecruitmentConstant {
     // 1차 모집 상수
     public static final String RECRUITMENT_ROUND_NAME = "2024학년도 1학기 1차 모집";
     public static final LocalDateTime START_DATE = LocalDateTime.of(2024, 3, 2, 0, 0);
@@ -26,5 +26,5 @@ public class RecruitmentConstant {
     public static final LocalDateTime ROUND_TWO_END_DATE = LocalDateTime.of(2024, 3, 10, 0, 0);
     public static final Period ROUND_TWO_START_TO_END_PERIOD = Period.of(ROUND_TWO_START_DATE, ROUND_TWO_END_DATE);
 
-    private RecruitmentConstant() {}
+    private TestRecruitmentConstant() {}
 }

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/TestStudyConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/TestStudyConstant.java
@@ -8,8 +8,8 @@ import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
-public class StudyConstant {
-    private StudyConstant() {}
+public class TestStudyConstant {
+    private TestStudyConstant() {}
 
     public static final String STUDY_TITLE = "스터디 제목";
     public static final String STUDY_DESCRIPTION = "스터디 설명";

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/TestTemporalConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/TestTemporalConstant.java
@@ -4,7 +4,7 @@ import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Semester;
 import java.time.LocalDateTime;
 
-public class TemporalConstant {
+public class TestTemporalConstant {
     // academic year
     public static final Integer ACADEMIC_YEAR = 2024;
 
@@ -14,5 +14,5 @@ public class TemporalConstant {
     public static final LocalDateTime SEMESTER_END_DATE = LocalDateTime.of(2024, 8, 31, 0, 0);
     public static final Semester SEMESTER = Semester.of(ACADEMIC_YEAR, SEMESTER_TYPE);
 
-    private TemporalConstant() {}
+    private TestTemporalConstant() {}
 }

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -3,12 +3,12 @@ package com.gdschongik.gdsc.helper;
 import static com.gdschongik.gdsc.domain.member.domain.Department.*;
 import static com.gdschongik.gdsc.domain.member.domain.MemberManageRole.ADMIN;
 import static com.gdschongik.gdsc.domain.member.domain.MemberStudyRole.MENTOR;
-import static com.gdschongik.gdsc.global.common.constant.CouponConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.EventConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestCouponConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestEventConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestMemberConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestRecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestStudyConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestTemporalConstant.*;
 
 import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.common.model.SemesterType;

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -1,12 +1,12 @@
 package com.gdschongik.gdsc.helper;
 
 import static com.gdschongik.gdsc.domain.member.domain.Department.*;
-import static com.gdschongik.gdsc.global.common.constant.CouponConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.EventConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
-import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestCouponConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestEventConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestMemberConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestRecruitmentConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestStudyConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.TestTemporalConstant.*;
 import static org.mockito.Mockito.*;
 
 import com.gdschongik.gdsc.config.TestRedisConfig;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1379

## 📌 작업 내용 및 특이사항
[문제 상황]
- main 패키지 내부의 소스코드 수정 후 gradle check/test 실행 시 빌드 에러가 발생하는 문제
- 간헐적으로 발생하며 clean build 시 해결됨

[원인]
main과 test의 두 상수 파일(`TemporalConstant`, `DiscordConstant`)이 동일한 FQCN을 가짐.
-> (`com.gdschongik.gdsc.global.common.constant.TemporalConstant`)

- `src/main/java/...TemporalConstant.java`
- `src/test/java/...TemporalConstant.java`
→ 동일한 패키지 구조 + 클래스명이기 때문

FQCN이란?
- FQCN (Fully Qualified Class Name) = 패키지 경로를 포함한 클래스의 "전체 이름"
- import 시 사용하는 경로라고 생각해도 됨

JVM은 클래스를 식별할 때 단순 클래스명(TemporalConstant)이 아니라 FQCN으로 구분.  즉, JVM 입장에서는 "패키지 + 클래스명"이 완전히 일치하면 같은 클래스로 본다.

JVM의 클래스 로더는 클래스패스를 순서대로 탐색해서 FQCN과 일치하는 첫 번째 .class를 로드. 정상 상황에선 test 시에는 test의 .class를 로드해 문제 없음

main의 소스코드를 수정해 main class들만 다시 컴파일 할 시 gradle의 증분 컴파일 특성상 main 패키지만 새로 컴파일되어 클래스패스 순서가 변경될 가능성 존재. 
-> test 패키지의 constant가 아닌 main 패키지의 constant를 조회할 수 있음

clean build 시 문제가 사라지거나, CI/CD에선 한 번도 문제가 발생하지 않았던 이유도 설명 가능

**핵심은 증분 컴파일 상황에서 "FQCN이 같은 .class가 두 곳에 존재한다는 상황 자체가 컴파일 시 비결정적 행동을 만든다"**

[해결 방안]
- 그냥 간단하게 테스트용 상수 클래스는 `TestXXXConstant` 처럼 테스트용임을 명시 -> 클래스명을 다르게 분리
- 해당 컨벤션을 TESTING.md에 업데이트

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 테스트 인프라 개선

* **Tests**
  * 테스트 전용 상수 클래스에 `Test` 접두어를 추가하여 프로덕션 코드 상수와의 명확한 구분을 강화했습니다.
  * 여러 테스트 파일을 업데이트하여 새로운 테스트 전용 상수 클래스를 참조하도록 변경했습니다.

* **Chores**
  * 테스트 상수 정의 가이드 문서를 갱신했습니다.

**사용자 영향: 없음** (내부 테스트 인프라 개선)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gdg-hongik-univ/gdsc-server/pull/1380)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->