### PR TITLE
fix: 주문 조회 테스트 에러 해결하기

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -17,6 +17,8 @@ env:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
+    env:
+      TZ: Asia/Seoul
     environment: develop
     strategy:
       matrix:

--- a/.github/workflows/production_build_deploy.yml
+++ b/.github/workflows/production_build_deploy.yml
@@ -16,6 +16,8 @@ env:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
+    env:
+      TZ: Asia/Seoul
     environment: production
     strategy:
       matrix:

--- a/.github/workflows/pull_request_gradle_build.yml
+++ b/.github/workflows/pull_request_gradle_build.yml
@@ -10,6 +10,8 @@ permissions:
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    env:
+      TZ: Asia/Seoul
 
     steps:
       - name: Git Checkout

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderQueryMethod.java
@@ -62,9 +62,9 @@ public interface OrderQueryMethod {
         if (approvedAt == null) {
             return null;
         }
-        ZoneId seoulZone = ZoneId.of("Asia/Seoul");
-        ZonedDateTime startOfDay = approvedAt.atStartOfDay(seoulZone);
-        ZonedDateTime endOfDay = approvedAt.atTime(LocalTime.MAX).atZone(seoulZone);
+        ZoneId zoneId = ZoneId.systemDefault();
+        ZonedDateTime startOfDay = approvedAt.atStartOfDay(zoneId);
+        ZonedDateTime endOfDay = approvedAt.atTime(LocalTime.MAX).atZone(zoneId);
         return order.approvedAt.between(startOfDay, endOfDay);
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -525,8 +525,10 @@ class OrderServiceTest extends IntegrationTest {
             OrderQueryOption queryOption = new OrderQueryOption(null, null, null, null, null, null, null, date);
 
             // when
+            List<Order> all = orderRepository.findAll();
             Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
-            log.debug("approvedAt = {}", orderResponse.get().findFirst().map(OrderAdminResponse::approvedAt));
+            log.debug("approvedAt = {}", all.get(0).getApprovedAt());
+            log.debug("orderAllSize = {}", all.size());
 
             // then
             boolean orderExists = orderResponse.getContent().stream()

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -32,6 +32,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
@@ -40,6 +41,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
+@Slf4j
 class OrderServiceTest extends IntegrationTest {
 
     public static final Money MONEY_20000_WON = Money.from(20000L);
@@ -519,10 +521,12 @@ class OrderServiceTest extends IntegrationTest {
             orderService.completeOrder(request);
 
             LocalDate date = LocalDate.now();
+            log.debug("LocalDate = {}", date);
             OrderQueryOption queryOption = new OrderQueryOption(null, null, null, null, null, null, null, date);
 
             // when
             Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
+            log.debug("approvedAt = {}", orderResponse.get().findFirst().map(OrderAdminResponse::approvedAt));
 
             // then
             boolean orderExists = orderResponse.getContent().stream()

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -486,7 +486,7 @@ class OrderServiceTest extends IntegrationTest {
         }
     }
 
-    @Disabled // TODO: CI 환경에서만 실패하는 테스트, TZ 관련 설정 확인 필요
+    // TODO: CI 환경에서만 실패하는 테스트, TZ 관련 설정 확인 필요
     @Nested
     class 일자기준으로_주문목록_조회시 {
 

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -30,7 +30,6 @@ import com.gdschongik.gdsc.infra.feign.payment.dto.response.PaymentResponse;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -489,7 +488,6 @@ class OrderServiceTest extends IntegrationTest {
         }
     }
 
-    // TODO: CI 환경에서만 실패하는 테스트, TZ 관련 설정 확인 필요
     @Nested
     class 일자기준으로_주문목록_조회시 {
 
@@ -522,15 +520,10 @@ class OrderServiceTest extends IntegrationTest {
             orderService.completeOrder(request);
 
             LocalDate date = LocalDate.now();
-            log.debug("LocalDate = {}", date);
             OrderQueryOption queryOption = new OrderQueryOption(null, null, null, null, null, null, null, date);
 
             // when
-            List<Order> all = orderRepository.findAll();
             Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
-            log.debug("approvedAt = {}", all.get(0).getApprovedAt());
-            log.debug("orderAllSize = {}", all.size());
-            log.debug("JVM TimeZone = {}", ZoneId.systemDefault());
 
             // then
             boolean orderExists = orderResponse.getContent().stream()

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -32,7 +32,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
@@ -41,7 +40,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
-@Slf4j
 class OrderServiceTest extends IntegrationTest {
 
     public static final Money MONEY_20000_WON = Money.from(20000L);

--- a/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/order/application/OrderServiceTest.java
@@ -30,6 +30,7 @@ import com.gdschongik.gdsc.infra.feign.payment.dto.response.PaymentResponse;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -529,6 +530,7 @@ class OrderServiceTest extends IntegrationTest {
             Page<OrderAdminResponse> orderResponse = orderService.searchOrders(queryOption, PageRequest.of(0, 10));
             log.debug("approvedAt = {}", all.get(0).getApprovedAt());
             log.debug("orderAllSize = {}", all.size());
+            log.debug("JVM TimeZone = {}", ZoneId.systemDefault());
 
             // then
             boolean orderExists = orderResponse.getContent().stream()

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -14,3 +14,7 @@ jwt:
     EMAIL_VERIFICATION_TOKEN:
       secret: 235872q3ywhtf87q243yt98qop42y3whtg8oiq92ayh4gq2g
       expiration-time: 1800
+
+logging:
+  level:
+    com.gdschongik.gdsc: debug

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -14,7 +14,3 @@ jwt:
     EMAIL_VERIFICATION_TOKEN:
       secret: 235872q3ywhtf87q243yt98qop42y3whtg8oiq92ayh4gq2g
       expiration-time: 1800
-
-logging:
-  level:
-    com.gdschongik.gdsc: debug


### PR DESCRIPTION
## 🌱 관련 이슈
- close #534

## 📌 작업 내용 및 특이사항
- 문제가 되는 test의 when에서는 `orderService.searchOrders` 메서드로 조회를 실행합니다.
- 이때 파라미터로 아래와 같이 생성된 queryOption을 넘겨줍니다.
```java
LocalDate date = LocalDate.now();
OrderQueryOption queryOption = new OrderQueryOption(null, null, null, null, null, null, null, date);
```
- 그런데 이 option을 처리하는 레포지토리 메서드에서는 다음과 같이 TimeZone을 Asia/Seoul로 설정해서 실행합니다.
```java
default BooleanExpression eqApprovedAt(LocalDate approvedAt) {
     if (approvedAt == null) {
         return null;
     }
     ZoneId seoulZone = ZoneId.of("Asia/Seoul");
     ZonedDateTime startOfDay = approvedAt.atStartOfDay(seoulZone);
      ZonedDateTime endOfDay = approvedAt.atTime(LocalTime.MAX).atZone(seoulZone);
      return order.approvedAt.between(startOfDay, endOfDay);
}
```
- Github Actions는 UTC를 default로 사용하므로 0시부터 9시까지는 타임존 불일치로 인해 조회에 실패합니다.
- 따라서 빌드가 포함된 모든 워크플로우의 타임존을 Asia/Seoul로 설정합니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 주문 승인일 기준 조회 시 시스템 시간대를 일관되게 적용하도록 개선했습니다.
  * 날짜 기준 주문 목록 조회 기능의 테스트가 정상적으로 실행됩니다.
* **배포 및 안정성**
  * 빌드·배포 환경의 시간대를 한국 표준시로 통일해 환경에 따른 날짜 처리 차이를 줄였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->