### PR TITLE
refactor: QueryDSL을 openfeign 포크 버전으로 마이그레이션

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,8 +67,8 @@ dependencies {
     testImplementation 'com.github.codemonstur:embedded-redis:1.4.3'
 
     // Querydsl
-    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
-    annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+    implementation 'io.github.openfeign.querydsl:querydsl-jpa:6.11'
+    annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.11:jpa'
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 

--- a/build.gradle
+++ b/build.gradle
@@ -67,8 +67,8 @@ dependencies {
     testImplementation 'com.github.codemonstur:embedded-redis:1.4.3'
 
     // Querydsl
-    implementation 'io.github.openfeign.querydsl:querydsl-jpa:6.11'
-    annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.11:jpa'
+    implementation 'io.github.openfeign.querydsl:querydsl-jpa:6.12'
+    annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.12:jpa'
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #392

## 📌 작업 내용 및 특이사항
- 기존 QueryDSL 프로젝트의 유지보수 중단에 따라 OpenFeign 유지보수 버전으로 전환
- #1177 진행 전 선행되어야 하는 작업

## 📝 참고사항
- QClass 정상 생성 확인 & 통합 테스트 전부 잘 돌아가는 것 확인
- DEV DB에 연결해서 queryDSL 사용하는 대표적 쿼리 (페이징, 검색) 들 테스트 완료 & 문제 없는 것 확인

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Querydsl JPA 관련 의존성이 최신 호환 패키지로 변경되어 빌드/애너테이션 처리 환경의 최신성 및 호환성을 개선했습니다.
  * 애플리케이션의 나머지 설정 및 동작 방식은 그대로 유지되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->